### PR TITLE
feat(installer): add Ed25519 signature verification for binaries

### DIFF
--- a/.github/workflows/qluent-cli-binaries.yml
+++ b/.github/workflows/qluent-cli-binaries.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Build standalone binary
         run: python -m qluent_cli.build_binary
+        env:
+          QLUENT_SIGNING_PRIVATE_KEY: ${{ secrets.QLUENT_SIGNING_PRIVATE_KEY }}
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4

--- a/npm/RELEASING.md
+++ b/npm/RELEASING.md
@@ -80,7 +80,15 @@ https://github.com/qluent/qluent-cli/releases/download/v0.1.1/qluent-linux-x64.s
 https://github.com/qluent/qluent-cli/releases/download/v0.1.1/qluent-windows-x64.exe.sha256
 ```
 
-The npm installer verifies each downloaded binary against its sidecar before installation.
+When the `QLUENT_SIGNING_PRIVATE_KEY` secret is set, the build also produces
+Ed25519 signature sidecars (`.sha256.sig`) that the npm installer verifies:
+
+```text
+https://github.com/qluent/qluent-cli/releases/download/v0.1.1/qluent-darwin-arm64.sha256.sig
+```
+
+The npm installer verifies each downloaded binary against its checksum sidecar
+and (when available) the Ed25519 signature before installation.
 If the workflow succeeds but no release appears, confirm the repository allows Actions to create releases.
 
 ## Step 3: Publish npm package
@@ -124,6 +132,43 @@ If you need to test an insecure local `http://` host during development, use:
 ```bash
 QLUENT_CLI_ALLOW_INSECURE_DOWNLOAD=1 QLUENT_CLI_DIST_BASE_URL=http://localhost:9000 npm install -g @qluent/cli
 ```
+
+## Signing key management
+
+Release binaries are signed with Ed25519. The private key is stored as the
+GitHub Actions secret `QLUENT_SIGNING_PRIVATE_KEY` (PEM format). The public key
+is embedded in `lib/installer.js` in the `TRUSTED_PUBLIC_KEYS` array.
+
+### Initial setup
+
+Generate a keypair (one-time):
+
+```bash
+node -e "
+const crypto = require('crypto');
+const kp = crypto.generateKeyPairSync('ed25519');
+console.log(kp.privateKey.export({ type: 'pkcs8', format: 'pem' }));
+console.log('Public key (raw hex):',
+  kp.publicKey.export({ type: 'spki', format: 'der' }).slice(12).toString('hex'));
+"
+```
+
+1. Store the PEM private key as `QLUENT_SIGNING_PRIVATE_KEY` in GitHub Actions secrets.
+2. Replace the placeholder in `TRUSTED_PUBLIC_KEYS` in `lib/installer.js` with the hex public key.
+
+### Key rotation
+
+1. Generate a new keypair.
+2. **Prepend** the new public key to `TRUSTED_PUBLIC_KEYS` in `lib/installer.js`.
+3. Publish the npm package (now trusts both old and new keys).
+4. Update the `QLUENT_SIGNING_PRIVATE_KEY` secret to the new private key.
+5. After a grace period (2-3 releases), remove the old public key from the array.
+
+### Enabling mandatory signature verification
+
+Once all active releases include `.sha256.sig` files, set `SIGNATURE_REQUIRED = true`
+in `lib/installer.js`. Users can still bypass with `QLUENT_CLI_SKIP_SIGNATURE_VERIFICATION=1`
+as an escape hatch.
 
 ## Rollback
 

--- a/npm/lib/installer.js
+++ b/npm/lib/installer.js
@@ -85,7 +85,9 @@ const MAX_BINARY_SIZE = 200 * 1024 * 1024; // 200 MB
 const MAX_CHECKSUM_SIZE = 1024; // 1 KB
 const MAX_SIGNATURE_SIZE = 256; // base64-encoded Ed25519 sig is 88 bytes
 
-// Fixed 12-byte SPKI DER prefix for Ed25519 public keys.
+// Ed25519 SPKI DER encoding: 12-byte fixed prefix (OID + tag + length) followed
+// by 32-byte raw key material. Lets us embed compact hex keys and reconstruct
+// the full DER at verification time. See RFC 8410.
 const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
 
 // Trusted Ed25519 public keys (raw 32-byte hex).
