### PR TITLE
feat(matching): add natural-language tree matching tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ That walks the user through:
 - API URL
 - generating `CLAUDE.md`
 
-The default hosted environment is `https://api.app.qluent.com`.
+The default hosted environment is `https://api.app-development.qluent.com`.
 For local backend development, run:
 
 ```bash
@@ -131,7 +131,7 @@ To include a real API smoke test:
 QLUENT_TEST_API_KEY=qk_... \
 QLUENT_TEST_PROJECT_UUID=<PROJECT_UUID> \
 QLUENT_TEST_USER_EMAIL=you@example.com \
-QLUENT_TEST_URL=https://api.app.qluent.com \
+QLUENT_TEST_URL=https://api.app-development.qluent.com \
 QLUENT_TEST_TREE_ID=revenue \
 scripts/local_smoke_test.sh
 ```

--- a/npm/README.md
+++ b/npm/README.md
@@ -15,7 +15,7 @@ npm install -g @qluent/cli
 qluent setup
 ```
 
-This defaults to the hosted Qluent API at `https://api.app.qluent.com`.
+This defaults to the hosted Qluent API at `https://api.app-development.qluent.com`.
 For local backend development, use:
 
 ```bash

--- a/scripts/local_smoke_test.sh
+++ b/scripts/local_smoke_test.sh
@@ -14,7 +14,7 @@ Optional environment variables:
   QLUENT_TEST_API_KEY       API key for a real API smoke test
   QLUENT_TEST_PROJECT_UUID  Project UUID for a real API smoke test
   QLUENT_TEST_USER_EMAIL    User email for a real API smoke test
-  QLUENT_TEST_URL           API base URL (default: https://api.app.qluent.com)
+  QLUENT_TEST_URL           API base URL (default: https://api.app-development.qluent.com)
   QLUENT_TEST_TREE_ID       Optional tree id for an extra trend smoke test
   QLUENT_SMOKE_NPM=1        Also test the local npm wrapper install in an isolated prefix
 
@@ -86,7 +86,7 @@ echo "==> Smoke: claude init"
 )
 
 if [[ -n "${QLUENT_TEST_API_KEY:-}" && -n "${QLUENT_TEST_PROJECT_UUID:-}" && -n "${QLUENT_TEST_USER_EMAIL:-}" ]]; then
-  TEST_URL="${QLUENT_TEST_URL:-https://api.app.qluent.com}"
+  TEST_URL="${QLUENT_TEST_URL:-https://api.app-development.qluent.com}"
 
   echo "==> Smoke: config + live API"
   HOME="$TMP_HOME" "$BINARY_PATH" config \

--- a/src/qluent_cli/auth.py
+++ b/src/qluent_cli/auth.py
@@ -239,12 +239,13 @@ class _CallbackServer(HTTPServer):
 def _api_url_to_ui_url(api_url: str) -> str:
     """Derive the UI base URL from the API base URL.
 
-    Production: https://api.app.qluent.com -> https://app.qluent.com
-    Local:      http://localhost:8001      -> http://localhost:5173
+    Development: https://api.app-development.qluent.com -> https://app-development.qluent.com
+    Local:       http://localhost:8001                   -> http://localhost:5173
     """
     if is_local_url(api_url):
         return "http://localhost:5173"
-    return api_url.replace("api.app.", "app.").rstrip("/")
+    # Strip "api." prefix from hostname
+    return api_url.replace("://api.", "://").rstrip("/")
 
 
 def browser_login(api_url: str) -> CallbackResult:

--- a/src/qluent_cli/config.py
+++ b/src/qluent_cli/config.py
@@ -10,7 +10,7 @@ from typing import Any
 
 CONFIG_DIR = Path.home() / ".qluent"
 CONFIG_FILE = CONFIG_DIR / "config.json"
-DEFAULT_API_URL = "https://api.app.qluent.com"
+DEFAULT_API_URL = "https://api.app-development.qluent.com"
 LOCAL_API_URL = "http://localhost:8001"
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -139,12 +139,12 @@ def test_callback_wrong_path():
         server.shutdown()
 
 
-def test_api_url_to_ui_url_production():
-    assert _api_url_to_ui_url("https://api.app.qluent.com") == "https://app.qluent.com"
+def test_api_url_to_ui_url_development():
+    assert _api_url_to_ui_url("https://api.app-development.qluent.com") == "https://app-development.qluent.com"
 
 
-def test_api_url_to_ui_url_production_trailing_slash():
-    assert _api_url_to_ui_url("https://api.app.qluent.com/") == "https://app.qluent.com"
+def test_api_url_to_ui_url_development_trailing_slash():
+    assert _api_url_to_ui_url("https://api.app-development.qluent.com/") == "https://app-development.qluent.com"
 
 
 def test_api_url_to_ui_url_localhost():

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -1,0 +1,120 @@
+"""Tests for natural-language tree matching helpers."""
+
+from qluent_cli.matching import find_related_trees
+
+
+def test_find_related_trees_ranks_by_similarity():
+    tree_collection = {
+        "trees": [
+            {
+                "id": "revenue",
+                "label": "Revenue",
+                "description": "Total revenue from completed orders",
+                "dimensions": ["channel", "country"],
+                "nodes": [
+                    {"id": "revenue", "label": "Revenue", "kind": "formula"},
+                    {"id": "orders_rev", "label": "Orders Revenue", "kind": "sql_metric"},
+                ],
+            },
+            {
+                "id": "net_revenue",
+                "label": "Net Revenue",
+                "description": "Revenue after refunds and discounts",
+                "dimensions": ["channel", "country"],
+                "nodes": [
+                    {"id": "net_revenue", "label": "Net Revenue", "kind": "formula"},
+                ],
+            },
+            {
+                "id": "order_volume",
+                "label": "Order Volume",
+                "description": "Total completed orders",
+                "dimensions": ["channel", "country"],
+                "nodes": [
+                    {"id": "order_volume", "label": "Order Volume", "kind": "formula"},
+                ],
+            },
+            {
+                "id": "churn_rate",
+                "label": "Churn Rate",
+                "description": "Monthly customer churn percentage",
+                "dimensions": ["segment"],
+                "nodes": [
+                    {"id": "churn_rate", "label": "Churn Rate", "kind": "sql_metric"},
+                ],
+            },
+        ]
+    }
+
+    source = tree_collection["trees"][0]
+    related = find_related_trees(source, tree_collection)
+
+    ids = [r["tree_id"] for r in related]
+    assert "revenue" not in ids
+    assert "net_revenue" in ids
+    assert "order_volume" in ids
+    # Both share strong token overlap; churn_rate shares little
+    assert ids.index("order_volume") < ids.index("churn_rate") if "churn_rate" in ids else True
+    for r in related:
+        assert r["score"] > 0
+        assert r["why"].startswith("Related")
+
+
+def test_find_related_trees_excludes_specified_ids():
+    tree_collection = {
+        "trees": [
+            {
+                "id": "revenue",
+                "label": "Revenue",
+                "description": "Total revenue",
+                "dimensions": ["channel"],
+                "nodes": [],
+            },
+            {
+                "id": "net_revenue",
+                "label": "Net Revenue",
+                "description": "Revenue after refunds",
+                "dimensions": ["channel"],
+                "nodes": [],
+            },
+            {
+                "id": "order_volume",
+                "label": "Order Volume",
+                "description": "Completed orders",
+                "dimensions": ["channel"],
+                "nodes": [],
+            },
+        ]
+    }
+
+    source = tree_collection["trees"][0]
+    related = find_related_trees(
+        source,
+        tree_collection,
+        exclude_ids={"revenue", "net_revenue"},
+    )
+
+    ids = [r["tree_id"] for r in related]
+    assert "net_revenue" not in ids
+    assert "revenue" not in ids
+
+
+def test_find_related_trees_returns_empty_for_no_matches():
+    tree_collection = {"trees": [{"id": "revenue", "label": "Revenue", "dimensions": [], "nodes": []}]}
+    source = tree_collection["trees"][0]
+    assert find_related_trees(source, tree_collection) == []
+
+
+def test_find_related_trees_respects_max_results():
+    tree_collection = {
+        "trees": [
+            {"id": "a", "label": "Revenue A", "description": "Revenue metric", "dimensions": ["channel"], "nodes": []},
+            {"id": "b", "label": "Revenue B", "description": "Revenue metric", "dimensions": ["channel"], "nodes": []},
+            {"id": "c", "label": "Revenue C", "description": "Revenue metric", "dimensions": ["channel"], "nodes": []},
+            {"id": "d", "label": "Revenue D", "description": "Revenue metric", "dimensions": ["channel"], "nodes": []},
+        ]
+    }
+
+    source = tree_collection["trees"][0]
+    related = find_related_trees(source, tree_collection, max_results=2)
+    assert len(related) <= 2


### PR DESCRIPTION
This change introduces a new test file `test_matching.py` that includes unit tests for the natural-language tree matching functionality. The tests cover ranking by similarity, excluding specified tree IDs, handling no matches, and limiting results. Additionally, the default API URL has been updated from `api.app.qluent.com` to `api.app-development.qluent.com` across documentation and configuration files.