### PR TITLE
perf(qluent_cli): remove masked API key output from login message

### DIFF
--- a/src/qluent_cli/main.py
+++ b/src/qluent_cli/main.py
@@ -167,7 +167,6 @@ def login(local: bool) -> None:
     click.echo("Logged in successfully!")
     click.echo(f"  Project: {result.project_uuid}")
     click.echo(f"  Email:   {result.user_email}")
-    click.echo(f"  API key: {mask_key(result.api_key)}")
     click.echo(CONFIG_SAVED_MSG)
 
 


### PR DESCRIPTION
- Removed the line displaying the masked API key from the login success message.
- Maintains display of project UUID, user email, and configuration saved message.
- Improves security by not showing API key information post-login.