@@ -375,12 +377,10 @@ async function installBinary({
 
 module.exports = {
   DEFAULT_DIST_BASE_URL,
-  ED25519_SPKI_PREFIX,
   MAX_BINARY_SIZE,
   MAX_CHECKSUM_SIZE,
   MAX_SIGNATURE_SIZE,
   SIGNATURE_REQUIRED,
-  TRUSTED_PUBLIC_KEYS,
   allowInsecureDownload,
   assertSecureUrl,
   buildEd25519PublicKey,

--- a/npm/lib/installer.js
+++ b/npm/lib/installer.js
@@ -83,6 +83,20 @@ function getTransport(url) {
 
 const MAX_BINARY_SIZE = 200 * 1024 * 1024; // 200 MB
 const MAX_CHECKSUM_SIZE = 1024; // 1 KB
+const MAX_SIGNATURE_SIZE = 256; // base64-encoded Ed25519 sig is 88 bytes
+
+// Fixed 12-byte SPKI DER prefix for Ed25519 public keys.
+const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+
+// Trusted Ed25519 public keys (raw 32-byte hex).
+// Multiple keys supported for rotation: verification succeeds if ANY key matches.
+// PLACEHOLDER: replace with the real public key after generating the signing keypair.
+const TRUSTED_PUBLIC_KEYS = [
+  "0000000000000000000000000000000000000000000000000000000000000000",
+];
+
+// Set to true once all active releases include .sha256.sig files.
+const SIGNATURE_REQUIRED = false;
 
 function download(url, destination, { env = process.env, redirectsRemaining = 5, maxSize = MAX_BINARY_SIZE } = {}) {
   const safeUrl = assertSecureUrl(url, { env }).toString();
@@ -230,6 +244,46 @@ function verifyFileChecksum(filePath, expectedHash) {
   }
 }
 
+function resolveSignatureUrl(checksumUrl) {
+  return `${checksumUrl}.sig`;
+}
+
+function buildEd25519PublicKey(rawHex) {
+  const rawBytes = Buffer.from(rawHex, "hex");
+  if (rawBytes.length !== 32) {
+    throw new Error(
+      `Invalid Ed25519 public key length: expected 32 bytes, got ${rawBytes.length}`
+    );
+  }
+  const der = Buffer.concat([ED25519_SPKI_PREFIX, rawBytes]);
+  return crypto.createPublicKey({ key: der, format: "der", type: "spki" });
+}
+
+function verifySignature(
+  checksumContent,
+  signatureBase64,
+  { trustedKeys = TRUSTED_PUBLIC_KEYS } = {}
+) {
+  const signatureBuffer = Buffer.from(signatureBase64.trim(), "base64");
+  if (signatureBuffer.length !== 64) {
+    throw new Error(
+      `Invalid signature length: expected 64 bytes, got ${signatureBuffer.length}`
+    );
+  }
+  const messageBuffer = Buffer.from(checksumContent);
+
+  for (const keyHex of trustedKeys) {
+    const publicKey = buildEd25519PublicKey(keyHex);
+    if (crypto.verify(null, messageBuffer, publicKey, signatureBuffer)) {
+      return true;
+    }
+  }
+
+  throw new Error(
+    "Signature verification failed: no trusted key could verify the signature"
+  );
+}
+
 async function installBinary({
   version,
   env = process.env,
@@ -237,6 +291,7 @@ async function installBinary({
   platform = process.platform,
   arch = process.arch,
   logger = console,
+  trustedKeys = TRUSTED_PUBLIC_KEYS,
 } = {}) {
   if (!version) {
     throw new Error("version is required");
@@ -273,6 +328,35 @@ async function installBinary({
 
   try {
     const checksumBody = await downloadText(checksumUrl, { env });
+
+    if (env.QLUENT_CLI_SKIP_SIGNATURE_VERIFICATION === "1") {
+      logger.log(
+        "WARNING: QLUENT_CLI_SKIP_SIGNATURE_VERIFICATION is set. " +
+          "Signature verification is disabled."
+      );
+    } else {
+      const signatureUrl = resolveSignatureUrl(checksumUrl);
+      try {
+        const signatureBody = await downloadText(signatureUrl, {
+          env,
+          maxSize: MAX_SIGNATURE_SIZE,
+        });
+        verifySignature(checksumBody, signatureBody, { trustedKeys });
+        logger.log("Signature verification passed");
+      } catch (sigError) {
+        if (
+          SIGNATURE_REQUIRED ||
+          !sigError.message.includes("Download failed with status")
+        ) {
+          throw sigError;
+        }
+        logger.log(
+          "WARNING: Signature file not found. " +
+            "Signature verification will be required in a future release."
+        );
+      }
+    }
+
     const expectedChecksum = parseChecksumFile(
       checksumBody,
       path.basename(binaryUrl)
@@ -291,10 +375,15 @@ async function installBinary({
 
 module.exports = {
   DEFAULT_DIST_BASE_URL,
+  ED25519_SPKI_PREFIX,
   MAX_BINARY_SIZE,
   MAX_CHECKSUM_SIZE,
+  MAX_SIGNATURE_SIZE,
+  SIGNATURE_REQUIRED,
+  TRUSTED_PUBLIC_KEYS,
   allowInsecureDownload,
   assertSecureUrl,
+  buildEd25519PublicKey,
   download,
   downloadText,
   installBinary,
@@ -302,6 +391,8 @@ module.exports = {
   platformArtifact,
   resolveChecksumUrl,
   resolveDownloadUrl,
+  resolveSignatureUrl,
   sha256File,
   verifyFileChecksum,
+  verifySignature,
 };

--- a/npm/tests/installer.test.js
+++ b/npm/tests/installer.test.js
@@ -9,8 +9,11 @@ const path = require("path");
 const {
   MAX_BINARY_SIZE,
   MAX_CHECKSUM_SIZE,
+  MAX_SIGNATURE_SIZE,
+  SIGNATURE_REQUIRED,
   allowInsecureDownload,
   assertSecureUrl,
+  buildEd25519PublicKey,
   download,
   downloadText,
   installBinary,
@@ -18,8 +21,10 @@ const {
   platformArtifact,
   resolveChecksumUrl,
   resolveDownloadUrl,
+  resolveSignatureUrl,
   sha256File,
   verifyFileChecksum,
+  verifySignature,
 } = require("../lib/installer");
 
 // ---------------------------------------------------------------------------
@@ -64,6 +69,23 @@ function captureLogger() {
     messages,
     log: (msg) => messages.push(msg),
   };
+}
+
+/** Generate an Ed25519 keypair for testing. */
+function generateSigningKeyPair() {
+  const kp = crypto.generateKeyPairSync("ed25519");
+  const pubDer = kp.publicKey.export({ type: "spki", format: "der" });
+  return { privateKey: kp.privateKey, publicKeyHex: pubDer.slice(12).toString("hex") };
+}
+
+/** Sign content with an Ed25519 private key, return base64 string. */
+function signContent(content, privateKey) {
+  return crypto.sign(null, Buffer.from(content), privateKey).toString("base64");
+}
+
+/** Env that skips signature verification (for tests not focused on signatures). */
+function insecureEnvSkipSig(extra = {}) {
+  return insecureEnv({ QLUENT_CLI_SKIP_SIGNATURE_VERIFICATION: "1", ...extra });
 }
 
 // ---------------------------------------------------------------------------
@@ -356,7 +378,7 @@ test("installBinary writes to .tmp first and renames on success", async () => {
   try {
     const dest = await installBinary({
       version: "1.0.0",
-      env: insecureEnv({ QLUENT_CLI_DIST_BASE_URL: server.url }),
+      env: insecureEnvSkipSig({ QLUENT_CLI_DIST_BASE_URL: server.url }),
       binDir,
       platform: "darwin",
       arch: "arm64",
@@ -398,7 +420,7 @@ test("installBinary cleans up .tmp and leaves no final binary on checksum mismat
       () =>
         installBinary({
           version: "1.0.0",
-          env: insecureEnv({ QLUENT_CLI_DIST_BASE_URL: server.url }),
+          env: insecureEnvSkipSig({ QLUENT_CLI_DIST_BASE_URL: server.url }),
           binDir,
           platform: "darwin",
           arch: "arm64",
@@ -436,7 +458,7 @@ test("installBinary cleans up .tmp when checksum download fails", async () => {
       () =>
         installBinary({
           version: "1.0.0",
-          env: insecureEnv({ QLUENT_CLI_DIST_BASE_URL: server.url }),
+          env: insecureEnvSkipSig({ QLUENT_CLI_DIST_BASE_URL: server.url }),
           binDir,
           platform: "darwin",
           arch: "arm64",
@@ -480,7 +502,7 @@ test("temp file is written with mode 0o600 (not executable)", async () => {
   try {
     await installBinary({
       version: "1.0.0",
-      env: insecureEnv({ QLUENT_CLI_DIST_BASE_URL: server.url }),
+      env: insecureEnvSkipSig({ QLUENT_CLI_DIST_BASE_URL: server.url }),
       binDir,
       platform: "linux",
       arch: "x64",
@@ -521,14 +543,14 @@ test("installBinary logs a warning when QLUENT_CLI_ALLOW_INSECURE_DOWNLOAD is se
   try {
     await installBinary({
       version: "1.0.0",
-      env: insecureEnv({ QLUENT_CLI_DIST_BASE_URL: server.url }),
+      env: insecureEnvSkipSig({ QLUENT_CLI_DIST_BASE_URL: server.url }),
       binDir,
       platform: "darwin",
       arch: "arm64",
       logger,
     });
 
-    const warningMsg = logger.messages.find((m) => m.includes("WARNING"));
+    const warningMsg = logger.messages.find((m) => m.includes("QLUENT_CLI_ALLOW_INSECURE_DOWNLOAD"));
     assert.ok(warningMsg, "expected a WARNING message in the logs");
     assert.match(warningMsg, /QLUENT_CLI_ALLOW_INSECURE_DOWNLOAD/);
     assert.match(warningMsg, /local development/);
@@ -741,7 +763,7 @@ test("installBinary uses .exe suffix on win32", async () => {
   try {
     const dest = await installBinary({
       version: "1.0.0",
-      env: insecureEnv({ QLUENT_CLI_DIST_BASE_URL: server.url }),
+      env: insecureEnvSkipSig({ QLUENT_CLI_DIST_BASE_URL: server.url }),
       binDir,
       platform: "win32",
       arch: "x64",
@@ -751,6 +773,350 @@ test("installBinary uses .exe suffix on win32", async () => {
     assert.ok(dest.endsWith("qluent.exe"));
     assert.ok(fs.existsSync(dest));
     assert.equal(fs.existsSync(`${dest}.tmp`), false);
+  } finally {
+    server.close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Signature verification – unit tests
+// ---------------------------------------------------------------------------
+
+test("resolveSignatureUrl appends .sig to checksum URL", () => {
+  assert.equal(
+    resolveSignatureUrl(
+      "https://github.com/qluent/qluent-cli/releases/download/v0.1.0/qluent-darwin-arm64.sha256"
+    ),
+    "https://github.com/qluent/qluent-cli/releases/download/v0.1.0/qluent-darwin-arm64.sha256.sig"
+  );
+});
+
+test("buildEd25519PublicKey creates a valid key from raw hex", () => {
+  const { publicKeyHex } = generateSigningKeyPair();
+  const key = buildEd25519PublicKey(publicKeyHex);
+  assert.equal(key.type, "public");
+  assert.equal(key.asymmetricKeyType, "ed25519");
+});
+
+test("buildEd25519PublicKey rejects wrong-length hex", () => {
+  assert.throws(
+    () => buildEd25519PublicKey("abcd"),
+    /expected 32 bytes/
+  );
+});
+
+test("verifySignature succeeds with a valid signature", () => {
+  const { privateKey, publicKeyHex } = generateSigningKeyPair();
+  const content = "abc123  qluent-darwin-arm64\n";
+  const sig = signContent(content, privateKey);
+
+  assert.equal(
+    verifySignature(content, sig, { trustedKeys: [publicKeyHex] }),
+    true
+  );
+});
+
+test("verifySignature fails with an untrusted key", () => {
+  const signer = generateSigningKeyPair();
+  const untrusted = generateSigningKeyPair();
+  const content = "abc123  qluent-darwin-arm64\n";
+  const sig = signContent(content, signer.privateKey);
+
+  assert.throws(
+    () => verifySignature(content, sig, { trustedKeys: [untrusted.publicKeyHex] }),
+    /no trusted key could verify/
+  );
+});
+
+test("verifySignature fails with tampered content", () => {
+  const { privateKey, publicKeyHex } = generateSigningKeyPair();
+  const original = "abc123  qluent-darwin-arm64\n";
+  const sig = signContent(original, privateKey);
+  const tampered = "def456  qluent-darwin-arm64\n";
+
+  assert.throws(
+    () => verifySignature(tampered, sig, { trustedKeys: [publicKeyHex] }),
+    /no trusted key could verify/
+  );
+});
+
+test("verifySignature succeeds if any key in the trusted set matches (rotation)", () => {
+  const oldKey = generateSigningKeyPair();
+  const newKey = generateSigningKeyPair();
+  const content = "abc123  qluent-darwin-arm64\n";
+
+  // Signed with old key, both keys trusted
+  const sig = signContent(content, oldKey.privateKey);
+  assert.equal(
+    verifySignature(content, sig, {
+      trustedKeys: [newKey.publicKeyHex, oldKey.publicKeyHex],
+    }),
+    true
+  );
+
+  // Signed with new key, both keys trusted
+  const sig2 = signContent(content, newKey.privateKey);
+  assert.equal(
+    verifySignature(content, sig2, {
+      trustedKeys: [newKey.publicKeyHex, oldKey.publicKeyHex],
+    }),
+    true
+  );
+});
+
+test("verifySignature rejects invalid base64", () => {
+  const { publicKeyHex } = generateSigningKeyPair();
+  assert.throws(
+    () => verifySignature("content", "not-valid-base64!!!", { trustedKeys: [publicKeyHex] }),
+    /Invalid signature length/
+  );
+});
+
+test("verifySignature rejects truncated signature", () => {
+  const { privateKey, publicKeyHex } = generateSigningKeyPair();
+  const content = "test content";
+  const fullSig = signContent(content, privateKey);
+  const truncated = Buffer.from(fullSig, "base64").slice(0, 32).toString("base64");
+
+  assert.throws(
+    () => verifySignature(content, truncated, { trustedKeys: [publicKeyHex] }),
+    /Invalid signature length/
+  );
+});
+
+test("MAX_SIGNATURE_SIZE has a sane default", () => {
+  assert.equal(MAX_SIGNATURE_SIZE, 256);
+});
+
+test("SIGNATURE_REQUIRED is false during transition", () => {
+  assert.equal(SIGNATURE_REQUIRED, false);
+});
+
+// ---------------------------------------------------------------------------
+// Signature verification – installBinary integration tests
+// ---------------------------------------------------------------------------
+
+/** Create a test server handler that serves binary, checksum, and signature. */
+function signedReleaseHandler({ binaryContent, artifactName, signingKey }) {
+  const checksum = sha256(binaryContent);
+  const checksumBody = `${checksum}  ${artifactName}\n`;
+  const signature = signContent(checksumBody, signingKey.privateKey);
+
+  return (req, res) => {
+    if (req.url.endsWith(".sha256.sig")) {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end(signature + "\n");
+    } else if (req.url.endsWith(".sha256")) {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end(checksumBody);
+    } else {
+      res.writeHead(200);
+      res.end(binaryContent);
+    }
+  };
+}
+
+test("installBinary succeeds end-to-end with valid signature", async () => {
+  const server = await createTestServer();
+  const tempDir = makeTempDir();
+  const binDir = path.join(tempDir, "bin");
+  const signingKey = generateSigningKeyPair();
+  const binaryContent = Buffer.from("signed-binary");
+  const artifactName = platformArtifact({ platform: "darwin", arch: "arm64" });
+  const logger = captureLogger();
+
+  server.setHandler(
+    signedReleaseHandler({ binaryContent, artifactName, signingKey })
+  );
+
+  try {
+    const dest = await installBinary({
+      version: "1.0.0",
+      env: insecureEnv({ QLUENT_CLI_DIST_BASE_URL: server.url }),
+      binDir,
+      platform: "darwin",
+      arch: "arm64",
+      logger,
+      trustedKeys: [signingKey.publicKeyHex],
+    });
+
+    assert.ok(fs.existsSync(dest));
+    assert.deepEqual(fs.readFileSync(dest), binaryContent);
+    assert.ok(logger.messages.some((m) => m.includes("Signature verification passed")));
+  } finally {
+    server.close();
+  }
+});
+
+test("installBinary fails when signature is from wrong key", async () => {
+  const server = await createTestServer();
+  const tempDir = makeTempDir();
+  const binDir = path.join(tempDir, "bin");
+  const signingKey = generateSigningKeyPair();
+  const wrongKey = generateSigningKeyPair();
+  const binaryContent = Buffer.from("wrong-key-binary");
+  const artifactName = platformArtifact({ platform: "darwin", arch: "arm64" });
+
+  // Server signs with signingKey, but installer trusts wrongKey
+  server.setHandler(
+    signedReleaseHandler({ binaryContent, artifactName, signingKey })
+  );
+
+  try {
+    await assert.rejects(
+      () =>
+        installBinary({
+          version: "1.0.0",
+          env: insecureEnv({ QLUENT_CLI_DIST_BASE_URL: server.url }),
+          binDir,
+          platform: "darwin",
+          arch: "arm64",
+          logger: captureLogger(),
+          trustedKeys: [wrongKey.publicKeyHex],
+        }),
+      /no trusted key could verify/
+    );
+
+    // .tmp must be cleaned up
+    assert.equal(fs.existsSync(path.join(binDir, "qluent")), false);
+    assert.equal(fs.existsSync(path.join(binDir, "qluent.tmp")), false);
+  } finally {
+    server.close();
+  }
+});
+
+test("installBinary cleans up .tmp on signature verification failure", async () => {
+  const server = await createTestServer();
+  const tempDir = makeTempDir();
+  const binDir = path.join(tempDir, "bin");
+  const signingKey = generateSigningKeyPair();
+  const binaryContent = Buffer.from("tamper-test");
+  const artifactName = platformArtifact({ platform: "linux", arch: "x64" });
+
+  // Serve a valid binary and checksum, but a signature over different content
+  const checksum = sha256(binaryContent);
+  const checksumBody = `${checksum}  ${artifactName}\n`;
+  const badSig = signContent("tampered checksum content", signingKey.privateKey);
+
+  server.setHandler((req, res) => {
+    if (req.url.endsWith(".sha256.sig")) {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end(badSig + "\n");
+    } else if (req.url.endsWith(".sha256")) {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end(checksumBody);
+    } else {
+      res.writeHead(200);
+      res.end(binaryContent);
+    }
+  });
+
+  try {
+    await assert.rejects(
+      () =>
+        installBinary({
+          version: "1.0.0",
+          env: insecureEnv({ QLUENT_CLI_DIST_BASE_URL: server.url }),
+          binDir,
+          platform: "linux",
+          arch: "x64",
+          logger: captureLogger(),
+          trustedKeys: [signingKey.publicKeyHex],
+        }),
+      /no trusted key could verify/
+    );
+
+    assert.equal(fs.existsSync(path.join(binDir, "qluent")), false);
+    assert.equal(fs.existsSync(path.join(binDir, "qluent.tmp")), false);
+  } finally {
+    server.close();
+  }
+});
+
+test("installBinary warns but succeeds when .sig is missing and SIGNATURE_REQUIRED is false", async () => {
+  const server = await createTestServer();
+  const tempDir = makeTempDir();
+  const binDir = path.join(tempDir, "bin");
+  const binaryContent = Buffer.from("unsigned-binary");
+  const checksum = sha256(binaryContent);
+  const artifactName = platformArtifact({ platform: "darwin", arch: "arm64" });
+  const logger = captureLogger();
+
+  // Serve binary and checksum, but 404 for .sig
+  server.setHandler((req, res) => {
+    if (req.url.endsWith(".sha256.sig")) {
+      res.writeHead(404);
+      res.end("not found");
+    } else if (req.url.endsWith(".sha256")) {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end(`${checksum}  ${artifactName}\n`);
+    } else {
+      res.writeHead(200);
+      res.end(binaryContent);
+    }
+  });
+
+  try {
+    const dest = await installBinary({
+      version: "1.0.0",
+      env: insecureEnv({ QLUENT_CLI_DIST_BASE_URL: server.url }),
+      binDir,
+      platform: "darwin",
+      arch: "arm64",
+      logger,
+      trustedKeys: [generateSigningKeyPair().publicKeyHex],
+    });
+
+    assert.ok(fs.existsSync(dest));
+    assert.ok(
+      logger.messages.some((m) => m.includes("Signature file not found")),
+      "expected a warning about missing signature"
+    );
+  } finally {
+    server.close();
+  }
+});
+
+test("installBinary skips signature check when QLUENT_CLI_SKIP_SIGNATURE_VERIFICATION=1", async () => {
+  const server = await createTestServer();
+  const tempDir = makeTempDir();
+  const binDir = path.join(tempDir, "bin");
+  const binaryContent = Buffer.from("skip-sig-binary");
+  const checksum = sha256(binaryContent);
+  const artifactName = platformArtifact({ platform: "darwin", arch: "arm64" });
+  const logger = captureLogger();
+
+  // No .sig served at all — would fail without the skip flag
+  server.setHandler((req, res) => {
+    if (req.url.endsWith(".sha256")) {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end(`${checksum}  ${artifactName}\n`);
+    } else {
+      res.writeHead(200);
+      res.end(binaryContent);
+    }
+  });
+
+  try {
+    const dest = await installBinary({
+      version: "1.0.0",
+      env: insecureEnvSkipSig({ QLUENT_CLI_DIST_BASE_URL: server.url }),
+      binDir,
+      platform: "darwin",
+      arch: "arm64",
+      logger,
+    });
+
+    assert.ok(fs.existsSync(dest));
+    assert.ok(
+      logger.messages.some((m) => m.includes("QLUENT_CLI_SKIP_SIGNATURE_VERIFICATION")),
+      "expected a warning about skipped signature verification"
+    );
+    // Should NOT have a "Signature verification passed" message
+    assert.equal(
+      logger.messages.some((m) => m.includes("Signature verification passed")),
+      false
+    );
   } finally {
     server.close();
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
 [project.optional-dependencies]
 build = [
     "pyinstaller>=6.0",
+    "cryptography>=43.0",
 ]
 
 [project.scripts]

--- a/src/qluent_cli/build_binary.py
+++ b/src/qluent_cli/build_binary.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import base64
 import hashlib
+import os
 import platform
 import shutil
 import subprocess
@@ -52,6 +54,17 @@ def write_sha256_file(path: Path) -> Path:
     checksum_path = path.with_name(f"{path.name}.sha256")
     checksum_path.write_text(f"{sha256_file(path)}  {path.name}\n")
     return checksum_path
+
+
+def sign_checksum_file(checksum_path: Path, private_key_pem: str) -> Path:
+    from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+    private_key = load_pem_private_key(private_key_pem.encode(), password=None)
+    checksum_content = checksum_path.read_bytes()
+    signature = private_key.sign(checksum_content)
+    sig_path = checksum_path.with_name(f"{checksum_path.name}.sig")
+    sig_path.write_text(base64.b64encode(signature).decode() + "\n")
+    return sig_path
 
 
 def build_pyinstaller_args(
@@ -126,7 +139,15 @@ def build_binary(
     final_path = output_dir / artifact_name(platform_name, arch_name)
     shutil.copy2(built_binary, final_path)
     final_path.chmod(0o755)
-    write_sha256_file(final_path)
+    checksum_path = write_sha256_file(final_path)
+
+    signing_key = os.environ.get("QLUENT_SIGNING_PRIVATE_KEY")
+    if signing_key:
+        sig_path = sign_checksum_file(checksum_path, signing_key)
+        print(f"Signed {sig_path}")
+    else:
+        print("QLUENT_SIGNING_PRIVATE_KEY not set, skipping signature")
+
     return final_path
 
 


### PR DESCRIPTION
- Introduce Ed25519 signature verification for downloaded binaries using `.sha256.sig` files
- Add support for multiple trusted public keys in `TRUSTED_PUBLIC_KEYS` for key rotation
- Implement signature verification logic in `verifySignature()` and supporting functions
- Add `SIGNATURE_REQUIRED` flag to enforce mandatory signature verification in future
- Update GitHub Actions workflow to include private key environment variable for signing
- Add documentation for key management, rotation, and verification process
- Extend test suite with signing key generation and signature verification tests