### PR TITLE
feat(cli): add browser-based login command and supporting infrastructure

### DIFF
--- a/src/qluent_cli/auth.py
+++ b/src/qluent_cli/auth.py
@@ -7,11 +7,14 @@ import socket
 import threading
 import webbrowser
 from dataclasses import dataclass
+from html import escape as html_escape
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import click
+
+from qluent_cli.config import is_local_url
 
 LOGIN_TIMEOUT_SECONDS = 300  # 5 minutes
 LOGIN_PATH = "/cli-auth"
@@ -44,6 +47,11 @@ _ERROR_HTML_TEMPLATE = (
 )
 
 
+def _error_html(message: str) -> str:
+    """Render error page with HTML-escaped message to prevent XSS."""
+    return _ERROR_HTML_TEMPLATE % html_escape(message)
+
+
 @dataclass
 class CallbackResult:
     """Result from the browser callback."""
@@ -56,14 +64,12 @@ class CallbackResult:
 
 
 def _single(values: list[str] | None) -> str:
-    """Extract a single value from a query-parameter list, or empty string."""
     if not values:
         return ""
     return values[0]
 
 
 def _find_free_port() -> int:
-    """Find a free port on 127.0.0.1 by binding to port 0."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
@@ -82,12 +88,11 @@ class _CallbackHandler(BaseHTTPRequestHandler):
 
         params = parse_qs(parsed.query)
 
-        # Validate CSRF state token
         state = _single(params.get("state"))
         if state != self.server.expected_state:
             self._respond_html(
                 400,
-                _ERROR_HTML_TEMPLATE % "Invalid state parameter. Please try again.",
+                _error_html("Invalid state parameter. Please try again."),
             )
             self.server.result = CallbackResult(
                 success=False, error="State mismatch (possible CSRF)"
@@ -95,16 +100,14 @@ class _CallbackHandler(BaseHTTPRequestHandler):
             self.server.got_callback.set()
             return
 
-        # Check for error response from the auth server
         error = _single(params.get("error"))
         if error:
             error_desc = _single(params.get("error_description")) or error
-            self._respond_html(400, _ERROR_HTML_TEMPLATE % error_desc)
+            self._respond_html(400, _error_html(error_desc))
             self.server.result = CallbackResult(success=False, error=error_desc)
             self.server.got_callback.set()
             return
 
-        # Extract credentials
         api_key = _single(params.get("api_key"))
         project_uuid = _single(params.get("project_uuid"))
         user_email = _single(params.get("user_email"))
@@ -120,7 +123,7 @@ class _CallbackHandler(BaseHTTPRequestHandler):
                 if not val
             ]
             msg = f"Missing parameters: {', '.join(missing)}"
-            self._respond_html(400, _ERROR_HTML_TEMPLATE % msg)
+            self._respond_html(400, _error_html(msg))
             self.server.result = CallbackResult(success=False, error=msg)
             self.server.got_callback.set()
             return
@@ -164,13 +167,10 @@ def _api_url_to_ui_url(api_url: str) -> str:
     """Derive the UI base URL from the API base URL.
 
     Production: https://api.app.qluent.com -> https://app.qluent.com
