### PR TITLE
refactor(client): update API URL structure and versioning

### DIFF
--- a/src/qluent_cli/client.py
+++ b/src/qluent_cli/client.py
@@ -14,7 +14,7 @@ class QluentClient:
 
     def __init__(self, config: QluentConfig) -> None:
         self._config = config
-        self._base = f"{config.api_url}/api/projects/{config.project_uuid}"
+        self._base = f"{config.api_url}/api/v1/project/{config.project_uuid}"
         headers: dict[str, str] = {}
         if config.bearer_token:
             headers["Authorization"] = f"Bearer {config.bearer_token}"

--- a/src/qluent_cli/config.py
+++ b/src/qluent_cli/config.py
@@ -10,7 +10,7 @@ from typing import Any
 
 CONFIG_DIR = Path.home() / ".qluent"
 CONFIG_FILE = CONFIG_DIR / "config.json"
-DEFAULT_API_URL = "https://app-development.qluent.com"
+DEFAULT_API_URL = "https://api.app-development.qluent.com"
 LOCAL_API_URL = "http://localhost:8001"
 
 


### PR DESCRIPTION
- Changed base URL from `/api/projects/{project_uuid}` to `/api/v1/project/{project_uuid}` to support versioning
- Updated default API URL to include `api` subpath: `https://api.app-development.qluent.com`
- No functional changes, only structural updates for future-proofing API compatibility