### PR TITLE
chore(npm): add temporary files to .gitignore and implement download size limits

### DIFF
--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,4 +1,6 @@
 bin/qluent
 bin/qluent.exe
+bin/qluent.tmp
+bin/qluent.exe.tmp
 node_modules/
 package-lock.json

--- a/npm/lib/installer.js
+++ b/npm/lib/installer.js
@@ -81,7 +81,10 @@ function getTransport(url) {
   return url.startsWith("https:") ? https : http;
 }
 
-function download(url, destination, { env = process.env, redirectsRemaining = 5 } = {}) {
+const MAX_BINARY_SIZE = 200 * 1024 * 1024; // 200 MB
+const MAX_CHECKSUM_SIZE = 1024; // 1 KB
+
+function download(url, destination, { env = process.env, redirectsRemaining = 5, maxSize = MAX_BINARY_SIZE } = {}) {
   const safeUrl = assertSecureUrl(url, { env }).toString();
   const transport = getTransport(safeUrl);
 
@@ -100,6 +103,7 @@ function download(url, destination, { env = process.env, redirectsRemaining = 5 
         download(response.headers.location, destination, {
           env,
           redirectsRemaining: redirectsRemaining - 1,
+          maxSize,
         }).then(resolve, reject);
         return;
       }
@@ -109,7 +113,19 @@ function download(url, destination, { env = process.env, redirectsRemaining = 5 
         return;
       }
 
-      const file = fs.createWriteStream(destination, { mode: 0o755 });
+      let received = 0;
+      const file = fs.createWriteStream(destination, { mode: 0o600 });
+
+      response.on("data", (chunk) => {
+        received += chunk.length;
+        if (received > maxSize) {
+          response.destroy();
+          file.destroy();
+          fs.rmSync(destination, { force: true });
+          reject(new Error(`Download exceeded maximum size of ${maxSize} bytes`));
+        }
+      });
+
       response.pipe(file);
       file.on("finish", () => {
         file.close(resolve);
@@ -121,7 +137,7 @@ function download(url, destination, { env = process.env, redirectsRemaining = 5 
   });
 }
 
-function downloadText(url, { env = process.env, redirectsRemaining = 5 } = {}) {
+function downloadText(url, { env = process.env, redirectsRemaining = 5, maxSize = MAX_CHECKSUM_SIZE } = {}) {
   const safeUrl = assertSecureUrl(url, { env }).toString();
   const transport = getTransport(safeUrl);
 
@@ -140,6 +156,7 @@ function downloadText(url, { env = process.env, redirectsRemaining = 5 } = {}) {
         downloadText(response.headers.location, {
           env,
           redirectsRemaining: redirectsRemaining - 1,
+          maxSize,
         }).then(resolve, reject);
         return;
       }
@@ -150,8 +167,15 @@ function downloadText(url, { env = process.env, redirectsRemaining = 5 } = {}) {
       }
 
       let body = "";
+      let received = 0;
       response.setEncoding("utf8");
       response.on("data", (chunk) => {
+        received += Buffer.byteLength(chunk, "utf8");
+        if (received > maxSize) {
+          response.destroy();
+          reject(new Error(`Download exceeded maximum size of ${maxSize} bytes`));
+          return;
+        }
         body += chunk;
       });
       response.on("end", () => resolve(body));
@@ -223,8 +247,17 @@ async function installBinary({
     return null;
   }
 
+  if (allowInsecureDownload(env)) {
+    logger.log(
+      "WARNING: QLUENT_CLI_ALLOW_INSECURE_DOWNLOAD is set. " +
+        "Binary will be downloaded over insecure HTTP. " +
+        "This should ONLY be used for local development."
+    );
+  }
+
   const binaryName = platform === "win32" ? "qluent.exe" : "qluent";
   const destination = path.join(binDir, binaryName);
+  const tempDestination = `${destination}.tmp`;
   const binaryUrl = resolveDownloadUrl({
     env,
     version,
@@ -236,7 +269,7 @@ async function installBinary({
   fs.mkdirSync(binDir, { recursive: true });
 
   logger.log(`Downloading Qluent CLI from ${binaryUrl}`);
-  await download(binaryUrl, destination, { env });
+  await download(binaryUrl, tempDestination, { env });
 
   try {
     const checksumBody = await downloadText(checksumUrl, { env });
@@ -244,12 +277,13 @@ async function installBinary({
       checksumBody,
       path.basename(binaryUrl)
     );
-    verifyFileChecksum(destination, expectedChecksum);
+    verifyFileChecksum(tempDestination, expectedChecksum);
   } catch (error) {
-    fs.rmSync(destination, { force: true });
+    fs.rmSync(tempDestination, { force: true });
     throw error;
   }
 
+  fs.renameSync(tempDestination, destination);
   fs.chmodSync(destination, 0o755);
   logger.log(`Installed Qluent CLI to ${destination}`);
   return destination;
@@ -257,6 +291,8 @@ async function installBinary({
 
 module.exports = {
   DEFAULT_DIST_BASE_URL,
+  MAX_BINARY_SIZE,
+  MAX_CHECKSUM_SIZE,
   allowInsecureDownload,
   assertSecureUrl,
   download,

--- a/npm/tests/installer.test.js
+++ b/npm/tests/installer.test.js
@@ -1,11 +1,19 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const crypto = require("crypto");
 const fs = require("fs");
+const http = require("http");
 const os = require("os");
 const path = require("path");
 
 const {
+  MAX_BINARY_SIZE,
+  MAX_CHECKSUM_SIZE,
+  allowInsecureDownload,
   assertSecureUrl,
+  download,
+  downloadText,
+  installBinary,
   parseChecksumFile,
   platformArtifact,
   resolveChecksumUrl,
@@ -13,6 +21,54 @@ const {
   sha256File,
   verifyFileChecksum,
 } = require("../lib/installer");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "qluent-test-"));
+}
+
+function sha256(data) {
+  return crypto.createHash("sha256").update(data).digest("hex");
+}
+
+/** Spin up a throwaway HTTP server.  Returns { url, close, setHandler }. */
+async function createTestServer() {
+  let handler = (_req, res) => {
+    res.writeHead(404);
+    res.end();
+  };
+  const server = http.createServer((req, res) => handler(req, res));
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => server.close(),
+    setHandler: (fn) => {
+      handler = fn;
+    },
+  };
+}
+
+/** Env object that allows insecure downloads (needed for local HTTP server). */
+function insecureEnv(extra = {}) {
+  return { QLUENT_CLI_ALLOW_INSECURE_DOWNLOAD: "1", ...extra };
+}
+
+/** A silent logger that captures messages. */
+function captureLogger() {
+  const messages = [];
+  return {
+    messages,
+    log: (msg) => messages.push(msg),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Original unit tests
+// ---------------------------------------------------------------------------
 
 test("resolveDownloadUrl uses the default HTTPS host", () => {
   const url = resolveDownloadUrl({
@@ -89,7 +145,7 @@ test("resolveChecksumUrl appends .sha256", () => {
 });
 
 test("verifyFileChecksum validates the downloaded binary content", () => {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "qluent-installer-"));
+  const tempDir = makeTempDir();
   const filePath = path.join(tempDir, "qluent-darwin-arm64");
   fs.writeFileSync(filePath, "hello");
 
@@ -112,4 +168,590 @@ test("assertSecureUrl accepts HTTPS and rejects HTTP by default", () => {
     () => assertSecureUrl("http://github.com/qluent/qluent-cli/releases/download"),
     /Refusing insecure download URL/
   );
+});
+
+// ---------------------------------------------------------------------------
+// Size limit tests
+// ---------------------------------------------------------------------------
+
+test("download rejects when response exceeds maxSize", async () => {
+  const server = await createTestServer();
+  const tempDir = makeTempDir();
+  const dest = path.join(tempDir, "too-large");
+
+  server.setHandler((_req, res) => {
+    res.writeHead(200);
+    // Send 2 KB when limit is 1 KB
+    res.end(Buffer.alloc(2048, 0x41));
+  });
+
+  try {
+    await assert.rejects(
+      () => download(server.url + "/big", dest, { env: insecureEnv(), maxSize: 1024 }),
+      /exceeded maximum size/
+    );
+    // Partial file must be cleaned up
+    assert.equal(fs.existsSync(dest), false);
+  } finally {
+    server.close();
+  }
+});
+
+test("download succeeds when response is within maxSize", async () => {
+  const server = await createTestServer();
+  const tempDir = makeTempDir();
+  const dest = path.join(tempDir, "ok-size");
+
+  const body = Buffer.from("small payload");
+  server.setHandler((_req, res) => {
+    res.writeHead(200);
+    res.end(body);
+  });
+
+  try {
+    await download(server.url + "/ok", dest, {
+      env: insecureEnv(),
+      maxSize: 1024 * 1024,
+    });
+    assert.deepEqual(fs.readFileSync(dest), body);
+  } finally {
+    server.close();
+  }
+});
+
+test("downloadText rejects when response exceeds maxSize", async () => {
+  const server = await createTestServer();
+
+  server.setHandler((_req, res) => {
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end("x".repeat(2048));
+  });
+
+  try {
+    await assert.rejects(
+      () => downloadText(server.url + "/big", { env: insecureEnv(), maxSize: 512 }),
+      /exceeded maximum size/
+    );
+  } finally {
+    server.close();
+  }
+});
+
+test("downloadText succeeds within maxSize", async () => {
+  const server = await createTestServer();
+  const payload = "a]".repeat(32);
+
+  server.setHandler((_req, res) => {
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end(payload);
+  });
+
+  try {
+    const text = await downloadText(server.url + "/small", {
+      env: insecureEnv(),
+      maxSize: 4096,
+    });
+    assert.equal(text, payload);
+  } finally {
+    server.close();
+  }
+});
+
+test("MAX_BINARY_SIZE and MAX_CHECKSUM_SIZE have sane defaults", () => {
+  assert.equal(MAX_BINARY_SIZE, 200 * 1024 * 1024);
+  assert.equal(MAX_CHECKSUM_SIZE, 1024);
+});
+
+// ---------------------------------------------------------------------------
+// Download rejects non-200 status codes
+// ---------------------------------------------------------------------------
+
+test("download rejects on HTTP 404", async () => {
+  const server = await createTestServer();
+  const dest = path.join(makeTempDir(), "missing");
+
+  server.setHandler((_req, res) => {
+    res.writeHead(404);
+    res.end("not found");
+  });
+
+  try {
+    await assert.rejects(
+      () => download(server.url + "/missing", dest, { env: insecureEnv() }),
+      /Download failed with status 404/
+    );
+  } finally {
+    server.close();
+  }
+});
+
+test("download rejects after too many redirects", async () => {
+  const server = await createTestServer();
+  const dest = path.join(makeTempDir(), "loop");
+
+  server.setHandler((_req, res) => {
+    res.writeHead(302, { Location: server.url + "/loop" });
+    res.end();
+  });
+
+  try {
+    await assert.rejects(
+      () =>
+        download(server.url + "/loop", dest, {
+          env: insecureEnv(),
+          redirectsRemaining: 2,
+        }),
+      /Too many redirects/
+    );
+  } finally {
+    server.close();
+  }
+});
+
+test("download follows redirects up to the limit", async () => {
+  const server = await createTestServer();
+  const dest = path.join(makeTempDir(), "redirected");
+  const body = Buffer.from("final content");
+
+  server.setHandler((req, res) => {
+    if (req.url === "/step1") {
+      res.writeHead(302, { Location: server.url + "/step2" });
+      res.end();
+    } else {
+      res.writeHead(200);
+      res.end(body);
+    }
+  });
+
+  try {
+    await download(server.url + "/step1", dest, { env: insecureEnv() });
+    assert.deepEqual(fs.readFileSync(dest), body);
+  } finally {
+    server.close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Write-then-rename (TOCTOU) tests
+// ---------------------------------------------------------------------------
+
+test("installBinary writes to .tmp first and renames on success", async () => {
+  const server = await createTestServer();
+  const tempDir = makeTempDir();
+  const binDir = path.join(tempDir, "bin");
+  const binaryContent = Buffer.from("fake-binary-content");
+  const checksum = sha256(binaryContent);
+  const artifactName = platformArtifact({ platform: "darwin", arch: "arm64" });
+
+  server.setHandler((req, res) => {
+    if (req.url.endsWith(".sha256")) {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end(`${checksum}  ${artifactName}\n`);
+    } else {
+      res.writeHead(200);
+      res.end(binaryContent);
+    }
+  });
+
+  try {
+    const dest = await installBinary({
+      version: "1.0.0",
+      env: insecureEnv({ QLUENT_CLI_DIST_BASE_URL: server.url }),
+      binDir,
+      platform: "darwin",
+      arch: "arm64",
+      logger: captureLogger(),
+    });
+
+    // Final binary exists and is executable
+    assert.ok(fs.existsSync(dest));
+    const stat = fs.statSync(dest);
+    assert.equal(stat.mode & 0o755, 0o755);
+
+    // .tmp must not linger
+    assert.equal(fs.existsSync(`${dest}.tmp`), false);
+
+    // Content matches
+    assert.deepEqual(fs.readFileSync(dest), binaryContent);
+  } finally {
+    server.close();
+  }
+});
+
+test("installBinary cleans up .tmp and leaves no final binary on checksum mismatch", async () => {
+  const server = await createTestServer();
+  const tempDir = makeTempDir();
+  const binDir = path.join(tempDir, "bin");
+
+  server.setHandler((req, res) => {
+    if (req.url.endsWith(".sha256")) {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end("0".repeat(64)); // wrong checksum
+    } else {
+      res.writeHead(200);
+      res.end(Buffer.from("some binary"));
+    }
+  });
+
+  try {
+    await assert.rejects(
+      () =>
+        installBinary({
+          version: "1.0.0",
+          env: insecureEnv({ QLUENT_CLI_DIST_BASE_URL: server.url }),
+          binDir,
+          platform: "darwin",
+          arch: "arm64",
+          logger: captureLogger(),
+        }),
+      /Checksum mismatch/
+    );
+
+    // Neither .tmp nor final binary should exist
+    const binaryName = "qluent";
+    assert.equal(fs.existsSync(path.join(binDir, binaryName)), false);
+    assert.equal(fs.existsSync(path.join(binDir, `${binaryName}.tmp`)), false);
+  } finally {
+    server.close();
+  }
+});
+
+test("installBinary cleans up .tmp when checksum download fails", async () => {
+  const server = await createTestServer();
+  const tempDir = makeTempDir();
+  const binDir = path.join(tempDir, "bin");
+
+  server.setHandler((req, res) => {
+    if (req.url.endsWith(".sha256")) {
+      res.writeHead(404);
+      res.end("not found");
+    } else {
+      res.writeHead(200);
+      res.end(Buffer.from("binary payload"));
+    }
+  });
+
+  try {
+    await assert.rejects(
+      () =>
+        installBinary({
+          version: "1.0.0",
+          env: insecureEnv({ QLUENT_CLI_DIST_BASE_URL: server.url }),
+          binDir,
+          platform: "darwin",
+          arch: "arm64",
+          logger: captureLogger(),
+        }),
+      /Download failed with status 404/
+    );
+
+    assert.equal(fs.existsSync(path.join(binDir, "qluent")), false);
+    assert.equal(fs.existsSync(path.join(binDir, "qluent.tmp")), false);
+  } finally {
+    server.close();
+  }
+});
+
+test("temp file is written with mode 0o600 (not executable)", async () => {
+  const server = await createTestServer();
+  const tempDir = makeTempDir();
+  const binDir = path.join(tempDir, "bin");
+  let observedTmpMode = null;
+
+  const binaryContent = Buffer.from("check-mode");
+  const checksum = sha256(binaryContent);
+  const artifactName = platformArtifact({ platform: "linux", arch: "x64" });
+
+  server.setHandler((req, res) => {
+    if (req.url.endsWith(".sha256")) {
+      // Before returning checksum, observe the .tmp file permissions
+      const tmpPath = path.join(binDir, "qluent.tmp");
+      if (fs.existsSync(tmpPath)) {
+        observedTmpMode = fs.statSync(tmpPath).mode & 0o777;
+      }
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end(`${checksum}  ${artifactName}\n`);
+    } else {
+      res.writeHead(200);
+      res.end(binaryContent);
+    }
+  });
+
+  try {
+    await installBinary({
+      version: "1.0.0",
+      env: insecureEnv({ QLUENT_CLI_DIST_BASE_URL: server.url }),
+      binDir,
+      platform: "linux",
+      arch: "x64",
+      logger: captureLogger(),
+    });
+
+    // The .tmp file should have been 0o600 when it existed
+    assert.equal(observedTmpMode, 0o600);
+  } finally {
+    server.close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Insecure download warning
+// ---------------------------------------------------------------------------
+
+test("installBinary logs a warning when QLUENT_CLI_ALLOW_INSECURE_DOWNLOAD is set", async () => {
+  const server = await createTestServer();
+  const tempDir = makeTempDir();
+  const binDir = path.join(tempDir, "bin");
+  const logger = captureLogger();
+
+  const binaryContent = Buffer.from("warn-test");
+  const checksum = sha256(binaryContent);
+  const artifactName = platformArtifact({ platform: "darwin", arch: "arm64" });
+
+  server.setHandler((req, res) => {
+    if (req.url.endsWith(".sha256")) {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end(`${checksum}  ${artifactName}\n`);
+    } else {
+      res.writeHead(200);
+      res.end(binaryContent);
+    }
+  });
+
+  try {
+    await installBinary({
+      version: "1.0.0",
+      env: insecureEnv({ QLUENT_CLI_DIST_BASE_URL: server.url }),
+      binDir,
+      platform: "darwin",
+      arch: "arm64",
+      logger,
+    });
+
+    const warningMsg = logger.messages.find((m) => m.includes("WARNING"));
+    assert.ok(warningMsg, "expected a WARNING message in the logs");
+    assert.match(warningMsg, /QLUENT_CLI_ALLOW_INSECURE_DOWNLOAD/);
+    assert.match(warningMsg, /local development/);
+  } finally {
+    server.close();
+  }
+});
+
+test("installBinary does not warn when QLUENT_CLI_ALLOW_INSECURE_DOWNLOAD is not set", async () => {
+  // We can't hit a real HTTPS server in unit tests, so just test the skip path
+  const logger = captureLogger();
+
+  await installBinary({
+    version: "1.0.0",
+    env: { QLUENT_SKIP_DOWNLOAD: "1" },
+    logger,
+  });
+
+  const warningMsg = logger.messages.find((m) => m.includes("WARNING"));
+  assert.equal(warningMsg, undefined, "should not log a WARNING");
+});
+
+// ---------------------------------------------------------------------------
+// QLUENT_SKIP_DOWNLOAD
+// ---------------------------------------------------------------------------
+
+test("installBinary returns null when QLUENT_SKIP_DOWNLOAD=1", async () => {
+  const logger = captureLogger();
+  const result = await installBinary({
+    version: "1.0.0",
+    env: { QLUENT_SKIP_DOWNLOAD: "1" },
+    logger,
+  });
+
+  assert.equal(result, null);
+  assert.ok(logger.messages.some((m) => m.includes("Skipping")));
+});
+
+test("installBinary throws when version is missing", async () => {
+  await assert.rejects(
+    () => installBinary({ env: {} }),
+    /version is required/
+  );
+});
+
+// ---------------------------------------------------------------------------
+// resolveDownloadUrl – env var overrides
+// ---------------------------------------------------------------------------
+
+test("resolveDownloadUrl uses QLUENT_CLI_BIN_URL when set", () => {
+  const url = resolveDownloadUrl({
+    env: { QLUENT_CLI_BIN_URL: "https://my-mirror.example.com/qluent-darwin-arm64" },
+    version: "0.1.0",
+    platform: "darwin",
+    arch: "arm64",
+  });
+  assert.equal(url, "https://my-mirror.example.com/qluent-darwin-arm64");
+});
+
+test("resolveDownloadUrl rejects HTTP QLUENT_CLI_BIN_URL without insecure override", () => {
+  assert.throws(
+    () =>
+      resolveDownloadUrl({
+        env: { QLUENT_CLI_BIN_URL: "http://evil.example.com/qluent" },
+        version: "0.1.0",
+      }),
+    /Refusing insecure download URL/
+  );
+});
+
+test("resolveDownloadUrl requires a version", () => {
+  assert.throws(
+    () => resolveDownloadUrl({ env: {} }),
+    /version is required/
+  );
+});
+
+// ---------------------------------------------------------------------------
+// platformArtifact edge cases
+// ---------------------------------------------------------------------------
+
+test("platformArtifact rejects unsupported platform", () => {
+  assert.throws(
+    () => platformArtifact({ platform: "freebsd", arch: "x64" }),
+    /Unsupported platform/
+  );
+});
+
+test("platformArtifact rejects unsupported arch", () => {
+  assert.throws(
+    () => platformArtifact({ platform: "linux", arch: "mips" }),
+    /Unsupported platform/
+  );
+});
+
+test("platformArtifact covers all supported combinations", () => {
+  const expected = {
+    "darwin-x64": "qluent-darwin-x64",
+    "darwin-arm64": "qluent-darwin-arm64",
+    "linux-x64": "qluent-linux-x64",
+    "linux-arm64": "qluent-linux-arm64",
+    "win32-x64": "qluent-windows-x64.exe",
+    "win32-arm64": "qluent-windows-arm64.exe",
+  };
+
+  for (const [key, artifact] of Object.entries(expected)) {
+    const [platform, arch] = key.split("-");
+    assert.equal(platformArtifact({ platform, arch }), artifact);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// parseChecksumFile edge cases
+// ---------------------------------------------------------------------------
+
+test("parseChecksumFile rejects empty content", () => {
+  assert.throws(() => parseChecksumFile("", "qluent-darwin-arm64"), /empty/);
+  assert.throws(() => parseChecksumFile("   \n\n  ", "qluent-darwin-arm64"), /empty/);
+});
+
+test("parseChecksumFile rejects content that doesn't match artifact", () => {
+  assert.throws(
+    () => parseChecksumFile(`${"a".repeat(64)}  wrong-artifact`, "qluent-darwin-arm64"),
+    /Could not parse checksum/
+  );
+});
+
+test("parseChecksumFile handles CRLF line endings", () => {
+  const checksum = "d".repeat(64);
+  const content = `${checksum}  qluent-linux-x64\r\n`;
+  assert.equal(parseChecksumFile(content, "qluent-linux-x64"), checksum);
+});
+
+test("parseChecksumFile handles binary mode indicator (*)", () => {
+  const checksum = "e".repeat(64);
+  const content = `${checksum} *qluent-linux-x64`;
+  assert.equal(parseChecksumFile(content, "qluent-linux-x64"), checksum);
+});
+
+test("parseChecksumFile normalizes uppercase hex to lowercase", () => {
+  const upper = "ABCDEF".repeat(10) + "ABCD";
+  assert.equal(
+    parseChecksumFile(upper, "qluent-darwin-arm64"),
+    upper.toLowerCase()
+  );
+});
+
+// ---------------------------------------------------------------------------
+// allowInsecureDownload
+// ---------------------------------------------------------------------------
+
+test("allowInsecureDownload returns false for empty env", () => {
+  assert.equal(allowInsecureDownload({}), false);
+});
+
+test("allowInsecureDownload returns false for non-1 values", () => {
+  assert.equal(allowInsecureDownload({ QLUENT_CLI_ALLOW_INSECURE_DOWNLOAD: "true" }), false);
+  assert.equal(allowInsecureDownload({ QLUENT_CLI_ALLOW_INSECURE_DOWNLOAD: "yes" }), false);
+  assert.equal(allowInsecureDownload({ QLUENT_CLI_ALLOW_INSECURE_DOWNLOAD: "0" }), false);
+});
+
+test("allowInsecureDownload returns true only for exactly '1'", () => {
+  assert.equal(allowInsecureDownload({ QLUENT_CLI_ALLOW_INSECURE_DOWNLOAD: "1" }), true);
+});
+
+// ---------------------------------------------------------------------------
+// assertSecureUrl edge cases
+// ---------------------------------------------------------------------------
+
+test("assertSecureUrl allows HTTP when insecure override is set", () => {
+  const url = assertSecureUrl("http://localhost:9000/test", {
+    env: { QLUENT_CLI_ALLOW_INSECURE_DOWNLOAD: "1" },
+  });
+  assert.equal(url.protocol, "http:");
+});
+
+test("assertSecureUrl rejects non-http(s) protocols", () => {
+  assert.throws(
+    () => assertSecureUrl("ftp://files.example.com/qluent"),
+    /Refusing insecure download URL/
+  );
+  assert.throws(
+    () => assertSecureUrl("file:///etc/passwd"),
+    /Refusing insecure download URL/
+  );
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end installBinary with Windows naming
+// ---------------------------------------------------------------------------
+
+test("installBinary uses .exe suffix on win32", async () => {
+  const server = await createTestServer();
+  const tempDir = makeTempDir();
+  const binDir = path.join(tempDir, "bin");
+  const binaryContent = Buffer.from("win-binary");
+  const checksum = sha256(binaryContent);
+  const artifactName = platformArtifact({ platform: "win32", arch: "x64" });
+
+  server.setHandler((req, res) => {
+    if (req.url.endsWith(".sha256")) {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end(`${checksum}  ${artifactName}\n`);
+    } else {
+      res.writeHead(200);
+      res.end(binaryContent);
+    }
+  });
+
+  try {
+    const dest = await installBinary({
+      version: "1.0.0",
+      env: insecureEnv({ QLUENT_CLI_DIST_BASE_URL: server.url }),
+      binDir,
+      platform: "win32",
+      arch: "x64",
+      logger: captureLogger(),
+    });
+
+    assert.ok(dest.endsWith("qluent.exe"));
+    assert.ok(fs.existsSync(dest));
+    assert.equal(fs.existsSync(`${dest}.tmp`), false);
+  } finally {
+    server.close();
+  }
 });


### PR DESCRIPTION
- Added `.tmp` files (`qluent.tmp` and `qluent.exe.tmp`) to `.gitignore` to prevent temporary files from being tracked.
- Introduced download size limits for binaries (200 MB) and checksums (1 KB) to prevent oversized downloads.
- Modified the `download` function to reject downloads exceeding the specified size limits.
- Updated `downloadText` to enforce size limits for text-based downloads (e.g., checksums).
- Changed the installer to write binaries to a temporary file first and then rename it to the final destination after verification.
- Added a warning message when insecure downloads are allowed via the `QLUENT_CLI_ALLOW_INSECURE_DOWNLOAD` environment variable.