### PR TITLE
feat(qluent-cli): add investigation agent and top findings to CLI output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,145 @@
+# Qluent Metric Trees
+
+You have access to the `qluent` CLI for deterministic KPI analysis. Use it to answer
+questions about business performance, revenue drivers, cost breakdowns, and trend changes.
+
+## Commands
+
+```bash
+qluent trees list                                           # List available metric trees
+qluent trees match "Why did revenue drop last week?"        # Match a question to the best tree + infer windows
+qluent trees get <tree_id>                                  # Show tree hierarchy
+qluent trees validate <tree_id>                             # Validate tree SQL contracts and dimensions
+qluent trees evaluate <tree_id> --period "last week"        # Evaluate with natural language period
+qluent trees evaluate <tree_id> --current YYYY-MM-DD:YYYY-MM-DD --compare YYYY-MM-DD:YYYY-MM-DD
+qluent trees trend <tree_id> --periods 4 --grain week       # Multi-period trend analysis
+qluent trees trend <tree_id> --periods 3 --grain month      # Monthly trend
+qluent trees compare <tree_id> <tree_id> --period "last week"  # Side-by-side tree comparison
+qluent trees investigate revenue --period "last week"       # Validate + trend + evaluate + RCA bundle
+qluent rca analyze revenue --period "last week"             # Deterministic tree + segment RCA
+```
+
+All commands support `--json-output` for raw JSON. The `trend` command supports `--as-of YYYY-MM-DD`
+to set the reference date. The `investigate` command supports `--trend-as-of YYYY-MM-DD`
+for reproducible bundled trend analysis.
+
+Supported periods: "last week", "this week", "last month", "this month", "last quarter",
+"yesterday", "last 30 days", "week over week", "month over month", or explicit ISO dates.
+
+## Preferred Claude Code workflow
+
+When Claude Code is asked to investigate KPI movement, prefer the bundled investigation command
+with `--json-output` as the first step:
+
+```bash
+qluent trees investigate --question "Why did revenue drop last week?" --json-output
+```
+
+If the user already named the tree, use:
+
+```bash
+qluent trees investigate revenue --current YYYY-MM-DD:YYYY-MM-DD --compare YYYY-MM-DD:YYYY-MM-DD --json-output
+```
+
+Read the investigation bundle in this order:
+
+1. `agent.status`
+2. `agent.top_findings`
+3. `agent.gaps`
+4. `agent.recommended_next_steps`
+5. `root_cause`, `evaluation`, and `trend` details for evidence
+
+Use these rules:
+
+- Prefer `investigate --question` over manually chaining `match`, `trend`, `evaluate`, and `rca analyze`.
+- Prefer `--json-output` when Claude Code is driving the workflow.
+- If `agent.status = needs_tree_selection`, inspect `match.top_candidates` and either pick the strongest tree or ask the user.
+- If `agent.status = needs_more_data` or `partially_resolved`, run the first relevant command from `agent.recommended_next_steps` before inventing your own drill-down.
+- If `agent.status = resolved`, summarize the evidence and stop unless the user explicitly wants a deeper drill-down.
+- Always report the exact current and comparison windows you used.
+- Treat `agent.top_findings` as the fastest summary, then verify against `root_cause.conclusion.takeaways` and supporting evidence.
+
+## Manual root cause analysis workflow
+
+When asked to analyze business performance, follow this 3-step drill-down:
+
+### Step 1: Spot the anomaly with `trend`
+```bash
+qluent trees trend revenue --periods 4 --grain week
+```
+Look for: which period had an unusual change? Is the trend accelerating, declining, or volatile?
+
+### Step 2: Drill into the anomaly with `evaluate`
+```bash
+qluent trees evaluate revenue --period "last week"
+```
+The Shapley attribution tells you WHICH sub-metric drove the change and by how much.
+Focus on the top contributors — they explain where the delta came from.
+
+### Step 3: Validate segment contracts with `trees validate`
+```bash
+qluent trees validate revenue
+```
+Use this before relying on segment RCA. A tree should explicitly project its execution columns
+and declared dimensions at every leaf node.
+
+### Step 4: Run deterministic root cause analysis with `rca analyze`
+```bash
+qluent rca analyze revenue --period "last week"
+```
+This traverses the tree and, when dimensions are available, cuts suspect nodes by segment
+to surface where the movement is concentrated.
+
+### Step 5: Cross-reference with `compare`
+```bash
+qluent trees compare revenue order_volume --period "last week"
+```
+Comparing related trees validates the mechanism. For example:
+- Revenue up +20% but Orders up +20% → pure volume growth
+- Revenue up +20% but Orders up +5% → basket size / mix shift
+- Revenue up but ROAS down → growth is coming at higher cost
+
+## How to interpret results
+
+### Shapley-value attribution (Top contributors)
+Each child's contribution to the parent's delta is computed using Shapley values from
+cooperative game theory. This answers: "how much of the parent's change is attributable
+to each child?"
+
+Key properties:
+- **Contributions sum to the parent delta** — they fully explain the change.
+- **A share > 100%** means this child drove MORE change than the total, offset by others.
+- **A negative share** means this child moved against the overall trend.
+- This is NOT a simple percentage breakdown — it accounts for formula interactions
+  (e.g., in ROAS = revenue / spend, both numerator and denominator are attributed correctly).
+
+### Trend labels
+- **accelerating**: positive and growing faster
+- **decelerating**: positive but slowing down
+- **recovering**: was negative, now positive
+- **declining**: was positive, now negative
+- **volatile**: direction changes frequently
+- **stable**: changes within ±2%
+
+### RCA confidence
+`conclusion.confidence` and `conclusion.confidence_score` are NOT probabilities.
+They are evidence-coverage heuristics.
+
+Interpret them like this:
+- `confidence_type = evidence_coverage_heuristic` means the score reflects how much deterministic evidence is available.
+- Higher scores mean broader coverage across driver, time-slice, segment/mix-shift, and mechanism evidence.
+- Warnings and unresolved branches reduce the score.
+- Use `evidence_types_present`, `evidence_types_missing`, and `confidence_factors` to explain why the score is high, medium, or low.
+- Never describe `80%` as "80% likely to be true." Describe it as an evidence or coverage score.
+
+### Example analysis
+"Why did revenue change last week?"
+
+1. `trend` shows: Revenue was +11%, +11%, then +6% → **decelerating**
+2. `evaluate` shows: Owned channels drove 143% of growth, but Organic declined 56%
+3. `compare` Revenue vs Orders: Owned revenue +20% but Owned orders -5% → higher basket size,
+   not more customers. Organic orders -5% matching Organic revenue -12% → volume loss.
+
+Conclusion: "Revenue growth is decelerating. Last week's gain came from higher basket sizes
+in owned channels (Direct, Email), not from customer acquisition. Organic traffic continues
+to decline — investigate SEO or content changes."

