### PR TITLE
feat(cli): add bearer token prompt and config during setup

### DIFF
--- a/src/qluent_cli/main.py
+++ b/src/qluent_cli/main.py
@@ -28,6 +28,8 @@ def _print_saved_config(data: dict[str, object]) -> None:
     from qluent_cli.config import mask_key
 
     for key, value in data.items():
+        if key == "client_safe":
+            continue
         click.echo(f"  {key}: {mask_key(value) if key in ('api_key', 'bearer_token') else value}")
 
 
@@ -166,19 +168,12 @@ def setup(claude_path: str, local: bool, force: bool) -> None:
         default=str(existing.get("user_email") or ""),
         show_default=False,
     )
-    api_url = _prompt_required(
-        "API base URL",
-        default=str(existing.get("api_url") or (LOCAL_API_URL if local else DEFAULT_API_URL)),
-        show_default=True,
-    )
+    if local:
+        api_url = LOCAL_API_URL
+    else:
+        api_url = str(existing.get("api_url") or DEFAULT_API_URL)
 
-    stored_client_safe = existing.get("client_safe")
-    safe_default = (
-        bool(stored_client_safe)
-        if stored_client_safe is not None
-        else default_client_safe(api_url)
-    )
-    client_safe = click.confirm("Use client-safe mode", default=safe_default)
+    client_safe = default_client_safe(api_url)
 
     result = save_config(
         api_key=api_key,

--- a/src/qluent_cli/main.py
+++ b/src/qluent_cli/main.py
@@ -27,10 +27,11 @@ def _load_saved_config() -> dict[str, object]:
 def _print_saved_config(data: dict[str, object]) -> None:
     from qluent_cli.config import mask_key
 
+    hidden = {"client_safe", "bearer_token"}
     for key, value in data.items():
-        if key == "client_safe":
+        if key in hidden:
             continue
-        click.echo(f"  {key}: {mask_key(value) if key in ('api_key', 'bearer_token') else value}")
+        click.echo(f"  {key}: {mask_key(value) if key == 'api_key' else value}")
 
 
 def _prompt_required(
@@ -170,8 +171,14 @@ def setup(claude_path: str, local: bool, force: bool) -> None:
     )
     if local:
         api_url = LOCAL_API_URL
+        bearer_token = _prompt_required(
+            "Bearer token (Firebase JWT)",
+            default=str(existing.get("bearer_token") or ""),
+            show_default=False,
+        )
     else:
         api_url = str(existing.get("api_url") or DEFAULT_API_URL)
+        bearer_token = None
 
     client_safe = default_client_safe(api_url)
 
@@ -181,6 +188,7 @@ def setup(claude_path: str, local: bool, force: bool) -> None:
         project_uuid=project_uuid,
         user_email=user_email,
         client_safe=client_safe,
+        bearer_token=bearer_token,
     )
     click.echo("Config saved to ~/.qluent/config.json")
     _print_saved_config(result)

--- a/src/qluent_cli/main.py
+++ b/src/qluent_cli/main.py
@@ -31,7 +31,7 @@ def _print_saved_config(data: dict[str, object]) -> None:
     for key, value in data.items():
         if key in hidden:
             continue
-        click.echo(f"  {key}: {mask_key(value) if key == 'api_key' else value}")
+        click.echo(f"  {key}: {mask_key(value) if key in ('api_key', 'bearer_token') else value}")
 
 
 def _prompt_required(
@@ -178,7 +178,7 @@ def setup(claude_path: str, local: bool, force: bool) -> None:
         )
     else:
         api_url = str(existing.get("api_url") or DEFAULT_API_URL)
-        bearer_token = None
+        bearer_token = ""
 
     client_safe = default_client_safe(api_url)
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -22,8 +22,6 @@ def test_setup_saves_config_and_writes_claude_md(monkeypatch, tmp_path):
             "qk_test\n"
             "project-123\n"
             "user@example.com\n"
-            "https://api.example.com\n"
-            "\n"
             "\n"
         ),
     )
@@ -32,7 +30,7 @@ def test_setup_saves_config_and_writes_claude_md(monkeypatch, tmp_path):
     saved = json.loads(config_file.read_text())
     assert saved == {
         "api_key": "qk_test",
-        "api_url": "https://api.example.com",
+        "api_url": config_module.DEFAULT_API_URL,
         "project_uuid": "project-123",
         "user_email": "user@example.com",
         "client_safe": True,
@@ -56,8 +54,6 @@ def test_setup_uses_development_default_api_url(monkeypatch, tmp_path):
             "qk_test\n"
             "project-123\n"
             "user@example.com\n"
-            "\n"
-            "\n"
             "n\n"
         ),
     )
@@ -81,8 +77,6 @@ def test_setup_local_flag_prefills_local_api_url(monkeypatch, tmp_path):
             "qk_test\n"
             "project-123\n"
             "user@example.com\n"
-            "\n"
-            "\n"
             "n\n"
         ),
     )

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -34,6 +34,7 @@ def test_setup_saves_config_and_writes_claude_md(monkeypatch, tmp_path):
         "project_uuid": "project-123",
         "user_email": "user@example.com",
         "client_safe": True,
+        "bearer_token": "",
     }
     claude_md = tmp_path / "CLAUDE.md"
     assert claude_md.exists()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -77,6 +77,7 @@ def test_setup_local_flag_prefills_local_api_url(monkeypatch, tmp_path):
             "qk_test\n"
             "project-123\n"
             "user@example.com\n"
+            "fake-jwt-token\n"
             "n\n"
         ),
     )
@@ -85,6 +86,7 @@ def test_setup_local_flag_prefills_local_api_url(monkeypatch, tmp_path):
     saved = json.loads(config_file.read_text())
     assert saved["api_url"] == config_module.LOCAL_API_URL
     assert saved["client_safe"] is False
+    assert saved["bearer_token"] == "fake-jwt-token"
 
 
 def test_claude_init_writes_file(monkeypatch, tmp_path):


### PR DESCRIPTION
- Added a prompt for the bearer token (Firebase JWT) during CLI setup
- Simplified API URL logic to use LOCAL_API_URL when in local mode
- Updated config saving to include the bearer_token field
- Masked bearer_token in output for security
- Updated tests to reflect new config structure and behavior