-    Local:      http://localhost:8001      -> http://localhost:3000
+    Local:      http://localhost:8001      -> http://localhost:5173
     """
-    normalized = api_url.rstrip("/").lower()
-    if normalized.startswith("http://localhost") or normalized.startswith(
-        "http://127.0.0.1"
-    ):
-        return "http://localhost:3000"
+    if is_local_url(api_url):
+        return "http://localhost:5173"
     return api_url.replace("api.app.", "app.").rstrip("/")
 
 
@@ -192,15 +192,8 @@ def browser_login(api_url: str) -> CallbackResult:
 
     try:
         click.echo("Opening browser to log in...")
-        opened = webbrowser.open(login_url)
-        if not opened:
-            click.echo(
-                "\nCould not open browser automatically. "
-                "Open this URL in your browser:\n"
-            )
-        else:
-            click.echo("If the browser did not open, copy this URL:\n")
-        click.echo(f"  {login_url}\n")
+        webbrowser.open(login_url)
+        click.echo(f"If the browser did not open, visit:\n\n  {login_url}\n")
         click.echo("Waiting for login...")
 
         got_it = server.got_callback.wait(timeout=LOGIN_TIMEOUT_SECONDS)

--- a/src/qluent_cli/auth.py
+++ b/src/qluent_cli/auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import secrets
 import socket
 import threading
@@ -10,7 +11,7 @@ from dataclasses import dataclass
 from html import escape as html_escape
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import urlencode, urlparse
 
 import click
 
@@ -18,6 +19,7 @@ from qluent_cli.config import is_local_url
 
 LOGIN_TIMEOUT_SECONDS = 300  # 5 minutes
 LOGIN_PATH = "/cli-auth"
+_MAX_POST_BYTES = 16_384  # 16 KB — actual payload is ~200 bytes
 
 _PAGE_STYLE = (
     "@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap');"
@@ -73,6 +75,39 @@ _ERROR_HTML_PREFIX = (
 
 _ERROR_HTML_SUFFIX = "</p></div></body></html>"
 
+# Relay page: extracts credentials from the query string, scrubs the URL
+# from browser history, and POSTs them to /complete so the API key never
+# persists in the address bar or history entries.
+_RELAY_PAGE_STYLE = (
+    "*{margin:0;padding:0;box-sizing:border-box}"
+    "body{font-family:system-ui,-apple-system,sans-serif;"
+    "display:flex;justify-content:center;align-items:center;"
+    "min-height:100vh;color:#666;font-size:0.875rem}"
+)
+
+_RELAY_HTML = (
+    "<!DOCTYPE html><html><head><meta charset='utf-8'>"
+    "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+    "<meta name='referrer' content='no-referrer'>"
+    "<title>Qluent CLI</title>"
+    f"<style>{_RELAY_PAGE_STYLE}</style>"
+    "</head><body>"
+    "<p>Completing login\u2026</p>"
+    "<script>"
+    "(function(){"
+    "var p={};"
+    "new URLSearchParams(location.search).forEach(function(v,k){p[k]=v});"
+    "history.replaceState(null,'','/');"
+    "fetch('/complete',{method:'POST',"
+    "headers:{'Content-Type':'application/json'},"
+    "body:JSON.stringify(p)})"
+    ".then(function(r){return r.text()})"
+    ".then(function(h){document.open();document.write(h);document.close()})"
+    ".catch(function(){document.body.textContent='Something went wrong. Check the terminal.'});"
+    "})();"
+    "</script></body></html>"
+)
+
 
 def _error_html(message: str) -> str:
     """Render error page with HTML-escaped message to prevent XSS."""
@@ -88,12 +123,6 @@ class CallbackResult:
     project_uuid: str = ""
     user_email: str = ""
     error: str = ""
-
-
-def _single(values: list[str] | None) -> str:
-    if not values:
-        return ""
-    return values[0]
 
 
 def _find_free_port() -> int:
@@ -112,10 +141,27 @@ class _CallbackHandler(BaseHTTPRequestHandler):
         if parsed.path != "/callback":
             self._respond(404, "Not found")
             return
+        # Serve the relay page — it will scrub the URL and POST credentials
+        # to /complete so the API key never stays in browser history.
+        self._respond_html(200, _RELAY_HTML)
 
-        params = parse_qs(parsed.query)
+    def do_POST(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        if parsed.path != "/complete":
+            self._respond(404, "Not found")
+            return
 
-        state = _single(params.get("state"))
+        content_length = int(self.headers.get("Content-Length", 0))
+        if content_length > _MAX_POST_BYTES:
+            self._respond(413, "Payload too large")
+            return
+        try:
+            params = json.loads(self.rfile.read(content_length))
+        except (json.JSONDecodeError, ValueError):
+            self._respond_html(400, _error_html("Invalid request."))
+            return
+
+        state = params.get("state", "")
         if state != self.server.expected_state:
             self._respond_html(
                 400,
@@ -127,17 +173,17 @@ class _CallbackHandler(BaseHTTPRequestHandler):
             self.server.got_callback.set()
             return
 
-        error = _single(params.get("error"))
+        error = params.get("error", "")
         if error:
-            error_desc = _single(params.get("error_description")) or error
+            error_desc = params.get("error_description") or error
             self._respond_html(400, _error_html(error_desc))
             self.server.result = CallbackResult(success=False, error=error_desc)
             self.server.got_callback.set()
             return
 
-        api_key = _single(params.get("api_key"))
-        project_uuid = _single(params.get("project_uuid"))
-        user_email = _single(params.get("user_email"))
+        api_key = params.get("api_key", "")
+        project_uuid = params.get("project_uuid", "")
+        user_email = params.get("user_email", "")
 
         if not all([api_key, project_uuid, user_email]):
             missing = [

--- a/src/qluent_cli/auth.py
+++ b/src/qluent_cli/auth.py
@@ -1,0 +1,217 @@
+"""Browser-based SSO login flow for the Qluent CLI."""
+
+from __future__ import annotations
+
+import secrets
+import socket
+import threading
+import webbrowser
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import click
+
+LOGIN_TIMEOUT_SECONDS = 300  # 5 minutes
+LOGIN_PATH = "/cli-auth"
+
+_SUCCESS_HTML = """\
+<!DOCTYPE html>
+<html><head><title>Qluent CLI</title>
+<style>body{font-family:system-ui,sans-serif;display:flex;justify-content:center;\
+align-items:center;min-height:100vh;margin:0;background:#f8f9fa}\
+.card{text-align:center;padding:2rem;border-radius:8px;background:#fff;\
+box-shadow:0 2px 8px rgba(0,0,0,0.1);max-width:400px}\
+h1{color:#16a34a;margin-bottom:0.5rem}p{color:#374151}</style>
+</head><body><div class="card">
+<h1>Logged in</h1>
+<p>You can close this tab and return to the terminal.</p>
+</div></body></html>
+"""
+
+_ERROR_HTML_TEMPLATE = (
+    '<!DOCTYPE html><html><head><title>Qluent CLI</title>'
+    "<style>body{font-family:system-ui,sans-serif;display:flex;justify-content:center;"
+    "align-items:center;min-height:100vh;margin:0;background:#f8f9fa}"
+    ".card{text-align:center;padding:2rem;border-radius:8px;background:#fff;"
+    "box-shadow:0 2px 8px rgba(0,0,0,0.1);max-width:400px}"
+    "h1{color:#dc2626;margin-bottom:0.5rem}p{color:#374151}</style>"
+    '</head><body><div class="card">'
+    "<h1>Login failed</h1>"
+    "<p>%s</p>"
+    "</div></body></html>"
+)
+
+
+@dataclass
+class CallbackResult:
+    """Result from the browser callback."""
+
+    success: bool
+    api_key: str = ""
+    project_uuid: str = ""
+    user_email: str = ""
+    error: str = ""
+
+
+def _single(values: list[str] | None) -> str:
+    """Extract a single value from a query-parameter list, or empty string."""
+    if not values:
+        return ""
+    return values[0]
+
+
+def _find_free_port() -> int:
+    """Find a free port on 127.0.0.1 by binding to port 0."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _CallbackHandler(BaseHTTPRequestHandler):
+    """Handle the OAuth-style callback from qluent-ui."""
+
+    server: _CallbackServer  # type: ignore[assignment]
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        if parsed.path != "/callback":
+            self._respond(404, "Not found")
+            return
+
+        params = parse_qs(parsed.query)
+
+        # Validate CSRF state token
+        state = _single(params.get("state"))
+        if state != self.server.expected_state:
+            self._respond_html(
+                400,
+                _ERROR_HTML_TEMPLATE % "Invalid state parameter. Please try again.",
+            )
+            self.server.result = CallbackResult(
+                success=False, error="State mismatch (possible CSRF)"
+            )
+            self.server.got_callback.set()
+            return
+
+        # Check for error response from the auth server
+        error = _single(params.get("error"))
+        if error:
+            error_desc = _single(params.get("error_description")) or error
+            self._respond_html(400, _ERROR_HTML_TEMPLATE % error_desc)
+            self.server.result = CallbackResult(success=False, error=error_desc)
+            self.server.got_callback.set()
+            return
+
+        # Extract credentials
+        api_key = _single(params.get("api_key"))
+        project_uuid = _single(params.get("project_uuid"))
+        user_email = _single(params.get("user_email"))
+
+        if not all([api_key, project_uuid, user_email]):
+            missing = [
+                name
+                for name, val in [
+                    ("api_key", api_key),
+                    ("project_uuid", project_uuid),
+                    ("user_email", user_email),
+                ]
+                if not val
+            ]
+            msg = f"Missing parameters: {', '.join(missing)}"
+            self._respond_html(400, _ERROR_HTML_TEMPLATE % msg)
+            self.server.result = CallbackResult(success=False, error=msg)
+            self.server.got_callback.set()
+            return
+
+        self._respond_html(200, _SUCCESS_HTML)
+        self.server.result = CallbackResult(
+            success=True,
+            api_key=api_key,
+            project_uuid=project_uuid,
+            user_email=user_email,
+        )
+        self.server.got_callback.set()
+
+    def _respond(self, status: int, body: str) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", "text/plain")
+        self.end_headers()
+        self.wfile.write(body.encode())
+
+    def _respond_html(self, status: int, html: str) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(html.encode())
+
+    def log_message(self, format: str, *args: Any) -> None:
+        """Suppress default stderr logging."""
+
+
+class _CallbackServer(HTTPServer):
+    """Local HTTP server that waits for the auth callback."""
+
+    def __init__(self, port: int, expected_state: str) -> None:
+        super().__init__(("127.0.0.1", port), _CallbackHandler)
+        self.expected_state = expected_state
+        self.result: CallbackResult | None = None
+        self.got_callback = threading.Event()
+
+
+def _api_url_to_ui_url(api_url: str) -> str:
+    """Derive the UI base URL from the API base URL.
+
+    Production: https://api.app.qluent.com -> https://app.qluent.com
+    Local:      http://localhost:8001      -> http://localhost:3000
+    """
+    normalized = api_url.rstrip("/").lower()
+    if normalized.startswith("http://localhost") or normalized.startswith(
+        "http://127.0.0.1"
+    ):
+        return "http://localhost:3000"
+    return api_url.replace("api.app.", "app.").rstrip("/")
+
+
+def browser_login(api_url: str) -> CallbackResult:
+    """Run the browser-based login flow. Returns credentials or error."""
+    state = secrets.token_urlsafe(32)
+    port = _find_free_port()
+    callback_url = f"http://127.0.0.1:{port}/callback"
+
+    ui_base = _api_url_to_ui_url(api_url)
+    login_url = (
+        f"{ui_base}{LOGIN_PATH}?"
+        + urlencode({"callback_url": callback_url, "state": state})
+    )
+
+    server = _CallbackServer(port, expected_state=state)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+
+    try:
+        click.echo("Opening browser to log in...")
+        opened = webbrowser.open(login_url)
+        if not opened:
+            click.echo(
+                "\nCould not open browser automatically. "
+                "Open this URL in your browser:\n"
+            )
+        else:
+            click.echo("If the browser did not open, copy this URL:\n")
+        click.echo(f"  {login_url}\n")
+        click.echo("Waiting for login...")
+
+        got_it = server.got_callback.wait(timeout=LOGIN_TIMEOUT_SECONDS)
+        if not got_it:
+            return CallbackResult(
+                success=False,
+                error=f"Login timed out after {LOGIN_TIMEOUT_SECONDS} seconds.",
+            )
+
+        return server.result or CallbackResult(
+            success=False, error="No result received."
+        )
+    finally:
+        server.shutdown()

--- a/src/qluent_cli/auth.py
+++ b/src/qluent_cli/auth.py
@@ -19,37 +19,64 @@ from qluent_cli.config import is_local_url
 LOGIN_TIMEOUT_SECONDS = 300  # 5 minutes
 LOGIN_PATH = "/cli-auth"
 
-_SUCCESS_HTML = """\
-<!DOCTYPE html>
-<html><head><title>Qluent CLI</title>
-<style>body{font-family:system-ui,sans-serif;display:flex;justify-content:center;\
-align-items:center;min-height:100vh;margin:0;background:#f8f9fa}\
-.card{text-align:center;padding:2rem;border-radius:8px;background:#fff;\
-box-shadow:0 2px 8px rgba(0,0,0,0.1);max-width:400px}\
-h1{color:#16a34a;margin-bottom:0.5rem}p{color:#374151}</style>
-</head><body><div class="card">
-<h1>Logged in</h1>
-<p>You can close this tab and return to the terminal.</p>
-</div></body></html>
-"""
+_PAGE_STYLE = (
+    "@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap');"
+    "*{margin:0;padding:0;box-sizing:border-box}"
+    "body{font-family:'Inter',system-ui,-apple-system,sans-serif;"
+    "display:flex;justify-content:center;align-items:center;"
+    "min-height:100vh;background:#fefffe;color:#1a1a1a;"
+    "letter-spacing:-0.011em;-webkit-font-smoothing:antialiased}"
+    ".card{text-align:center;padding:3rem 2.5rem;border-radius:0.5rem;"
+    "border:1px solid rgba(0,0,0,0.08);max-width:400px;width:100%}"
+    ".icon{width:48px;height:48px;border-radius:50%;display:inline-flex;"
+    "align-items:center;justify-content:center;margin-bottom:1.25rem}"
+    ".icon-ok{background:rgba(98,0,238,0.08)}"
+    ".icon-err{background:rgba(220,38,38,0.08)}"
+    ".icon svg{width:24px;height:24px}"
+    "h1{font-size:1.25rem;font-weight:500;margin-bottom:0.5rem}"
+    "p{font-size:0.875rem;color:#666;line-height:1.5}"
+)
 
-_ERROR_HTML_TEMPLATE = (
-    '<!DOCTYPE html><html><head><title>Qluent CLI</title>'
-    "<style>body{font-family:system-ui,sans-serif;display:flex;justify-content:center;"
-    "align-items:center;min-height:100vh;margin:0;background:#f8f9fa}"
-    ".card{text-align:center;padding:2rem;border-radius:8px;background:#fff;"
-    "box-shadow:0 2px 8px rgba(0,0,0,0.1);max-width:400px}"
-    "h1{color:#dc2626;margin-bottom:0.5rem}p{color:#374151}</style>"
+_CHECK_SVG = (
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" '
+    'stroke="rgb(98,0,238)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">'
+    '<polyline points="20 6 9 17 4 12"/></svg>'
+)
+
+_X_SVG = (
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" '
+    'stroke="#dc2626" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">'
+    '<line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>'
+)
+
+_SUCCESS_HTML = (
+    "<!DOCTYPE html><html><head><meta charset='utf-8'>"
+    "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+    "<title>Qluent CLI</title>"
+    f"<style>{_PAGE_STYLE}</style>"
     '</head><body><div class="card">'
-    "<h1>Login failed</h1>"
-    "<p>%s</p>"
+    f'<div class="icon icon-ok">{_CHECK_SVG}</div>'
+    "<h1>Logged in</h1>"
+    "<p>You can close this tab and return to the terminal.</p>"
     "</div></body></html>"
 )
+
+_ERROR_HTML_PREFIX = (
+    "<!DOCTYPE html><html><head><meta charset='utf-8'>"
+    "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+    "<title>Qluent CLI</title>"
+    f"<style>{_PAGE_STYLE}</style>"
+    '</head><body><div class="card">'
+    f'<div class="icon icon-err">{_X_SVG}</div>'
+    "<h1>Login failed</h1><p>"
+)
+
+_ERROR_HTML_SUFFIX = "</p></div></body></html>"
 
 
 def _error_html(message: str) -> str:
     """Render error page with HTML-escaped message to prevent XSS."""
-    return _ERROR_HTML_TEMPLATE % html_escape(message)
+    return _ERROR_HTML_PREFIX + html_escape(message) + _ERROR_HTML_SUFFIX
 
 
 @dataclass

--- a/src/qluent_cli/config.py
+++ b/src/qluent_cli/config.py
@@ -31,12 +31,16 @@ def _parse_bool(value: Any) -> bool:
     return str(value).strip().lower() in {"1", "true", "yes", "on"}
 
 
-def default_client_safe(api_url: str) -> bool:
+def is_local_url(api_url: str) -> bool:
+    """Check whether a URL points to localhost or 127.0.0.1."""
     normalized = api_url.rstrip("/").lower()
-    return not (
-        normalized.startswith("http://localhost")
-        or normalized.startswith("http://127.0.0.1")
+    return normalized.startswith("http://localhost") or normalized.startswith(
+        "http://127.0.0.1"
     )
+
+
+def default_client_safe(api_url: str) -> bool:
+    return not is_local_url(api_url)
 
 
 def load_config() -> QluentConfig:
@@ -51,10 +55,7 @@ def load_config() -> QluentConfig:
 
     api_key = get("QLUENT_API_KEY", "api_key")
     api_url = get("QLUENT_API_URL", "api_url") or DEFAULT_API_URL
-    if api_url.lower().startswith("http://") and not (
-        api_url.lower().startswith("http://localhost")
-        or api_url.lower().startswith("http://127.0.0.1")
-    ):
+    if api_url.lower().startswith("http://") and not is_local_url(api_url):
         raise SystemExit(
             f"Refusing to connect over plain HTTP to {api_url} — "
             "API keys would be sent in cleartext. Use https:// or --local for localhost."
@@ -75,11 +76,11 @@ def load_config() -> QluentConfig:
                 "Bearer-token auth is not supported by the public metric-tree API. "
                 "Configure an API key instead: qluent config --api-key qk_..."
             )
-        raise SystemExit("No API key configured. Run: qluent config --api-key qk_...")
+        raise SystemExit("No API key configured. Run: qluent login  or  qluent config --api-key qk_...")
     if not project_uuid:
-        raise SystemExit("No project configured. Run: qluent config --project UUID")
+        raise SystemExit("No project configured. Run: qluent login  or  qluent config --project UUID")
     if not user_email:
-        raise SystemExit("No email configured. Run: qluent config --email you@co.com")
+        raise SystemExit("No email configured. Run: qluent login  or  qluent config --email you@co.com")
 
     return QluentConfig(
         api_key=api_key,
@@ -98,10 +99,7 @@ def save_config(
     client_safe: bool | None = None,
 ) -> dict[str, Any]:
     """Save config values to ~/.qluent/config.json (merges with existing)."""
-    existing: dict[str, Any] = {}
-    if CONFIG_FILE.exists():
-        with open(CONFIG_FILE) as f:
-            existing = json.load(f)
+    existing = load_raw_config()
 
     if api_key is not None:
         existing["api_key"] = api_key
@@ -124,6 +122,17 @@ def save_config(
     return existing
 
 
+def load_raw_config() -> dict[str, Any]:
+    """Load raw config dict from ~/.qluent/config.json, or empty dict if missing."""
+    if CONFIG_FILE.exists():
+        with open(CONFIG_FILE) as f:
+            return json.load(f)
+    return {}
+
+
 def mask_key(value: str) -> str:
     """Mask an API key for display: show first 10 chars + '...'."""
     return value[:10] + "..." if len(value) > 10 else value
+
+
+CONFIG_SAVED_MSG = f"Config saved to {CONFIG_FILE}"

--- a/src/qluent_cli/main.py
+++ b/src/qluent_cli/main.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import click
@@ -14,14 +13,6 @@ from qluent_cli.trees import trees
 @click.group()
 def cli() -> None:
     """Qluent — metric tree analysis from the command line."""
-
-
-def _load_saved_config() -> dict[str, object]:
-    from qluent_cli.config import CONFIG_FILE
-
-    if not CONFIG_FILE.exists():
-        return {}
-    return json.loads(CONFIG_FILE.read_text())
 
 
 def _print_saved_config(data: dict[str, object]) -> None:
@@ -83,9 +74,11 @@ def config(
     """Configure Qluent API credentials."""
     from qluent_cli.config import (
         CONFIG_FILE,
+        CONFIG_SAVED_MSG,
         DEFAULT_API_URL,
         LOCAL_API_URL,
         default_client_safe,
+        load_raw_config,
         save_config,
     )
 
@@ -100,7 +93,7 @@ def config(
 
     if not any([api_key, effective_url, project, email, client_safe is not None]):
         if CONFIG_FILE.exists():
-            data = _load_saved_config()
+            data = load_raw_config()
             if "client_safe" not in data:
                 data["client_safe"] = default_client_safe(
                     str(data.get("api_url") or DEFAULT_API_URL)
@@ -121,7 +114,7 @@ def config(
         result["client_safe"] = default_client_safe(
             str(result.get("api_url") or DEFAULT_API_URL)
         )
-    click.echo("Config saved to ~/.qluent/config.json")
+    click.echo(CONFIG_SAVED_MSG)
     _print_saved_config(result)
 
 
@@ -139,6 +132,47 @@ def _write_claude_file(path: Path, *, force: bool) -> str:
 
 @cli.command()
 @click.option(
+    "--local",
+    is_flag=True,
+    help="Use the local API at http://localhost:8001 and local UI at http://localhost:5173.",
+)
+def login(local: bool) -> None:
+    """Log in via browser (opens qluent-ui for SSO authentication)."""
+    from qluent_cli.auth import browser_login
+    from qluent_cli.config import (
+        CONFIG_SAVED_MSG,
+        DEFAULT_API_URL,
+        LOCAL_API_URL,
+        default_client_safe,
+        mask_key,
+        save_config,
+    )
+
+    api_url = LOCAL_API_URL if local else DEFAULT_API_URL
+
+    result = browser_login(api_url)
+
+    if not result.success:
+        raise click.ClickException(f"Login failed: {result.error}")
+
+    client_safe = default_client_safe(api_url)
+    save_config(
+        api_key=result.api_key,
+        api_url=api_url,
+        project_uuid=result.project_uuid,
+        user_email=result.user_email,
+        client_safe=client_safe,
+    )
+
+    click.echo("Logged in successfully!")
+    click.echo(f"  Project: {result.project_uuid}")
+    click.echo(f"  Email:   {result.user_email}")
+    click.echo(f"  API key: {mask_key(result.api_key)}")
+    click.echo(CONFIG_SAVED_MSG)
+
+
+@cli.command()
+@click.option(
     "--claude-path",
     default="CLAUDE.md",
     show_default=True,
@@ -152,14 +186,18 @@ def _write_claude_file(path: Path, *, force: bool) -> str:
 @click.option("--force", is_flag=True, help="Overwrite an existing CLAUDE.md without prompting.")
 def setup(claude_path: str, local: bool, force: bool) -> None:
     """Interactive first-run setup for client installations."""
+    click.echo("Tip: Use 'qluent login' for browser-based login (recommended).\n")
+
     from qluent_cli.config import (
+        CONFIG_SAVED_MSG,
         DEFAULT_API_URL,
         LOCAL_API_URL,
         default_client_safe,
+        load_raw_config,
         save_config,
     )
 
-    existing = _load_saved_config()
+    existing = load_raw_config()
 
     api_key = _prompt_required(
         "API key",
@@ -186,7 +224,7 @@ def setup(claude_path: str, local: bool, force: bool) -> None:
         user_email=user_email,
         client_safe=client_safe,
     )
-    click.echo("Config saved to ~/.qluent/config.json")
+    click.echo(CONFIG_SAVED_MSG)
     _print_saved_config(result)
 
     target = Path(claude_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,30 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
+from qluent_cli import config as config_module
+
 
 SRC_DIR = Path(__file__).resolve().parents[1] / "src"
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
+
+
+@pytest.fixture()
+def isolated_config(monkeypatch, tmp_path):
+    """Redirect config to a temp directory and clear env vars."""
+    config_dir = tmp_path / ".qluent"
+    config_file = config_dir / "config.json"
+    monkeypatch.setattr(config_module, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(config_module, "CONFIG_FILE", config_file)
+    for var in (
+        "QLUENT_API_KEY",
+        "QLUENT_API_URL",
+        "QLUENT_PROJECT_UUID",
+        "QLUENT_USER_EMAIL",
+        "QLUENT_CLIENT_SAFE",
+        "QLUENT_BEARER_TOKEN",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    return config_dir, config_file

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -29,13 +29,30 @@ def _start_server(state: str) -> tuple[_CallbackServer, int]:
     return server, port
 
 
-def test_callback_success():
-    state = "test_state_123"
-    server, port = _start_server(state)
+def test_callback_get_serves_relay_page():
+    """GET /callback returns the relay page (no credentials processed yet)."""
+    server, port = _start_server("state")
     try:
         resp = httpx.get(
             f"http://127.0.0.1:{port}/callback",
-            params={
+            params={"api_key": "qk_test", "state": "state"},
+        )
+        assert resp.status_code == 200
+        assert "/complete" in resp.text
+        assert "history.replaceState" in resp.text
+        # Credentials are NOT processed on the GET — only the relay page is served
+        assert not server.got_callback.is_set()
+    finally:
+        server.shutdown()
+
+
+def test_complete_success():
+    state = "test_state_123"
+    server, port = _start_server(state)
+    try:
+        resp = httpx.post(
+            f"http://127.0.0.1:{port}/complete",
+            json={
                 "api_key": "qk_test_key",
                 "project_uuid": "proj-abc",
                 "user_email": "a@b.com",
@@ -55,12 +72,12 @@ def test_callback_success():
         server.shutdown()
 
 
-def test_callback_state_mismatch():
+def test_complete_state_mismatch():
     server, port = _start_server("correct_state")
     try:
-        resp = httpx.get(
-            f"http://127.0.0.1:{port}/callback",
-            params={
+        resp = httpx.post(
+            f"http://127.0.0.1:{port}/complete",
+            json={
                 "api_key": "qk_test",
                 "project_uuid": "proj-abc",
                 "user_email": "a@b.com",
@@ -75,13 +92,13 @@ def test_callback_state_mismatch():
         server.shutdown()
 
 
-def test_callback_missing_params():
+def test_complete_missing_params():
     state = "ok_state"
     server, port = _start_server(state)
     try:
-        resp = httpx.get(
-            f"http://127.0.0.1:{port}/callback",
-            params={"state": state, "api_key": "qk_test"},
+        resp = httpx.post(
+            f"http://127.0.0.1:{port}/complete",
+            json={"state": state, "api_key": "qk_test"},
         )
         assert resp.status_code == 400
         assert server.result is not None
@@ -92,13 +109,13 @@ def test_callback_missing_params():
         server.shutdown()
 
 
-def test_callback_error_from_auth_server():
+def test_complete_error_from_auth_server():
     state = "ok_state"
     server, port = _start_server(state)
     try:
-        resp = httpx.get(
-            f"http://127.0.0.1:{port}/callback",
-            params={
+        resp = httpx.post(
+            f"http://127.0.0.1:{port}/complete",
+            json={
                 "state": state,
                 "error": "access_denied",
                 "error_description": "User cancelled",
@@ -149,10 +166,9 @@ def test_browser_login_timeout(monkeypatch):
 
 
 def test_browser_login_success_flow(monkeypatch):
-    """Simulate a full login flow by having webbrowser.open trigger the callback."""
+    """Simulate a full login flow: browser GETs relay page, then POSTs to /complete."""
 
     def fake_open(url: str) -> bool:
-        # Parse the callback_url and state from the login URL
         from urllib.parse import parse_qs, urlparse
 
         parsed = urlparse(url)
@@ -160,10 +176,17 @@ def test_browser_login_success_flow(monkeypatch):
         callback_url = params["callback_url"][0]
         state = params["state"][0]
 
+        # Derive the server base from the callback URL
+        cb_parsed = urlparse(callback_url)
+        base = f"{cb_parsed.scheme}://{cb_parsed.netloc}"
+
         def do_callback():
-            httpx.get(
-                callback_url,
-                params={
+            # Step 1: browser hits the redirect URL (GET /callback) — relay page
+            httpx.get(callback_url, params={"state": state})
+            # Step 2: relay JS POSTs credentials to /complete
+            httpx.post(
+                f"{base}/complete",
+                json={
                     "api_key": "qk_browser_test",
                     "project_uuid": "proj-browser",
                     "user_email": "browser@test.com",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import threading
+
+import httpx
+import pytest
+
+from qluent_cli.auth import (
+    CallbackResult,
+    _CallbackServer,
+    _api_url_to_ui_url,
+    _find_free_port,
+    browser_login,
+)
+from qluent_cli import auth as auth_module
+
+
+def test_find_free_port_returns_valid_port():
+    port = _find_free_port()
+    assert isinstance(port, int)
+    assert 1024 <= port <= 65535
+
+
+def _start_server(state: str) -> tuple[_CallbackServer, int]:
+    port = _find_free_port()
+    server = _CallbackServer(port, expected_state=state)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, port
+
+
+def test_callback_success():
+    state = "test_state_123"
+    server, port = _start_server(state)
+    try:
+        resp = httpx.get(
+            f"http://127.0.0.1:{port}/callback",
+            params={
+                "api_key": "qk_test_key",
+                "project_uuid": "proj-abc",
+                "user_email": "a@b.com",
+                "state": state,
+            },
+        )
+        assert resp.status_code == 200
+        assert "Logged in" in resp.text
+
+        assert server.got_callback.is_set()
+        assert server.result is not None
+        assert server.result.success is True
+        assert server.result.api_key == "qk_test_key"
+        assert server.result.project_uuid == "proj-abc"
+        assert server.result.user_email == "a@b.com"
+    finally:
+        server.shutdown()
+
+
+def test_callback_state_mismatch():
+    server, port = _start_server("correct_state")
+    try:
+        resp = httpx.get(
+            f"http://127.0.0.1:{port}/callback",
+            params={
+                "api_key": "qk_test",
+                "project_uuid": "proj-abc",
+                "user_email": "a@b.com",
+                "state": "wrong_state",
+            },
+        )
+        assert resp.status_code == 400
+        assert server.result is not None
+        assert server.result.success is False
+        assert "State mismatch" in server.result.error
+    finally:
+        server.shutdown()
+
+
+def test_callback_missing_params():
+    state = "ok_state"
+    server, port = _start_server(state)
+    try:
+        resp = httpx.get(
+            f"http://127.0.0.1:{port}/callback",
+            params={"state": state, "api_key": "qk_test"},
+        )
+        assert resp.status_code == 400
+        assert server.result is not None
+        assert server.result.success is False
+        assert "project_uuid" in server.result.error
+        assert "user_email" in server.result.error
+    finally:
+        server.shutdown()
+
+
+def test_callback_error_from_auth_server():
+    state = "ok_state"
+    server, port = _start_server(state)
+    try:
+        resp = httpx.get(
+            f"http://127.0.0.1:{port}/callback",
+            params={
+                "state": state,
+                "error": "access_denied",
+                "error_description": "User cancelled",
+            },
+        )
+        assert resp.status_code == 400
+        assert server.result is not None
+        assert server.result.success is False
+        assert server.result.error == "User cancelled"
+    finally:
+        server.shutdown()
+
+
+def test_callback_wrong_path():
+    server, port = _start_server("state")
+    try:
+        resp = httpx.get(f"http://127.0.0.1:{port}/wrong")
+        assert resp.status_code == 404
+        assert not server.got_callback.is_set()
+    finally:
+        server.shutdown()
+
+
+def test_api_url_to_ui_url_production():
+    assert _api_url_to_ui_url("https://api.app.qluent.com") == "https://app.qluent.com"
+
+
+def test_api_url_to_ui_url_production_trailing_slash():
+    assert _api_url_to_ui_url("https://api.app.qluent.com/") == "https://app.qluent.com"
+
+
+def test_api_url_to_ui_url_localhost():
+    assert _api_url_to_ui_url("http://localhost:8001") == "http://localhost:3000"
+
+
+def test_api_url_to_ui_url_127():
+    assert _api_url_to_ui_url("http://127.0.0.1:8001") == "http://localhost:3000"
+
+
+def test_browser_login_timeout(monkeypatch):
+    monkeypatch.setattr(auth_module, "LOGIN_TIMEOUT_SECONDS", 1)
+    monkeypatch.setattr("webbrowser.open", lambda url: True)
+
+    result = browser_login("http://localhost:8001")
+
+    assert result.success is False
+    assert "timed out" in result.error.lower()
+
+
+def test_browser_login_success_flow(monkeypatch):
+    """Simulate a full login flow by having webbrowser.open trigger the callback."""
+
+    def fake_open(url: str) -> bool:
+        # Parse the callback_url and state from the login URL
+        from urllib.parse import parse_qs, urlparse
+
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+        callback_url = params["callback_url"][0]
+        state = params["state"][0]
+
+        def do_callback():
+            httpx.get(
+                callback_url,
+                params={
+                    "api_key": "qk_browser_test",
+                    "project_uuid": "proj-browser",
+                    "user_email": "browser@test.com",
+                    "state": state,
+                },
+            )
+
+        threading.Thread(target=do_callback, daemon=True).start()
+        return True
+
+    monkeypatch.setattr("webbrowser.open", fake_open)
+
+    result = browser_login("http://localhost:8001")
+
+    assert result.success is True
+    assert result.api_key == "qk_browser_test"
+    assert result.project_uuid == "proj-browser"
+    assert result.user_email == "browser@test.com"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -131,11 +131,11 @@ def test_api_url_to_ui_url_production_trailing_slash():
 
 
 def test_api_url_to_ui_url_localhost():
-    assert _api_url_to_ui_url("http://localhost:8001") == "http://localhost:3000"
+    assert _api_url_to_ui_url("http://localhost:8001") == "http://localhost:5173"
 
 
 def test_api_url_to_ui_url_127():
-    assert _api_url_to_ui_url("http://127.0.0.1:8001") == "http://localhost:3000"
+    assert _api_url_to_ui_url("http://127.0.0.1:8001") == "http://localhost:5173"
 
 
 def test_browser_login_timeout(monkeypatch):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,9 +13,8 @@ def test_default_client_safe_prefers_hosted_urls():
     assert config_module.default_client_safe("http://127.0.0.1:8001") is False
 
 
-def test_load_config_defaults_to_production_api_url(monkeypatch, tmp_path):
-    config_dir = tmp_path / ".qluent"
-    config_file = config_dir / "config.json"
+def test_load_config_defaults_to_production_api_url(isolated_config):
+    config_dir, config_file = isolated_config
     config_dir.mkdir()
     config_file.write_text(
         json.dumps(
@@ -27,24 +26,14 @@ def test_load_config_defaults_to_production_api_url(monkeypatch, tmp_path):
         )
     )
 
-    monkeypatch.setattr(config_module, "CONFIG_DIR", config_dir)
-    monkeypatch.setattr(config_module, "CONFIG_FILE", config_file)
-    monkeypatch.delenv("QLUENT_API_KEY", raising=False)
-    monkeypatch.delenv("QLUENT_API_URL", raising=False)
-    monkeypatch.delenv("QLUENT_PROJECT_UUID", raising=False)
-    monkeypatch.delenv("QLUENT_USER_EMAIL", raising=False)
-    monkeypatch.delenv("QLUENT_CLIENT_SAFE", raising=False)
-    monkeypatch.delenv("QLUENT_BEARER_TOKEN", raising=False)
-
     loaded = config_module.load_config()
 
     assert loaded.api_url == config_module.DEFAULT_API_URL
     assert loaded.client_safe is True
 
 
-def test_load_config_uses_client_safe_default_when_not_persisted(monkeypatch, tmp_path):
-    config_dir = tmp_path / ".qluent"
-    config_file = config_dir / "config.json"
+def test_load_config_uses_client_safe_default_when_not_persisted(isolated_config):
+    config_dir, config_file = isolated_config
     config_dir.mkdir()
     config_file.write_text(
         json.dumps(
@@ -57,23 +46,13 @@ def test_load_config_uses_client_safe_default_when_not_persisted(monkeypatch, tm
         )
     )
 
-    monkeypatch.setattr(config_module, "CONFIG_DIR", config_dir)
-    monkeypatch.setattr(config_module, "CONFIG_FILE", config_file)
-    monkeypatch.delenv("QLUENT_CLIENT_SAFE", raising=False)
-    monkeypatch.delenv("QLUENT_API_KEY", raising=False)
-    monkeypatch.delenv("QLUENT_API_URL", raising=False)
-    monkeypatch.delenv("QLUENT_PROJECT_UUID", raising=False)
-    monkeypatch.delenv("QLUENT_USER_EMAIL", raising=False)
-    monkeypatch.delenv("QLUENT_BEARER_TOKEN", raising=False)
-
     loaded = config_module.load_config()
 
     assert loaded.client_safe is True
 
 
-def test_load_config_rejects_http_non_local_url(monkeypatch, tmp_path):
-    config_dir = tmp_path / ".qluent"
-    config_file = config_dir / "config.json"
+def test_load_config_rejects_http_non_local_url(isolated_config):
+    config_dir, config_file = isolated_config
     config_dir.mkdir()
     config_file.write_text(
         json.dumps(
@@ -86,22 +65,12 @@ def test_load_config_rejects_http_non_local_url(monkeypatch, tmp_path):
         )
     )
 
-    monkeypatch.setattr(config_module, "CONFIG_DIR", config_dir)
-    monkeypatch.setattr(config_module, "CONFIG_FILE", config_file)
-    monkeypatch.delenv("QLUENT_API_KEY", raising=False)
-    monkeypatch.delenv("QLUENT_API_URL", raising=False)
-    monkeypatch.delenv("QLUENT_PROJECT_UUID", raising=False)
-    monkeypatch.delenv("QLUENT_USER_EMAIL", raising=False)
-    monkeypatch.delenv("QLUENT_CLIENT_SAFE", raising=False)
-    monkeypatch.delenv("QLUENT_BEARER_TOKEN", raising=False)
-
     with pytest.raises(SystemExit, match="Refusing to connect over plain HTTP"):
         config_module.load_config()
 
 
-def test_load_config_rejects_bearer_token_without_api_key(monkeypatch, tmp_path):
-    config_dir = tmp_path / ".qluent"
-    config_file = config_dir / "config.json"
+def test_load_config_rejects_bearer_token_without_api_key(isolated_config):
+    config_dir, config_file = isolated_config
     config_dir.mkdir()
     config_file.write_text(
         json.dumps(
@@ -114,22 +83,12 @@ def test_load_config_rejects_bearer_token_without_api_key(monkeypatch, tmp_path)
         )
     )
 
-    monkeypatch.setattr(config_module, "CONFIG_DIR", config_dir)
-    monkeypatch.setattr(config_module, "CONFIG_FILE", config_file)
-    monkeypatch.delenv("QLUENT_API_KEY", raising=False)
-    monkeypatch.delenv("QLUENT_API_URL", raising=False)
-    monkeypatch.delenv("QLUENT_PROJECT_UUID", raising=False)
-    monkeypatch.delenv("QLUENT_USER_EMAIL", raising=False)
-    monkeypatch.delenv("QLUENT_CLIENT_SAFE", raising=False)
-    monkeypatch.delenv("QLUENT_BEARER_TOKEN", raising=False)
-
     with pytest.raises(SystemExit, match="Bearer-token auth is not supported"):
         config_module.load_config()
 
 
-def test_load_config_fails_without_api_key(monkeypatch, tmp_path):
-    config_dir = tmp_path / ".qluent"
-    config_file = config_dir / "config.json"
+def test_load_config_fails_without_api_key(isolated_config):
+    config_dir, config_file = isolated_config
     config_dir.mkdir()
     config_file.write_text(
         json.dumps(
@@ -140,15 +99,6 @@ def test_load_config_fails_without_api_key(monkeypatch, tmp_path):
             }
         )
     )
-
-    monkeypatch.setattr(config_module, "CONFIG_DIR", config_dir)
-    monkeypatch.setattr(config_module, "CONFIG_FILE", config_file)
-    monkeypatch.delenv("QLUENT_API_KEY", raising=False)
-    monkeypatch.delenv("QLUENT_API_URL", raising=False)
-    monkeypatch.delenv("QLUENT_PROJECT_UUID", raising=False)
-    monkeypatch.delenv("QLUENT_USER_EMAIL", raising=False)
-    monkeypatch.delenv("QLUENT_CLIENT_SAFE", raising=False)
-    monkeypatch.delenv("QLUENT_BEARER_TOKEN", raising=False)
 
     with pytest.raises(SystemExit, match="No API key configured"):
         config_module.load_config()

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -17,11 +17,8 @@ def _mock_browser_login(result: CallbackResult):
     return fake_browser_login
 
 
-def test_login_saves_config_on_success(monkeypatch, tmp_path):
-    config_dir = tmp_path / ".qluent"
-    config_file = config_dir / "config.json"
-    monkeypatch.setattr(config_module, "CONFIG_DIR", config_dir)
-    monkeypatch.setattr(config_module, "CONFIG_FILE", config_file)
+def test_login_saves_config_on_success(monkeypatch, isolated_config):
+    _config_dir, config_file = isolated_config
 
     monkeypatch.setattr(
         "qluent_cli.auth.browser_login",
@@ -49,12 +46,7 @@ def test_login_saves_config_on_success(monkeypatch, tmp_path):
     assert saved["api_url"] == config_module.DEFAULT_API_URL
 
 
-def test_login_shows_error_on_failure(monkeypatch, tmp_path):
-    config_dir = tmp_path / ".qluent"
-    config_file = config_dir / "config.json"
-    monkeypatch.setattr(config_module, "CONFIG_DIR", config_dir)
-    monkeypatch.setattr(config_module, "CONFIG_FILE", config_file)
-
+def test_login_shows_error_on_failure(monkeypatch, isolated_config):
     monkeypatch.setattr(
         "qluent_cli.auth.browser_login",
         _mock_browser_login(
@@ -69,11 +61,8 @@ def test_login_shows_error_on_failure(monkeypatch, tmp_path):
     assert "Timed out" in result.output
 
 
-def test_login_local_flag_uses_local_url(monkeypatch, tmp_path):
-    config_dir = tmp_path / ".qluent"
-    config_file = config_dir / "config.json"
-    monkeypatch.setattr(config_module, "CONFIG_DIR", config_dir)
-    monkeypatch.setattr(config_module, "CONFIG_FILE", config_file)
+def test_login_local_flag_uses_local_url(monkeypatch, isolated_config):
+    _config_dir, config_file = isolated_config
 
     fake = _mock_browser_login(
         CallbackResult(

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from qluent_cli import config as config_module
+from qluent_cli.auth import CallbackResult
+from qluent_cli.main import cli
+
+
+def _mock_browser_login(result: CallbackResult):
+    """Return a function that ignores api_url and returns the given result."""
+    def fake_browser_login(api_url: str) -> CallbackResult:
+        fake_browser_login.called_with_url = api_url  # type: ignore[attr-defined]
+        return result
+    return fake_browser_login
+
+
+def test_login_saves_config_on_success(monkeypatch, tmp_path):
+    config_dir = tmp_path / ".qluent"
+    config_file = config_dir / "config.json"
+    monkeypatch.setattr(config_module, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(config_module, "CONFIG_FILE", config_file)
+
+    monkeypatch.setattr(
+        "qluent_cli.auth.browser_login",
+        _mock_browser_login(
+            CallbackResult(
+                success=True,
+                api_key="qk_login_test",
+                project_uuid="proj-login",
+                user_email="login@test.com",
+            )
+        ),
+    )
+
+    result = CliRunner().invoke(cli, ["login"])
+
+    assert result.exit_code == 0
+    assert "Logged in successfully" in result.output
+    assert "proj-login" in result.output
+    assert "login@test.com" in result.output
+
+    saved = json.loads(config_file.read_text())
+    assert saved["api_key"] == "qk_login_test"
+    assert saved["project_uuid"] == "proj-login"
+    assert saved["user_email"] == "login@test.com"
+    assert saved["api_url"] == config_module.DEFAULT_API_URL
+
+
+def test_login_shows_error_on_failure(monkeypatch, tmp_path):
+    config_dir = tmp_path / ".qluent"
+    config_file = config_dir / "config.json"
+    monkeypatch.setattr(config_module, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(config_module, "CONFIG_FILE", config_file)
+
+    monkeypatch.setattr(
+        "qluent_cli.auth.browser_login",
+        _mock_browser_login(
+            CallbackResult(success=False, error="Timed out")
+        ),
+    )
+
+    result = CliRunner().invoke(cli, ["login"])
+
+    assert result.exit_code != 0
+    assert "Login failed" in result.output
+    assert "Timed out" in result.output
+
+
+def test_login_local_flag_uses_local_url(monkeypatch, tmp_path):
+    config_dir = tmp_path / ".qluent"
+    config_file = config_dir / "config.json"
+    monkeypatch.setattr(config_module, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(config_module, "CONFIG_FILE", config_file)
+
+    fake = _mock_browser_login(
+        CallbackResult(
+            success=True,
+            api_key="qk_local",
+            project_uuid="proj-local",
+            user_email="local@test.com",
+        )
+    )
+    monkeypatch.setattr("qluent_cli.auth.browser_login", fake)
+
+    result = CliRunner().invoke(cli, ["login", "--local"])
+
+    assert result.exit_code == 0
+    assert fake.called_with_url == config_module.LOCAL_API_URL  # type: ignore[attr-defined]
+
+    saved = json.loads(config_file.read_text())
+    assert saved["api_url"] == config_module.LOCAL_API_URL
+    assert saved["client_safe"] is False

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -8,11 +8,8 @@ from qluent_cli import config as config_module
 from qluent_cli.main import cli
 
 
-def test_setup_saves_config_and_writes_claude_md(monkeypatch, tmp_path):
-    config_dir = tmp_path / ".qluent"
-    config_file = config_dir / "config.json"
-    monkeypatch.setattr(config_module, "CONFIG_DIR", config_dir)
-    monkeypatch.setattr(config_module, "CONFIG_FILE", config_file)
+def test_setup_saves_config_and_writes_claude_md(monkeypatch, isolated_config, tmp_path):
+    _config_dir, config_file = isolated_config
     monkeypatch.chdir(tmp_path)
 
     result = CliRunner().invoke(
@@ -40,11 +37,8 @@ def test_setup_saves_config_and_writes_claude_md(monkeypatch, tmp_path):
     assert "# Qluent Metric Trees" in claude_md.read_text()
 
 
-def test_setup_uses_production_default_api_url(monkeypatch, tmp_path):
-    config_dir = tmp_path / ".qluent"
-    config_file = config_dir / "config.json"
-    monkeypatch.setattr(config_module, "CONFIG_DIR", config_dir)
-    monkeypatch.setattr(config_module, "CONFIG_FILE", config_file)
+def test_setup_uses_production_default_api_url(monkeypatch, isolated_config, tmp_path):
+    _config_dir, config_file = isolated_config
     monkeypatch.chdir(tmp_path)
 
     result = CliRunner().invoke(
@@ -63,11 +57,8 @@ def test_setup_uses_production_default_api_url(monkeypatch, tmp_path):
     assert saved["api_url"] == config_module.DEFAULT_API_URL
 
 
-def test_setup_local_flag_prefills_local_api_url(monkeypatch, tmp_path):
-    config_dir = tmp_path / ".qluent"
-    config_file = config_dir / "config.json"
-    monkeypatch.setattr(config_module, "CONFIG_DIR", config_dir)
-    monkeypatch.setattr(config_module, "CONFIG_FILE", config_file)
+def test_setup_local_flag_prefills_local_api_url(monkeypatch, isolated_config, tmp_path):
+    _config_dir, config_file = isolated_config
     monkeypatch.chdir(tmp_path)
 
     result = CliRunner().invoke(


### PR DESCRIPTION
- Introduces `qluent login` command for browser-based SSO authentication
- Implements local callback server to handle authentication flow
- Adds HTML templates for success/error states with modern UI
- Creates reusable authentication components and utilities
- Updates config system to suggest login when credentials are missing
- Adds helper functions for URL parsing and local development detection