--- a/README.md
+++ b/README.md
@@ -60,10 +60,16 @@ That writes `CLAUDE.md` in the current directory so Claude Code can use the CLI 
 ```bash
 qluent trees list
 qluent trees match "Why did revenue drop last week?"
+qluent trees investigate --question "Why did revenue drop last week?" --json-output
 qluent trees trend revenue --periods 4 --grain week
 qluent trees investigate revenue --period "last week"
 qluent rca analyze revenue --period "last week"
 ```
+
+For Claude Code, prefer `qluent trees investigate --question ... --json-output`.
+That returns a bundled investigation plus `agent.status`, `agent.top_findings`,
+`agent.gaps`, and `agent.recommended_next_steps` so the model can continue RCA
+without manually inventing the next command.
 
 ## Internal / Direct Python Install
 

--- a/src/qluent_cli/formatters.py
+++ b/src/qluent_cli/formatters.py
@@ -611,6 +611,8 @@ def format_investigation(data: dict[str, Any]) -> str:
     evaluation = data.get("evaluation") or {}
     validation = data.get("validation") or {}
     root_cause = data.get("root_cause") or {}
+    match_result = data.get("match") or {}
+    agent = data.get("agent") or {}
     tree_label = (
         evaluation.get("tree_label")
         or validation.get("tree_label")
@@ -620,6 +622,21 @@ def format_investigation(data: dict[str, Any]) -> str:
     )
 
     lines = [f"{tree_label} Investigation", ""]
+    if data.get("question"):
+        lines.append(f'  Question: "{data["question"]}"')
+    if match_result:
+        if match_result.get("matched"):
+            lines.append(
+                "  Matched tree: "
+                + str(match_result.get("tree_id") or match_result.get("tree_label") or "?")
+            )
+        else:
+            decision = match_result.get("decision") or "no_match"
+            status_label = {
+                "ambiguous": "ambiguous match",
+                "no_trees": "no saved trees",
+            }.get(decision, "no tree match")
+            lines.append(f"  Match status: {status_label}")
     if data.get("period_label"):
         lines.append(f"  Period: {data['period_label']}")
     if data.get("segment_by_used"):
@@ -630,6 +647,32 @@ def format_investigation(data: dict[str, Any]) -> str:
             rendered_filters.append(f"{key}={','.join(values)}")
         if rendered_filters:
             lines.append("  Filters: " + "; ".join(rendered_filters))
