### PR TITLE
feat: switch to production API URL and deprecate bearer-token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ That walks the user through:
 - API URL
 - generating `CLAUDE.md`
 
-The default test environment is `https://app-development.qluent.com`.
+The default hosted environment is `https://api.app.qluent.com`.
 For local backend development, run:
 
 ```bash
@@ -125,7 +125,7 @@ To include a real API smoke test:
 QLUENT_TEST_API_KEY=qk_... \
 QLUENT_TEST_PROJECT_UUID=<PROJECT_UUID> \
 QLUENT_TEST_USER_EMAIL=you@example.com \
-QLUENT_TEST_URL=https://app-development.qluent.com \
+QLUENT_TEST_URL=https://api.app.qluent.com \
 QLUENT_TEST_TREE_ID=revenue \
 scripts/local_smoke_test.sh
 ```

--- a/npm/README.md
+++ b/npm/README.md
@@ -15,7 +15,7 @@ npm install -g @qluent/cli
 qluent setup
 ```
 
-This defaults to the Qluent test environment at `https://app-development.qluent.com`.
+This defaults to the hosted Qluent API at `https://api.app.qluent.com`.
 For local backend development, use:
 
 ```bash

--- a/scripts/local_smoke_test.sh
+++ b/scripts/local_smoke_test.sh
@@ -14,7 +14,7 @@ Optional environment variables:
   QLUENT_TEST_API_KEY       API key for a real API smoke test
   QLUENT_TEST_PROJECT_UUID  Project UUID for a real API smoke test
   QLUENT_TEST_USER_EMAIL    User email for a real API smoke test
-  QLUENT_TEST_URL           API base URL (default: https://app-development.qluent.com)
+  QLUENT_TEST_URL           API base URL (default: https://api.app.qluent.com)
   QLUENT_TEST_TREE_ID       Optional tree id for an extra trend smoke test
   QLUENT_SMOKE_NPM=1        Also test the local npm wrapper install in an isolated prefix
 
@@ -86,7 +86,7 @@ echo "==> Smoke: claude init"
 )
 
 if [[ -n "${QLUENT_TEST_API_KEY:-}" && -n "${QLUENT_TEST_PROJECT_UUID:-}" && -n "${QLUENT_TEST_USER_EMAIL:-}" ]]; then
-  TEST_URL="${QLUENT_TEST_URL:-https://app-development.qluent.com}"
+  TEST_URL="${QLUENT_TEST_URL:-https://api.app.qluent.com}"
 
   echo "==> Smoke: config + live API"
   HOME="$TMP_HOME" "$BINARY_PATH" config \

--- a/src/qluent_cli/client.py
+++ b/src/qluent_cli/client.py
@@ -16,9 +16,7 @@ class QluentClient:
         self._config = config
         self._base = f"{config.api_url}/api/v1/project/{config.project_uuid}"
         headers: dict[str, str] = {}
-        if config.bearer_token:
-            headers["Authorization"] = f"Bearer {config.bearer_token}"
-        elif config.api_key:
+        if config.api_key:
             headers["X-API-Key"] = config.api_key
         if config.client_safe:
             headers["X-Qluent-Client-Safe"] = "true"

--- a/src/qluent_cli/config.py
+++ b/src/qluent_cli/config.py
@@ -10,7 +10,7 @@ from typing import Any
 
 CONFIG_DIR = Path.home() / ".qluent"
 CONFIG_FILE = CONFIG_DIR / "config.json"
-DEFAULT_API_URL = "https://api.app-development.qluent.com"
+DEFAULT_API_URL = "https://api.app.qluent.com"
 LOCAL_API_URL = "http://localhost:8001"
 
 
@@ -62,8 +62,13 @@ def load_config() -> QluentConfig:
     else:
         client_safe = default_client_safe(api_url)
 
-    if not api_key and not bearer_token:
-        raise SystemExit("No API key or bearer token configured. Run: qluent config --api-key qk_... or --bearer-token <jwt>")
+    if not api_key:
+        if bearer_token:
+            raise SystemExit(
+                "Bearer-token auth is not supported by the public metric-tree API. "
+                "Configure an API key instead: qluent config --api-key qk_..."
+            )
+        raise SystemExit("No API key configured. Run: qluent config --api-key qk_...")
     if not project_uuid:
         raise SystemExit("No project configured. Run: qluent config --project UUID")
     if not user_email:

--- a/src/qluent_cli/config.py
+++ b/src/qluent_cli/config.py
@@ -51,6 +51,14 @@ def load_config() -> QluentConfig:
 
     api_key = get("QLUENT_API_KEY", "api_key")
     api_url = get("QLUENT_API_URL", "api_url") or DEFAULT_API_URL
+    if api_url.lower().startswith("http://") and not (
+        api_url.lower().startswith("http://localhost")
+        or api_url.lower().startswith("http://127.0.0.1")
+    ):
+        raise SystemExit(
+            f"Refusing to connect over plain HTTP to {api_url} — "
+            "API keys would be sent in cleartext. Use https:// or --local for localhost."
+        )
     project_uuid = get("QLUENT_PROJECT_UUID", "project_uuid")
     user_email = get("QLUENT_USER_EMAIL", "user_email")
     bearer_token = get("QLUENT_BEARER_TOKEN", "bearer_token")
@@ -105,6 +113,7 @@ def save_config(
         existing["user_email"] = user_email
     if client_safe is not None:
         existing["client_safe"] = client_safe
+    existing.pop("bearer_token", None)
 
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     CONFIG_DIR.chmod(0o700)

--- a/src/qluent_cli/config.py
+++ b/src/qluent_cli/config.py
@@ -21,7 +21,6 @@ class QluentConfig:
     project_uuid: str
     user_email: str
     client_safe: bool = False
-    bearer_token: str = ""
 
 
 def _parse_bool(value: Any) -> bool:
@@ -80,7 +79,6 @@ def load_config() -> QluentConfig:
         project_uuid=project_uuid,
         user_email=user_email,
         client_safe=client_safe,
-        bearer_token=bearer_token,
     )
 
 
@@ -90,7 +88,6 @@ def save_config(
     project_uuid: str | None = None,
     user_email: str | None = None,
     client_safe: bool | None = None,
-    bearer_token: str | None = None,
 ) -> dict[str, Any]:
     """Save config values to ~/.qluent/config.json (merges with existing)."""
     existing: dict[str, Any] = {}
@@ -108,8 +105,6 @@ def save_config(
         existing["user_email"] = user_email
     if client_safe is not None:
         existing["client_safe"] = client_safe
-    if bearer_token is not None:
-        existing["bearer_token"] = bearer_token
 
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     CONFIG_DIR.chmod(0o700)

--- a/src/qluent_cli/main.py
+++ b/src/qluent_cli/main.py
@@ -31,7 +31,7 @@ def _print_saved_config(data: dict[str, object]) -> None:
     for key, value in data.items():
         if key in hidden:
             continue
-        click.echo(f"  {key}: {mask_key(value) if key in ('api_key', 'bearer_token') else value}")
+        click.echo(f"  {key}: {mask_key(value) if key == 'api_key' else value}")
 
 
 def _prompt_required(
@@ -68,6 +68,7 @@ def _prompt_required(
 )
 @click.option(
     "--bearer-token",
+    hidden=True,
     help="Deprecated legacy option. The metric-tree API uses X-API-Key auth.",
 )
 def config(
@@ -97,7 +98,7 @@ def config(
 
     effective_url = LOCAL_API_URL if local else url
 
-    if not any([api_key, effective_url, project, email, client_safe is not None, bearer_token]):
+    if not any([api_key, effective_url, project, email, client_safe is not None]):
         if CONFIG_FILE.exists():
             data = _load_saved_config()
             if "client_safe" not in data:
@@ -115,7 +116,6 @@ def config(
         project_uuid=project,
         user_email=email,
         client_safe=client_safe,
-        bearer_token=bearer_token,
     )
     if "client_safe" not in result:
         result["client_safe"] = default_client_safe(
@@ -176,13 +176,7 @@ def setup(claude_path: str, local: bool, force: bool) -> None:
         default=str(existing.get("user_email") or ""),
         show_default=False,
     )
-    if local:
-        api_url = LOCAL_API_URL
-        bearer_token = ""
-    else:
-        api_url = str(existing.get("api_url") or DEFAULT_API_URL)
-        bearer_token = ""
-
+    api_url = LOCAL_API_URL if local else str(existing.get("api_url") or DEFAULT_API_URL)
     client_safe = default_client_safe(api_url)
 
     result = save_config(
@@ -191,7 +185,6 @@ def setup(claude_path: str, local: bool, force: bool) -> None:
         project_uuid=project_uuid,
         user_email=user_email,
         client_safe=client_safe,
-        bearer_token=bearer_token,
     )
     click.echo("Config saved to ~/.qluent/config.json")
     _print_saved_config(result)

--- a/src/qluent_cli/main.py
+++ b/src/qluent_cli/main.py
@@ -66,7 +66,10 @@ def _prompt_required(
     default=None,
     help="Redact tree formulas and SQL contract details for client-facing use.",
 )
-@click.option("--bearer-token", help="Bearer token for local backend auth (Firebase JWT).")
+@click.option(
+    "--bearer-token",
+    help="Deprecated legacy option. The metric-tree API uses X-API-Key auth.",
+)
 def config(
     api_key: str | None,
     url: str | None,
@@ -87,6 +90,10 @@ def config(
 
     if url and local:
         raise click.ClickException("Use either --url or --local, not both.")
+    if bearer_token:
+        raise click.ClickException(
+            "Bearer-token auth is not supported by the metric-tree API. Configure an API key instead."
+        )
 
     effective_url = LOCAL_API_URL if local else url
 
@@ -171,11 +178,7 @@ def setup(claude_path: str, local: bool, force: bool) -> None:
     )
     if local:
         api_url = LOCAL_API_URL
-        bearer_token = _prompt_required(
-            "Bearer token (Firebase JWT)",
-            default=str(existing.get("bearer_token") or ""),
-            show_default=False,
-        )
+        bearer_token = ""
     else:
         api_url = str(existing.get("api_url") or DEFAULT_API_URL)
         bearer_token = ""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -30,7 +30,7 @@ def test_client_safe_mode_adds_redaction_header(monkeypatch):
     }
 
 
-def test_bearer_token_uses_authorization_header(monkeypatch):
+def test_api_key_takes_precedence_over_bearer_token(monkeypatch):
     captured: dict[str, object] = {}
 
     class DummyHttpxClient:
@@ -50,9 +50,8 @@ def test_bearer_token_uses_authorization_header(monkeypatch):
         )
     )
 
-    assert "Authorization" in captured["headers"]
-    assert captured["headers"]["Authorization"] == "Bearer jwt_token_here"
-    assert "X-API-Key" not in captured["headers"]
+    assert captured["headers"]["X-API-Key"] == "qk_test"
+    assert "Authorization" not in captured["headers"]
 
 
 def test_api_key_used_when_no_bearer_token(monkeypatch):
@@ -113,4 +112,4 @@ def test_base_url_uses_projects_path(monkeypatch):
         )
     )
 
-    assert client._base == "https://api.example.com/api/projects/project-123"
+    assert client._base == "https://api.example.com/api/v1/project/project-123"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -30,31 +30,7 @@ def test_client_safe_mode_adds_redaction_header(monkeypatch):
     }
 
 
-def test_api_key_takes_precedence_over_bearer_token(monkeypatch):
-    captured: dict[str, object] = {}
-
-    class DummyHttpxClient:
-        def __init__(self, *, headers, timeout):
-            captured["headers"] = headers
-            captured["timeout"] = timeout
-
-    monkeypatch.setattr("qluent_cli.client.httpx.Client", DummyHttpxClient)
-
-    QluentClient(
-        QluentConfig(
-            api_key="qk_test",
-            api_url="http://localhost:8001",
-            project_uuid="project-123",
-            user_email="user@example.com",
-            bearer_token="jwt_token_here",
-        )
-    )
-
-    assert captured["headers"]["X-API-Key"] == "qk_test"
-    assert "Authorization" not in captured["headers"]
-
-
-def test_api_key_used_when_no_bearer_token(monkeypatch):
+def test_api_key_sets_header(monkeypatch):
     captured: dict[str, object] = {}
 
     class DummyHttpxClient:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from qluent_cli import config as config_module
 
 
@@ -93,8 +95,6 @@ def test_load_config_rejects_bearer_token_without_api_key(monkeypatch, tmp_path)
     monkeypatch.delenv("QLUENT_CLIENT_SAFE", raising=False)
     monkeypatch.delenv("QLUENT_BEARER_TOKEN", raising=False)
 
-    import pytest
-
     with pytest.raises(SystemExit, match="Bearer-token auth is not supported"):
         config_module.load_config()
 
@@ -122,6 +122,5 @@ def test_load_config_fails_without_api_key(monkeypatch, tmp_path):
     monkeypatch.delenv("QLUENT_CLIENT_SAFE", raising=False)
     monkeypatch.delenv("QLUENT_BEARER_TOKEN", raising=False)
 
-    import pytest
     with pytest.raises(SystemExit, match="No API key configured"):
         config_module.load_config()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -71,6 +71,34 @@ def test_load_config_uses_client_safe_default_when_not_persisted(monkeypatch, tm
     assert loaded.client_safe is True
 
 
+def test_load_config_rejects_http_non_local_url(monkeypatch, tmp_path):
+    config_dir = tmp_path / ".qluent"
+    config_file = config_dir / "config.json"
+    config_dir.mkdir()
+    config_file.write_text(
+        json.dumps(
+            {
+                "api_key": "qk_test",
+                "api_url": "http://api.example.com",
+                "project_uuid": "project-123",
+                "user_email": "user@example.com",
+            }
+        )
+    )
+
+    monkeypatch.setattr(config_module, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(config_module, "CONFIG_FILE", config_file)
+    monkeypatch.delenv("QLUENT_API_KEY", raising=False)
+    monkeypatch.delenv("QLUENT_API_URL", raising=False)
+    monkeypatch.delenv("QLUENT_PROJECT_UUID", raising=False)
+    monkeypatch.delenv("QLUENT_USER_EMAIL", raising=False)
+    monkeypatch.delenv("QLUENT_CLIENT_SAFE", raising=False)
+    monkeypatch.delenv("QLUENT_BEARER_TOKEN", raising=False)
+
+    with pytest.raises(SystemExit, match="Refusing to connect over plain HTTP"):
+        config_module.load_config()
+
+
 def test_load_config_rejects_bearer_token_without_api_key(monkeypatch, tmp_path):
     config_dir = tmp_path / ".qluent"
     config_file = config_dir / "config.json"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,7 +11,7 @@ def test_default_client_safe_prefers_hosted_urls():
     assert config_module.default_client_safe("http://127.0.0.1:8001") is False
 
 
-def test_load_config_defaults_to_development_api_url(monkeypatch, tmp_path):
+def test_load_config_defaults_to_production_api_url(monkeypatch, tmp_path):
     config_dir = tmp_path / ".qluent"
     config_file = config_dir / "config.json"
     config_dir.mkdir()
@@ -69,7 +69,7 @@ def test_load_config_uses_client_safe_default_when_not_persisted(monkeypatch, tm
     assert loaded.client_safe is True
 
 
-def test_load_config_accepts_bearer_token_without_api_key(monkeypatch, tmp_path):
+def test_load_config_rejects_bearer_token_without_api_key(monkeypatch, tmp_path):
     config_dir = tmp_path / ".qluent"
     config_file = config_dir / "config.json"
     config_dir.mkdir()
@@ -93,13 +93,13 @@ def test_load_config_accepts_bearer_token_without_api_key(monkeypatch, tmp_path)
     monkeypatch.delenv("QLUENT_CLIENT_SAFE", raising=False)
     monkeypatch.delenv("QLUENT_BEARER_TOKEN", raising=False)
 
-    loaded = config_module.load_config()
+    import pytest
 
-    assert loaded.bearer_token == "jwt_token_here"
-    assert loaded.api_key == ""
+    with pytest.raises(SystemExit, match="Bearer-token auth is not supported"):
+        config_module.load_config()
 
 
-def test_load_config_fails_without_api_key_or_bearer_token(monkeypatch, tmp_path):
+def test_load_config_fails_without_api_key(monkeypatch, tmp_path):
     config_dir = tmp_path / ".qluent"
     config_file = config_dir / "config.json"
     config_dir.mkdir()
@@ -123,5 +123,5 @@ def test_load_config_fails_without_api_key_or_bearer_token(monkeypatch, tmp_path
     monkeypatch.delenv("QLUENT_BEARER_TOKEN", raising=False)
 
     import pytest
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit, match="No API key configured"):
         config_module.load_config()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -41,7 +41,7 @@ def test_setup_saves_config_and_writes_claude_md(monkeypatch, tmp_path):
     assert "# Qluent Metric Trees" in claude_md.read_text()
 
 
-def test_setup_uses_development_default_api_url(monkeypatch, tmp_path):
+def test_setup_uses_production_default_api_url(monkeypatch, tmp_path):
     config_dir = tmp_path / ".qluent"
     config_file = config_dir / "config.json"
     monkeypatch.setattr(config_module, "CONFIG_DIR", config_dir)
@@ -78,7 +78,6 @@ def test_setup_local_flag_prefills_local_api_url(monkeypatch, tmp_path):
             "qk_test\n"
             "project-123\n"
             "user@example.com\n"
-            "fake-jwt-token\n"
             "n\n"
         ),
     )
@@ -87,7 +86,7 @@ def test_setup_local_flag_prefills_local_api_url(monkeypatch, tmp_path):
     saved = json.loads(config_file.read_text())
     assert saved["api_url"] == config_module.LOCAL_API_URL
     assert saved["client_safe"] is False
-    assert saved["bearer_token"] == "fake-jwt-token"
+    assert saved["bearer_token"] == ""
 
 
 def test_claude_init_writes_file(monkeypatch, tmp_path):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -34,7 +34,6 @@ def test_setup_saves_config_and_writes_claude_md(monkeypatch, tmp_path):
         "project_uuid": "project-123",
         "user_email": "user@example.com",
         "client_safe": True,
-        "bearer_token": "",
     }
     claude_md = tmp_path / "CLAUDE.md"
     assert claude_md.exists()
@@ -86,7 +85,7 @@ def test_setup_local_flag_prefills_local_api_url(monkeypatch, tmp_path):
     saved = json.loads(config_file.read_text())
     assert saved["api_url"] == config_module.LOCAL_API_URL
     assert saved["client_safe"] is False
-    assert saved["bearer_token"] == ""
+    assert "bearer_token" not in saved
 
 
 def test_claude_init_writes_file(monkeypatch, tmp_path):


### PR DESCRIPTION
The default API URL has been changed from the development environment to the production endpoint (`https://api.app.qluent.com`). This change affects:

- README.md: Updated documentation and smoke test URL
- npm/README.md: Clarified default API environment
- local_smoke_test.sh: Updated default URL in script
- config.py: Changed `DEFAULT_API_URL` to production
- main.py: Removed support for bearer token in favor of API key
- client.py: Simplified auth logic to prioritize API key
- test files: Updated assertions and test logic to reflect API key usage and URL changes