+    if agent.get("status"):
+        lines.append(
+            "  Investigation status: "
+            + str(agent["status"]).replace("_", " ")
+        )
+
+    top_findings = agent.get("top_findings") or []
+    if top_findings:
+        lines.extend(["", "  Top findings:"])
+        for index, finding in enumerate(top_findings[:3], start=1):
+            lines.append(f"    {index}. {finding}")
+
+    gaps = agent.get("gaps") or []
+    if gaps:
+        lines.extend(["", "  Evidence gaps:"])
+        for gap in gaps[:6]:
+            lines.append(f"    - {gap}")
+
+    recommended_next_steps = agent.get("recommended_next_steps") or []
+    if recommended_next_steps:
+        lines.extend(["", "  Recommended next steps:"])
+        for step in recommended_next_steps[:4]:
+            title = step.get("title") or step.get("kind") or "Next step"
+            lines.append(f"    - {title}: {step.get('why', '')}".rstrip())
+            if step.get("command"):
+                lines.append(f"      {step['command']}")
 
     step_errors = data.get("step_errors") or {}
 

--- a/src/qluent_cli/main.py
+++ b/src/qluent_cli/main.py
@@ -272,6 +272,7 @@ qluent trees trend <tree_id> --periods 4 --grain week       # Multi-period trend
 qluent trees trend <tree_id> --periods 3 --grain month      # Monthly trend
 qluent trees compare <tree_id> <tree_id> --period "last week"  # Side-by-side tree comparison
 qluent trees investigate revenue --period "last week"       # Validate + trend + evaluate + RCA bundle
+qluent trees investigate --question "Why did revenue drop last week?"  # Match tree + infer windows + bundle RCA
 qluent rca analyze revenue --period "last week"             # Deterministic tree + segment RCA
 ```
 
@@ -282,7 +283,40 @@ for reproducible bundled trend analysis.
 Supported periods: "last week", "this week", "last month", "this month", "last quarter",
 "yesterday", "last 30 days", "week over week", "month over month", or explicit ISO dates.
 
-## Root cause analysis workflow
+## Preferred Claude Code workflow
+
+When Claude Code is asked to investigate KPI movement, prefer the bundled investigation command
+with `--json-output` as the first step:
+
+```bash
+qluent trees investigate --question "Why did revenue drop last week?" --json-output
+```
+
+If the user already named the tree, use:
+
+```bash
+qluent trees investigate revenue --current YYYY-MM-DD:YYYY-MM-DD --compare YYYY-MM-DD:YYYY-MM-DD --json-output
+```
+
+Read the investigation bundle in this order:
+
+1. `agent.status`
+2. `agent.top_findings`
+3. `agent.gaps`
+4. `agent.recommended_next_steps`
+5. `root_cause`, `evaluation`, and `trend` details for evidence
+
+Use these rules:
+
+- Prefer `investigate --question` over manually chaining `match`, `trend`, `evaluate`, and `rca analyze`.
+- Prefer `--json-output` when Claude Code is driving the workflow.
+- If `agent.status = needs_tree_selection`, inspect `match.top_candidates` and either pick the strongest tree or ask the user.
+- If `agent.status = needs_more_data` or `partially_resolved`, run the first relevant command from `agent.recommended_next_steps` before inventing your own drill-down.
+- If `agent.status = resolved`, summarize the evidence and stop unless the user explicitly wants a deeper drill-down.
+- Always report the exact current and comparison windows you used.
+- Treat `agent.top_findings` as the fastest summary, then verify against `root_cause.conclusion.takeaways` and supporting evidence.
+
+## Manual root cause analysis workflow
 
 When asked to analyze business performance, follow this 3-step drill-down:
 

--- a/src/qluent_cli/trees.py
+++ b/src/qluent_cli/trees.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 from datetime import date as dt_date
 from typing import Any
 
@@ -124,6 +125,353 @@ def _collect_trend_evaluations(
         )
         evaluations.append(data)
     return evaluations
+
+
+def _resolve_investigation_input(
+    client: QluentClient,
+    tree_id: str | None,
+    question: str | None,
+    period: str | None,
+    current_range: str | None,
+    compare_range: str | None,
+) -> tuple[str | None, dict[str, Any] | None, str, str, str, str]:
+    """Resolve investigation target plus evaluation windows."""
+    if bool(tree_id) == bool(question):
+        raise click.UsageError("Provide either TREE_ID or --question.")
+
+    if question:
+        try:
+            tree_collection = client.list_trees()
+        except Exception as exc:
+            raise click.ClickException(
+                "Failed to load metric trees for question matching: "
+                + _format_step_error(exc)
+            ) from exc
+
+        match_result = match_tree_question(question, tree_collection)
+        if current_range or compare_range or period:
+            c_from, c_to, p_from, p_to = _resolve_date_args(
+                period,
+                current_range,
+                compare_range,
+            )
+        else:
+            current_window = match_result["current_window"]
+            comparison_window = match_result["comparison_window"]
+            c_from = current_window["date_from"]
+            c_to = current_window["date_to"]
+            p_from = comparison_window["date_from"]
+            p_to = comparison_window["date_to"]
+
+        resolved_tree_id = (
+            str(match_result.get("tree_id"))
+            if match_result.get("matched") and match_result.get("tree_id")
+            else None
+        )
+        return resolved_tree_id, match_result, c_from, c_to, p_from, p_to
+
+    assert tree_id is not None
+    c_from, c_to, p_from, p_to = _resolve_date_args(period, current_range, compare_range)
+    return tree_id, None, c_from, c_to, p_from, p_to
+
+
+def _period_command_args(c_from: str, c_to: str, p_from: str, p_to: str) -> list[str]:
+    return [
+        "--current",
+        f"{c_from}:{c_to}",
+        "--compare",
+        f"{p_from}:{p_to}",
+    ]
+
+
+def _agent_command(parts: list[str]) -> str:
+    return shlex.join(parts)
+
+
+def _add_recommendation(
+    recommendations: list[dict[str, str]],
+    *,
+    kind: str,
+    title: str,
+    why: str,
+    command: str,
+) -> None:
+    if any(item.get("command") == command for item in recommendations):
+        return
+    recommendations.append(
+        {
+            "kind": kind,
+            "title": title,
+            "why": why,
+            "command": command,
+        }
+    )
+
+
+def _collect_agent_top_findings(bundle: dict[str, Any]) -> list[str]:
+    """Summarize the strongest available evidence for an investigation."""
+    findings: list[str] = []
+
+    root_cause = bundle.get("root_cause") or {}
+    conclusion = root_cause.get("conclusion") or {}
+    for takeaway in conclusion.get("takeaways") or []:
+        summary = takeaway.get("summary")
+        if summary:
+            findings.append(str(summary))
+        if len(findings) >= 3:
+            return findings
+    if findings:
+        return findings
+
+    evaluation = bundle.get("evaluation") or {}
+    for contributor in evaluation.get("top_contributors") or []:
+        label = contributor.get("label") or contributor.get("node_id") or "Unknown"
+        delta_value = contributor.get("delta_value")
+        delta_share = contributor.get("delta_share")
+        summary = f"{label} drove Δ {delta_value}"
+        if delta_share is not None:
+            summary += f" ({delta_share:.0%} of change)"
+        findings.append(summary)
+        if len(findings) >= 3:
+            return findings
+
+    if evaluation:
+        tree_label = evaluation.get("tree_label", bundle.get("tree_label", bundle.get("tree_id", "Metric")))
+        findings.append(
+            f"{tree_label} moved from {evaluation.get('comparison_value')} to {evaluation.get('current_value')} "
+            f"(Δ {evaluation.get('delta_value')})."
+        )
+
+    return findings[:3]
+
+
+def _collect_agent_gaps(bundle: dict[str, Any]) -> list[str]:
+    """Highlight the main evidence gaps or blockers for an investigation."""
+    raw_gaps: list[str] = []
+    match_result = bundle.get("match") or {}
+    validation = bundle.get("validation") or {}
+    root_cause = bundle.get("root_cause") or {}
+    conclusion = root_cause.get("conclusion") or {}
+    step_errors = bundle.get("step_errors") or {}
+
+    if bundle.get("question") and not bundle.get("tree_id"):
+        decision = match_result.get("decision")
+        if decision == "ambiguous":
+            raw_gaps.append("Question matched multiple saved trees and needs an explicit tree choice.")
+        elif decision == "no_trees":
+            raw_gaps.append("No metric trees are configured for this project yet.")
+        else:
+            raw_gaps.append("No saved metric tree matched the investigation question.")
+
+    if validation and not validation.get("valid", True):
+        raw_gaps.extend(str(error) for error in (validation.get("errors") or [])[:3])
+
+    supported_dimensions = validation.get("supported_dimensions") or []
+    if bundle.get("tree_id") and not bundle.get("segment_by_used") and supported_dimensions:
+        raw_gaps.append(
+            "No segment cuts were applied. Available dimensions: "
+            + ", ".join(str(value) for value in supported_dimensions[:3])
+        )
+
+    if bundle.get("tree_id") and not root_cause:
+        raw_gaps.append("Root-cause analysis did not return results for this investigation.")
+
+    if root_cause and not conclusion:
+        raw_gaps.append("Root-cause analysis returned evidence without a ranked deterministic conclusion.")
+
+    if conclusion.get("evidence_types_missing"):
+        raw_gaps.append(
+            "Missing deterministic evidence: "
+            + ", ".join(str(value) for value in conclusion["evidence_types_missing"])
+        )
+
+    for unresolved in conclusion.get("unresolved_nodes") or []:
+        summary = unresolved.get("summary")
+        if summary:
+            raw_gaps.append(str(summary))
+
+    warnings = root_cause.get("warnings") or []
+    if warnings:
+        raw_gaps.extend(str(warning) for warning in warnings[:3])
+
+    for key, message in step_errors.items():
+        raw_gaps.append(f"{key.replace('_', ' ')} step error: {message}")
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for gap in raw_gaps:
+        cleaned = gap.strip()
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        deduped.append(cleaned)
+    return deduped[:6]
+
+
+def _derive_agent_status(bundle: dict[str, Any]) -> str:
+    """Classify investigation completeness for agentic follow-up."""
+    if bundle.get("question") and not bundle.get("tree_id"):
+        return "needs_tree_selection"
+
+    validation = bundle.get("validation") or {}
+    root_cause = bundle.get("root_cause") or {}
+    conclusion = root_cause.get("conclusion") or {}
+    step_errors = bundle.get("step_errors") or {}
+
+    if not root_cause:
+        return "needs_more_data"
+
+    if (
+        not validation.get("valid", True)
+        or step_errors
+        or not conclusion
+        or conclusion.get("evidence_types_missing")
+        or conclusion.get("unresolved_nodes")
+        or root_cause.get("warnings")
+    ):
+        return "partially_resolved"
+
+    return "resolved"
+
+
+def _build_recommended_next_steps(
+    bundle: dict[str, Any],
+    *,
+    compare_trees: tuple[str, ...],
+) -> list[dict[str, str]]:
+    """Emit deterministic follow-up commands that an agent can execute next."""
+    recommendations: list[dict[str, str]] = []
+    tree_id = bundle.get("tree_id")
+    question = bundle.get("question")
+    match_result = bundle.get("match") or {}
+    validation = bundle.get("validation") or {}
+    root_cause = bundle.get("root_cause") or {}
+    trend = bundle.get("trend") or {}
+    c_from = bundle["current_window"]["date_from"]
+    c_to = bundle["current_window"]["date_to"]
+    p_from = bundle["comparison_window"]["date_from"]
+    p_to = bundle["comparison_window"]["date_to"]
+    period_args = _period_command_args(c_from, c_to, p_from, p_to)
+
+    if question and not tree_id:
+        top_candidates = match_result.get("top_candidates") or []
+        best_candidate = next(
+            (
+                str(candidate.get("tree_id"))
+                for candidate in top_candidates
+                if candidate.get("tree_id")
+            ),
+            None,
+        )
+        if best_candidate:
+            _add_recommendation(
+                recommendations,
+                kind="tree_selection",
+                title=f"Investigate {best_candidate}",
+                why="Run the strongest candidate explicitly when the question does not resolve to one unambiguous tree.",
+                command=_agent_command(
+                    ["qluent", "trees", "investigate", best_candidate, *period_args, "--json-output"]
+                ),
+            )
+        _add_recommendation(
+            recommendations,
+            kind="tree_discovery",
+            title="Review saved trees",
+            why="Inspect available tree ids and labels before forcing a manual tree selection.",
+            command=_agent_command(["qluent", "trees", "list", "--json-output"]),
+        )
+        _add_recommendation(
+            recommendations,
+            kind="tree_match",
+            title="Inspect tree match candidates",
+            why="Look at match scores and candidate reasons directly if you want to tune the selection logic or choose manually.",
+            command=_agent_command(["qluent", "trees", "match", question, "--json-output"]),
+        )
+        return recommendations[:3]
+
+    assert tree_id is not None
+    tree_label = str(bundle.get("tree_label") or tree_id).lower()
+    segment_by_used = list(bundle.get("segment_by_used") or [])
+    supported_dimensions = [str(value) for value in (validation.get("supported_dimensions") or [])]
+
+    if not validation or not validation.get("valid", True):
+        _add_recommendation(
+            recommendations,
+            kind="validation",
+            title="Validate tree contract",
+            why="Confirm the saved metric tree exposes the dimensions and execution columns required for reliable RCA.",
+            command=_agent_command(["qluent", "trees", "validate", tree_id, "--json-output"]),
+        )
+
+    segment_dimensions = segment_by_used or supported_dimensions[:2]
+    segment_args: list[str] = []
+    for dimension in segment_dimensions:
+        segment_args.extend(["--segment-by", dimension])
+
+    if not root_cause:
+        _add_recommendation(
+            recommendations,
+            kind="root_cause",
+            title="Run standalone RCA",
+            why="Retry the deterministic RCA step directly to isolate whether the failure is in the bundled investigation or the root-cause endpoint itself.",
+            command=_agent_command(
+                ["qluent", "rca", "analyze", tree_id, *period_args, *segment_args, "--json-output"]
+            ),
+        )
+
+    if supported_dimensions and not segment_by_used:
+        _add_recommendation(
+            recommendations,
+            kind="segmentation",
+            title="Add segment cuts",
+            why="Segment evidence is available on this tree but was not used in the investigation bundle.",
+            command=_agent_command(
+                ["qluent", "rca", "analyze", tree_id, *period_args, *segment_args, "--json-output"]
+            ),
+        )
+
+    if not (trend.get("evaluations") or []):
+        _add_recommendation(
+            recommendations,
+            kind="trend",
+            title="Backfill recent trend context",
+            why="Trend context helps distinguish a one-period shock from a longer-running decline or recovery.",
+            command=_agent_command(["qluent", "trees", "trend", tree_id, "--periods", "4", "--grain", "week", "--json-output"]),
+        )
+
+    revenue_like = "revenue" in tree_id.lower() or "revenue" in tree_label
+    existing_compare_targets = {tree_id, *compare_trees}
+    revenue_playbook = [
+        (
+            "order_volume",
+            "Check whether the change is primarily driven by order volume rather than basket size.",
+        ),
+        (
+            "net_revenue",
+            "Check whether refunds or discounting explain the difference between gross and net performance.",
+        ),
+        (
+            "blended_roas",
+            "Check whether paid spend efficiency or budget changes are amplifying the revenue movement.",
+        ),
+    ]
+    if revenue_like:
+        for compare_tree_id, why in revenue_playbook:
+            if compare_tree_id in existing_compare_targets:
+                continue
+            _add_recommendation(
+                recommendations,
+                kind="comparison",
+                title=f"Compare against {compare_tree_id}",
+                why=why,
+                command=_agent_command(
+                    ["qluent", "trees", "compare", tree_id, compare_tree_id, *period_args, "--json-output"]
+                ),
+            )
+            if len(recommendations) >= 4:
+                break
+
+    return recommendations[:4]
 
 
 @trees.command(name="list")
@@ -253,7 +601,12 @@ def compare(
 
 
 @trees.command()
-@click.argument("tree_id")
+@click.argument("tree_id", required=False)
+@click.option(
+    "--question",
+    default=None,
+    help="Natural-language investigation prompt. The CLI will match the best tree and infer windows unless you override them.",
+)
 @click.option("--period", "-p", default=None, help='Period like "last week" or "this month"')
 @click.option("--current", "current_range", default=None, help="Current window as YYYY-MM-DD:YYYY-MM-DD")
 @click.option("--compare", "compare_range", default=None, help="Comparison window as YYYY-MM-DD:YYYY-MM-DD")
@@ -274,7 +627,8 @@ def compare(
 )
 @click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
 def investigate(
-    tree_id: str,
+    tree_id: str | None,
+    question: str | None,
     period: str | None,
     current_range: str | None,
     compare_range: str | None,
@@ -290,14 +644,24 @@ def investigate(
     min_contribution_share: float,
     as_json: bool,
 ) -> None:
-    """Run a deterministic multi-step investigation bundle for one tree."""
-    c_from, c_to, p_from, p_to = _resolve_date_args(period, current_range, compare_range)
+    """Run a deterministic multi-step investigation bundle for one tree or question."""
     parsed_filters = _parse_filters(filters)
-    period_label = format_period_label(c_from, c_to, p_from, p_to)
 
     client = QluentClient(load_config())
+    resolved_tree_id, match_result, c_from, c_to, p_from, p_to = _resolve_investigation_input(
+        client,
+        tree_id,
+        question,
+        period,
+        current_range,
+        compare_range,
+    )
+    period_label = format_period_label(c_from, c_to, p_from, p_to)
     bundle: dict[str, Any] = {
-        "tree_id": tree_id,
+        "question": question,
+        "match": match_result,
+        "tree_id": resolved_tree_id,
+        "tree_label": match_result.get("tree_label") if match_result else resolved_tree_id,
         "period_label": period_label,
         "current_window": {"date_from": c_from, "date_to": c_to},
         "comparison_window": {"date_from": p_from, "date_to": p_to},
@@ -319,10 +683,32 @@ def investigate(
             "errors": {},
         },
         "step_errors": {},
+        "agent": {
+            "status": "needs_more_data",
+            "top_findings": [],
+            "gaps": [],
+            "recommended_next_steps": [],
+        },
     }
 
+    if not resolved_tree_id:
+        bundle["agent"] = {
+            "status": _derive_agent_status(bundle),
+            "top_findings": _collect_agent_top_findings(bundle),
+            "gaps": _collect_agent_gaps(bundle),
+            "recommended_next_steps": _build_recommended_next_steps(
+                bundle,
+                compare_trees=compare_trees,
+            ),
+        }
+        if as_json:
+            click.echo(json.dumps(bundle, indent=2))
+        else:
+            click.echo(format_investigation(bundle))
+        return
+
     try:
-        validation = client.validate_tree(tree_id)
+        validation = client.validate_tree(resolved_tree_id)
         bundle["validation"] = validation
     except Exception as exc:  # pragma: no cover - defensive integration handling
         bundle["step_errors"]["validation"] = _format_step_error(exc)
@@ -331,7 +717,7 @@ def investigate(
     try:
         trend_evaluations = _collect_trend_evaluations(
             client,
-            tree_id,
+            resolved_tree_id,
             trend_periods,
             trend_grain,
             trend_as_of,
@@ -341,9 +727,9 @@ def investigate(
         bundle["step_errors"]["trend"] = _format_step_error(exc)
 
     try:
-        evaluation = client.evaluate_tree(tree_id, c_from, c_to, p_from, p_to)
+        evaluation = client.evaluate_tree(resolved_tree_id, c_from, c_to, p_from, p_to)
         bundle["evaluation"] = evaluation
-        bundle["tree_label"] = evaluation.get("tree_label", tree_id)
+        bundle["tree_label"] = evaluation.get("tree_label", resolved_tree_id)
     except Exception as exc:  # pragma: no cover - defensive integration handling
         bundle["step_errors"]["evaluation"] = _format_step_error(exc)
 
@@ -354,7 +740,7 @@ def investigate(
 
     try:
         root_cause = client.root_cause_tree(
-            tree_id,
+            resolved_tree_id,
             c_from,
             c_to,
             p_from,
@@ -368,7 +754,7 @@ def investigate(
         )
         bundle["root_cause"] = root_cause
         if not bundle.get("tree_label"):
-            bundle["tree_label"] = root_cause.get("tree_label", tree_id)
+            bundle["tree_label"] = root_cause.get("tree_label", resolved_tree_id)
     except Exception as exc:  # pragma: no cover - defensive integration handling
         bundle["step_errors"]["root_cause"] = _format_step_error(exc)
 
@@ -378,6 +764,16 @@ def investigate(
             bundle["comparison"]["results"].append(comparison_result)
         except Exception as exc:  # pragma: no cover - defensive integration handling
             bundle["comparison"]["errors"][compare_tree_id] = _format_step_error(exc)
+
+    bundle["agent"] = {
+        "status": _derive_agent_status(bundle),
+        "top_findings": _collect_agent_top_findings(bundle),
+        "gaps": _collect_agent_gaps(bundle),
+        "recommended_next_steps": _build_recommended_next_steps(
+            bundle,
+            compare_trees=compare_trees,
+        ),
+    }
 
     if as_json:
         click.echo(json.dumps(bundle, indent=2))

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -386,5 +386,179 @@ def test_trees_investigate_bundles_deterministic_steps(monkeypatch):
     assert [item["tree_id"] for item in payload["comparison"]["results"]] == ["orders"]
     assert payload["filters"] == {"country": ["SE"]}
     assert payload["step_errors"] == {}
+    assert payload["agent"]["status"] == "partially_resolved"
+    assert "ranked deterministic conclusion" in payload["agent"]["gaps"][0]
+    assert [item["kind"] for item in payload["agent"]["recommended_next_steps"]] == [
+        "comparison",
+        "comparison",
+        "comparison",
+    ]
     assert len(evaluate_calls) == 4
     assert root_cause_calls[0]["segment_by"] == ["channel", "country"]
+
+
+def test_trees_investigate_matches_question_for_agent_flow(monkeypatch):
+    monkeypatch.setattr(
+        "qluent_cli.trees.load_config",
+        lambda: QluentConfig(
+            api_key="qk_test",
+            api_url="https://api.example.com",
+            project_uuid="project-123",
+            user_email="user@example.com",
+        ),
+    )
+
+    evaluate_calls: list[tuple[str, str, str, str, str]] = []
+
+    def mock_list_trees(self):
+        return {
+            "trees": [
+                {
+                    "id": "revenue",
+                    "label": "Revenue",
+                    "description": "Total revenue from completed orders",
+                    "dimensions": ["channel", "country"],
+                    "nodes": [
+                        {"id": "revenue", "label": "Revenue", "kind": "formula"},
+                        {"id": "orders", "label": "Orders", "kind": "sql_metric"},
+                    ],
+                }
+            ]
+        }
+
+    def mock_validate_tree(self, tree_id):
+        assert tree_id == "revenue"
+        return {
+            "tree_id": "revenue",
+            "tree_label": "Revenue",
+            "valid": True,
+            "dimensions_declared": ["channel", "country"],
+            "supported_dimensions": ["channel", "country"],
+            "leaf_nodes": [],
+            "errors": [],
+            "warnings": [],
+        }
+
+    def mock_evaluate_tree(self, tree_id, current_from, current_to, comparison_from, comparison_to):
+        evaluate_calls.append((tree_id, current_from, current_to, comparison_from, comparison_to))
+        return {
+            "tree_id": tree_id,
+            "tree_label": "Revenue",
+            "root_node_id": tree_id,
+            "current_window": {"date_from": current_from, "date_to": current_to},
+            "comparison_window": {"date_from": comparison_from, "date_to": comparison_to},
+            "current_value": 900,
+            "comparison_value": 1000,
+            "delta_value": -100,
+            "delta_ratio": -0.1,
+            "top_contributors": [
+                {
+                    "node_id": "orders",
+                    "label": "Orders",
+                    "delta_value": -100,
+                    "delta_share": 1.0,
+                }
+            ],
+            "nodes": [],
+            "warnings": [],
+        }
+
+    def mock_root_cause_tree(
+        self,
+        tree_id,
+        current_from,
+        current_to,
+        comparison_from,
+        comparison_to,
+        *,
+        segment_by,
+        filters,
+        max_depth,
+        max_branching,
+        max_segments,
+        min_contribution_share,
+    ):
+        assert tree_id == "revenue"
+        assert current_from == "2026-03-09"
+        assert current_to == "2026-03-15"
+        assert comparison_from == "2026-03-02"
+        assert comparison_to == "2026-03-08"
+        return {
+            "tree_id": tree_id,
+            "tree_label": "Revenue",
+            "root_node_id": tree_id,
+            "current_window": {"date_from": current_from, "date_to": current_to},
+            "comparison_window": {"date_from": comparison_from, "date_to": comparison_to},
+            "current_value": 900,
+            "comparison_value": 1000,
+            "delta_value": -100,
+            "delta_ratio": -0.1,
+            "dimensions_considered": ["channel", "country"],
+            "time_slice_grain": "day",
+            "time_slices": [],
+            "mix_shift": None,
+            "conclusion": {
+                "confidence": "high",
+                "confidence_score": 0.85,
+                "confidence_type": "evidence_coverage_heuristic",
+                "confidence_description": "Broad deterministic evidence is present.",
+                "evidence_types_present": ["driver", "segment"],
+                "evidence_types_missing": [],
+                "confidence_factors": [],
+                "takeaways": [
+                    {
+                        "kind": "driver",
+                        "title": "Orders drove the decline",
+                        "summary": "Orders explain most of the revenue decline.",
+                        "score": 1.2,
+                        "node_id": "orders",
+                        "path": ["revenue", "orders"],
+                        "delta_value": -100,
+                        "effect_value": None,
+                        "share_of_change": 1.0,
+                        "dimension": None,
+                        "segment": None,
+                        "current_window": None,
+                        "comparison_window": None,
+                    }
+                ],
+                "unresolved_nodes": [],
+            },
+            "findings": [],
+            "warnings": [],
+        }
+
+    monkeypatch.setattr("qluent_cli.trees.QluentClient.list_trees", mock_list_trees)
+    monkeypatch.setattr("qluent_cli.trees.QluentClient.validate_tree", mock_validate_tree)
+    monkeypatch.setattr("qluent_cli.trees.QluentClient.evaluate_tree", mock_evaluate_tree)
+    monkeypatch.setattr("qluent_cli.trees.QluentClient.root_cause_tree", mock_root_cause_tree)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "trees",
+            "investigate",
+            "--question",
+            "Why did revenue drop from 2026-03-09 to 2026-03-15 compared with 2026-03-02 to 2026-03-08?",
+            "--json-output",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["question"].startswith("Why did revenue drop")
+    assert payload["match"]["matched"] is True
+    assert payload["tree_id"] == "revenue"
+    assert payload["period_label"] == "Mar 9–Mar 15 vs Mar 2–Mar 8"
+    assert payload["agent"]["status"] == "resolved"
+    assert payload["agent"]["top_findings"] == [
+        "Orders explain most of the revenue decline."
+    ]
+    assert payload["agent"]["recommended_next_steps"][0]["kind"] == "comparison"
+    assert (
+        "revenue",
+        "2026-03-09",
+        "2026-03-15",
+        "2026-03-02",
+        "2026-03-08",
+    ) in evaluate_calls


### PR DESCRIPTION
The following changes were made to enhance the Qluent CLI and improve integration with Claude Code:

- **Added an investigation agent** to the CLI output, which includes:
  - `agent.status` to indicate the current state of the investigation.
  - `agent.top_findings` to highlight the most significant findings from the analysis.
  - `agent.gaps` to identify areas with missing or insufficient data.
  - `agent.recommended_next_steps` to suggest follow-up actions for deeper analysis.

- **Improved formatting of investigation results** in the CLI output, including:
  - Displaying the matched tree and its status.
  - Showing the question being investigated and the period analyzed.
  - Listing top findings, evidence gaps, and recommended next steps in a structured format.

- **Updated documentation** to reflect the new `investigate` command and its use with the `--question` flag for automatic tree matching and period inference.
  - Emphasized the use of `--json-output` for integration with Claude Code.
  - Added guidance on interpreting the new agent fields and using them for deterministic root cause analysis.