### PR TITLE
chore(trees): drop match subcommand and --question flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,17 +55,17 @@ That writes `CLAUDE.md` in the current directory so Claude Code can use the CLI 
 
 ```bash
 qluent trees list
-qluent trees match "Why did revenue drop last week?"
-qluent trees investigate --question "Why did revenue drop last week?" --json-output
 qluent trees trend revenue --periods 4 --grain week
-qluent trees investigate revenue --period "last week"
+qluent trees investigate revenue --period "last week" --json-output
 qluent rca analyze revenue --period "last week"
 ```
 
-For Claude Code, prefer `qluent trees investigate --question ... --json-output`.
-That returns a bundled investigation plus `agent.status`, `agent.top_findings`,
-`agent.gaps`, and `agent.recommended_next_steps` so the model can continue RCA
-without manually inventing the next command.
+For Claude Code, the recommended flow is `qluent trees list --json-output` to
+discover available trees, then `qluent trees investigate <tree_id> --period
+"<period>" --json-output` for the chosen tree. The bundled response includes
+`agent.status`, `agent.top_findings`, `agent.gaps`, and
+`agent.recommended_next_steps` so the model can continue RCA without manually
+inventing the next command.
 
 ## Internal / Direct Python Install
 

--- a/src/qluent_cli/claude_instructions.md
+++ b/src/qluent_cli/claude_instructions.md
@@ -6,8 +6,7 @@ questions about business performance, revenue drivers, cost breakdowns, and tren
 ## Commands
 
 ```bash
-qluent trees list                                           # List available metric trees
-qluent trees match "Why did revenue drop last week?"        # Match a question to the best tree + infer windows
+qluent trees list                                           # List available metric trees (start here for any natural-language question)
 qluent trees get <tree_id>                                  # Show tree hierarchy
 qluent trees validate <tree_id>                             # Validate tree SQL contracts and dimensions
 qluent trees evaluate <tree_id> --period "last week"        # Evaluate with natural language period
@@ -16,8 +15,7 @@ qluent trees levers <tree_id> --period "last week"          # Quantify elasticit
 qluent trees trend <tree_id> --periods 4 --grain week       # Multi-period trend analysis
 qluent trees trend <tree_id> --periods 3 --grain month      # Monthly trend
 qluent trees compare <tree_id> <tree_id> --period "last week"  # Side-by-side tree comparison
-qluent trees investigate revenue --period "last week"       # Validate + trend + evaluate + RCA bundle
-qluent trees investigate --question "Why did revenue drop last week?"  # Match tree + infer windows + bundle RCA
+qluent trees investigate <tree_id> --period "last week"     # Validate + trend + evaluate + RCA bundle
 qluent rca analyze revenue --period "last week"             # Deterministic tree + segment RCA
 ```
 
@@ -30,21 +28,23 @@ Supported periods: "last week", "this week", "last month", "this month", "last q
 
 ## Preferred Claude Code workflow
 
-**IMPORTANT: Always start with `investigate`.** Do NOT manually chain `trend`, `evaluate`,
-`list`, or `rca analyze` commands. The `investigate` command bundles all of these into a
-single call and returns a structured response. Running individual commands is slower,
-more error-prone, and misses the agent-level analysis.
+**Pick a tree, then `investigate`.** The qluent server is deterministic and does
+not match natural-language questions to trees — Claude must select the tree
+client-side and pass it as an explicit positional argument.
 
-Your first command for ANY question about metrics, KPIs, revenue, sales, costs, or
-business performance should be:
+If the user already named the tree (e.g. "investigate revenue last week"), run:
 
 ```bash
-qluent trees investigate --question "<user's question>" --json-output
+qluent trees investigate <tree_id> --period "<period>" --json-output
 ```
 
-If the user already named the tree, use:
+If the user asked a natural-language question without naming a tree, list the
+available trees first and pick the best fit by matching the question against
+each tree's `id`, `label`, `description`, child node labels, and declared
+`dimensions`:
 
 ```bash
+qluent trees list --json-output
 qluent trees investigate <tree_id> --period "<period>" --json-output
 ```
 
@@ -53,6 +53,11 @@ For explicit date ranges:
 ```bash
 qluent trees investigate <tree_id> --current YYYY-MM-DD:YYYY-MM-DD --compare YYYY-MM-DD:YYYY-MM-DD --json-output
 ```
+
+Once you have the bundled response, use it to drive follow-ups: do NOT manually
+chain `trend`, `evaluate`, or `rca analyze` unless `agent.recommended_next_steps`
+calls for it. Running individual commands first is slower, more error-prone,
+and misses the agent-level analysis.
 
 Only use individual commands (`trend`, `evaluate`, `rca analyze`) as follow-up steps
 when `investigate` returns `agent.recommended_next_steps` that call for them.
@@ -69,7 +74,6 @@ Read the investigation bundle in this order:
 Use these rules:
 
 - Prefer `--json-output` when Claude Code is driving the workflow.
-- If `agent.status = needs_tree_selection`, inspect `match.top_candidates` and either pick the strongest tree or ask the user.
 - If `agent.status = needs_more_data` or `partially_resolved`, run the first relevant command from `agent.recommended_next_steps` before inventing your own drill-down.
 - If `agent.status = resolved`, summarize the evidence and stop unless the user explicitly wants a deeper drill-down.
 - Always report the exact current and comparison windows you used.

--- a/src/qluent_cli/client.py
+++ b/src/qluent_cli/client.py
@@ -105,18 +105,6 @@ class QluentClient:
         resp.raise_for_status()
         return resp.json()
 
-    def match_tree(self, question: str) -> dict[str, Any]:
-        """Match a natural-language question to the best metric tree (server-side)."""
-        resp = self._client.post(
-            f"{self._base}/metric-trees/match/",
-            json={
-                "user_email": self._config.user_email,
-                "question": question,
-            },
-        )
-        resp.raise_for_status()
-        return resp.json()
-
     def investigate_tree(
         self,
         tree_id: str,
@@ -125,7 +113,6 @@ class QluentClient:
         comparison_from: str,
         comparison_to: str,
         *,
-        question: str | None = None,
         trend_periods: int = 4,
         trend_grain: str = "week",
         trend_as_of: str | None = None,
@@ -145,7 +132,6 @@ class QluentClient:
             max_segments=max_segments, min_contribution_share=min_contribution_share,
         )
         body.update({
-            "question": question,
             "trend_periods": trend_periods,
             "trend_grain": trend_grain,
             "trend_as_of": trend_as_of,

--- a/src/qluent_cli/formatters.py
+++ b/src/qluent_cli/formatters.py
@@ -87,55 +87,6 @@ def format_tree_list(data: dict[str, Any]) -> str:
     return "\n".join(lines).rstrip()
 
 
-def format_tree_match(data: dict[str, Any]) -> str:
-    """Format natural-language tree matching output."""
-    current_window = data["current_window"]
-    comparison_window = data["comparison_window"]
-    lines = [f'Question: "{data["question"]}"', ""]
-
-    if data.get("matched"):
-        lines.append(
-            f"Matched tree: {data['tree_id']} ({data.get('tree_label') or data['tree_id']})"
-        )
-        lines.append(f"  Score: {data.get('score', 0)}")
-        reasons = data.get("reasons") or []
-        if reasons:
-            lines.append("  Reasons:")
-            for reason in reasons:
-                lines.append(f"    - {reason}")
-    else:
-        decision = data.get("decision") or "no_match"
-        if decision == "ambiguous":
-            lines.append("No unambiguous tree match.")
-        elif decision == "no_trees":
-            lines.append("No metric trees are configured.")
-        else:
-            lines.append("No tree match found.")
-
-    lines.append("")
-    lines.append(
-        "Inferred window: "
-        + format_period_label(
-            current_window["date_from"],
-            current_window["date_to"],
-            comparison_window["date_from"],
-            comparison_window["date_to"],
-        )
-    )
-
-    top_candidates = data.get("top_candidates") or []
-    if top_candidates:
-        lines.append("")
-        lines.append("Top candidates:")
-        for candidate in top_candidates:
-            label = candidate.get("tree_label") or candidate.get("tree_id")
-            lines.append(
-                f"  {candidate.get('tree_id')} ({label}) — score {candidate.get('score', 0)}"
-            )
-
-    return "\n".join(lines)
-
-
 def format_tree_detail(data: dict[str, Any]) -> str:
     """Format a single tree as an indented hierarchy."""
     nodes_by_id = {n["id"]: n for n in data.get("nodes", [])}
@@ -690,7 +641,6 @@ def _fmt_investigation_header(data: dict[str, Any], lines: list[str]) -> str:
     evaluation = data.get("evaluation") or {}
     validation = data.get("validation") or {}
     root_cause = data.get("root_cause") or {}
-    match_result = data.get("match") or {}
     agent = data.get("agent") or {}
     tree_label = (
         evaluation.get("tree_label")
@@ -701,21 +651,6 @@ def _fmt_investigation_header(data: dict[str, Any], lines: list[str]) -> str:
     )
 
     lines.extend([f"{tree_label} Investigation", ""])
-    if data.get("question"):
-        lines.append(f'  Question: "{data["question"]}"')
-    if match_result:
-        if match_result.get("matched"):
-            lines.append(
-                "  Matched tree: "
-                + str(match_result.get("tree_id") or match_result.get("tree_label") or "?")
-            )
-        else:
-            decision = match_result.get("decision") or "no_match"
-            status_label = {
-                "ambiguous": "ambiguous match",
-                "no_trees": "no saved trees",
-            }.get(decision, "no tree match")
-            lines.append(f"  Match status: {status_label}")
     if data.get("period_label"):
         lines.append(f"  Period: {data['period_label']}")
     if data.get("segment_by_used"):

--- a/src/qluent_cli/trees.py
+++ b/src/qluent_cli/trees.py
@@ -1,4 +1,4 @@
-"""Metric tree commands — list, match, evaluate, trend, compare, investigate."""
+"""Metric tree commands — list, evaluate, trend, compare, investigate."""
 
 from __future__ import annotations
 
@@ -19,7 +19,6 @@ from qluent_cli.formatters import (
     format_trend,
     format_tree_detail,
     format_tree_list,
-    format_tree_match,
     format_tree_validation,
 )
 from qluent_cli.utils import parse_filters, resolve_date_args
@@ -212,20 +211,6 @@ def list_trees(as_json: bool) -> None:
 
 
 @trees.command()
-@click.argument("question")
-@click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
-def match(question: str, as_json: bool) -> None:
-    """Match a natural-language question to the best saved metric tree."""
-    client = QluentClient(load_config())
-    result = client.match_tree(question)
-
-    if as_json:
-        click.echo(json.dumps(result, indent=2))
-    else:
-        click.echo(format_tree_match(result))
-
-
-@trees.command()
 @click.argument("tree_id")
 @click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
 def get(tree_id: str, as_json: bool) -> None:
@@ -362,12 +347,7 @@ def compare(
 
 
 @trees.command()
-@click.argument("tree_id", required=False)
-@click.option(
-    "--question",
-    default=None,
-    help="Natural-language investigation prompt. The server will match the best tree and infer windows unless you override them.",
-)
+@click.argument("tree_id")
 @click.option("--period", "-p", default=None, help='Period like "last week" or "this month"')
 @click.option("--current", "current_range", default=None, help="Current window as YYYY-MM-DD:YYYY-MM-DD")
 @click.option("--compare", "compare_range", default=None, help="Comparison window as YYYY-MM-DD:YYYY-MM-DD")
@@ -388,8 +368,7 @@ def compare(
 )
 @click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
 def investigate(
-    tree_id: str | None,
-    question: str | None,
+    tree_id: str,
     period: str | None,
     current_range: str | None,
     compare_range: str | None,
@@ -405,48 +384,17 @@ def investigate(
     min_contribution_share: float,
     as_json: bool,
 ) -> None:
-    """Run a deterministic multi-step investigation bundle for one tree or question."""
-    if bool(tree_id) == bool(question):
-        raise click.UsageError("Provide either TREE_ID or --question.")
-
+    """Run a deterministic multi-step investigation bundle for a tree."""
     client = QluentClient(load_config())
     parsed_filters = parse_filters(filters)
-
-    # When using --question, resolve the tree via server-side matching first
-    if question and not tree_id:
-        match_result = client.match_tree(question)
-        if match_result.get("matched") and match_result.get("tree_id"):
-            tree_id = str(match_result["tree_id"])
-        else:
-            # Return the match result as-is so the caller can see candidates
-            bundle = {
-                "question": question,
-                "match": match_result,
-                "tree_id": None,
-                "agent": {
-                    "status": "needs_tree_selection",
-                    "top_findings": [],
-                    "gaps": ["No unambiguous tree match. See match.top_candidates."],
-                    "recommended_next_steps": [],
-                },
-            }
-            if as_json:
-                click.echo(json.dumps(bundle, indent=2))
-            else:
-                click.echo(format_investigation(bundle))
-            return
-
-    assert tree_id is not None
     c_from, c_to, p_from, p_to = resolve_date_args(period, current_range, compare_range)
 
-    # Delegate full investigation to server
     bundle = client.investigate_tree(
         tree_id,
         c_from,
         c_to,
         p_from,
         p_to,
-        question=question,
         trend_periods=trend_periods,
         trend_grain=trend_grain,
         trend_as_of=trend_as_of,

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -150,112 +150,6 @@ def test_trees_validate_formats_redacted_contract_diagnostics(monkeypatch):
     assert "missing dimensions: country" in result.output
 
 
-def test_trees_match_delegates_to_server(monkeypatch):
-    monkeypatch.setattr(
-        "qluent_cli.trees.load_config",
-        lambda: QluentConfig(
-            api_key="qk_test",
-            api_url="https://api.example.com",
-            project_uuid="project-123",
-            user_email="user@example.com",
-        ),
-    )
-
-    def mock_match_tree(self, question):
-        return {
-            "question": question,
-            "decision": "matched",
-            "matched": True,
-            "tree_id": "revenue",
-            "tree_label": "Revenue",
-            "score": 12,
-            "reasons": ["exact id phrase 'revenue'"],
-            "current_window": {
-                "date_from": "2026-03-09",
-                "date_to": "2026-03-15",
-            },
-            "comparison_window": {
-                "date_from": "2026-03-02",
-                "date_to": "2026-03-08",
-            },
-            "top_candidates": [
-                {"tree_id": "revenue", "score": 12, "reasons": []},
-            ],
-        }
-
-    monkeypatch.setattr("qluent_cli.trees.QluentClient.match_tree", mock_match_tree)
-
-    result = CliRunner().invoke(
-        cli,
-        [
-            "trees",
-            "match",
-            "Why did revenue drop from 2026-03-09 to 2026-03-15 compared with 2026-03-02 to 2026-03-08?",
-            "--json-output",
-        ],
-    )
-
-    assert result.exit_code == 0
-    payload = json.loads(result.output)
-    assert payload["matched"] is True
-    assert payload["decision"] == "matched"
-    assert payload["tree_id"] == "revenue"
-    assert payload["current_window"] == {
-        "date_from": "2026-03-09",
-        "date_to": "2026-03-15",
-    }
-
-
-def test_trees_match_reports_ambiguous_candidates(monkeypatch):
-    monkeypatch.setattr(
-        "qluent_cli.trees.load_config",
-        lambda: QluentConfig(
-            api_key="qk_test",
-            api_url="https://api.example.com",
-            project_uuid="project-123",
-            user_email="user@example.com",
-        ),
-    )
-
-    def mock_match_tree(self, question):
-        return {
-            "question": question,
-            "decision": "ambiguous",
-            "matched": False,
-            "tree_id": None,
-            "tree_label": None,
-            "score": 0,
-            "reasons": [],
-            "current_window": {"date_from": "2026-03-30", "date_to": "2026-04-05"},
-            "comparison_window": {"date_from": "2026-03-23", "date_to": "2026-03-29"},
-            "top_candidates": [
-                {"tree_id": "orders", "score": 4, "reasons": []},
-                {"tree_id": "revenue", "score": 4, "reasons": []},
-            ],
-        }
-
-    monkeypatch.setattr("qluent_cli.trees.QluentClient.match_tree", mock_match_tree)
-
-    result = CliRunner().invoke(
-        cli,
-        [
-            "trees",
-            "match",
-            "Compare revenue and orders",
-            "--json-output",
-        ],
-    )
-
-    assert result.exit_code == 0
-    payload = json.loads(result.output)
-    assert payload["matched"] is False
-    assert payload["decision"] == "ambiguous"
-    assert [candidate["tree_id"] for candidate in payload["top_candidates"][:2]] == [
-        "orders",
-        "revenue",
-    ]
-
-
 def test_trees_levers_outputs_ranked_scenarios(monkeypatch):
     monkeypatch.setattr(
         "qluent_cli.trees.load_config",
@@ -529,67 +423,15 @@ def test_trees_investigate_delegates_to_server(monkeypatch):
     assert investigate_calls[0]["filters"] == {"country": ["SE"]}
 
 
-def test_trees_investigate_matches_question_via_server(monkeypatch):
-    monkeypatch.setattr(
-        "qluent_cli.trees.load_config",
-        lambda: QluentConfig(
-            api_key="qk_test",
-            api_url="https://api.example.com",
-            project_uuid="project-123",
-            user_email="user@example.com",
-        ),
-    )
+def test_trees_investigate_requires_tree_id():
+    result = CliRunner().invoke(cli, ["trees", "investigate"])
 
-    def mock_match_tree(self, question):
-        return {
-            "question": question,
-            "decision": "matched",
-            "matched": True,
-            "tree_id": "revenue",
-            "tree_label": "Revenue",
-            "score": 12,
-            "reasons": [],
-            "current_window": {"date_from": "2026-03-09", "date_to": "2026-03-15"},
-            "comparison_window": {"date_from": "2026-03-02", "date_to": "2026-03-08"},
-            "top_candidates": [],
-        }
+    assert result.exit_code != 0
+    assert "TREE_ID" in result.output or "tree_id" in result.output.lower()
 
-    def mock_investigate_tree(self, tree_id, c_from, c_to, p_from, p_to, **kwargs):
-        return {
-            "question": kwargs.get("question"),
-            "match": {"matched": True, "tree_id": "revenue"},
-            "tree_id": tree_id,
-            "tree_label": "Revenue",
-            "current_window": {"date_from": c_from, "date_to": c_to},
-            "comparison_window": {"date_from": p_from, "date_to": p_to},
-            "agent": {
-                "status": "resolved",
-                "top_findings": ["Orders explain most of the revenue decline."],
-                "gaps": [],
-                "recommended_next_steps": [],
-            },
-        }
 
-    monkeypatch.setattr("qluent_cli.trees.QluentClient.match_tree", mock_match_tree)
-    monkeypatch.setattr(
-        "qluent_cli.trees.QluentClient.investigate_tree", mock_investigate_tree
-    )
+def test_trees_match_subcommand_removed():
+    result = CliRunner().invoke(cli, ["trees", "match", "any question"])
 
-    result = CliRunner().invoke(
-        cli,
-        [
-            "trees",
-            "investigate",
-            "--question",
-            "Why did revenue drop from 2026-03-09 to 2026-03-15 compared with 2026-03-02 to 2026-03-08?",
-            "--json-output",
-        ],
-    )
-
-    assert result.exit_code == 0
-    payload = json.loads(result.output)
-    assert payload["tree_id"] == "revenue"
-    assert payload["agent"]["status"] == "resolved"
-    assert payload["agent"]["top_findings"] == [
-        "Orders explain most of the revenue decline."
-    ]
+    assert result.exit_code != 0
+    assert "no such command" in result.output.lower()


### PR DESCRIPTION
## Summary

- Removes the `qluent trees match` subcommand and the `--question` flag on `qluent trees investigate`. The server's `/metric-trees/match/` endpoint no longer exists, so both code paths fail at runtime.
- `tree_id` is now a required positional on `investigate`. Tree selection is the caller's responsibility — Claude lists trees and picks one client-side (see companion plugin PR).
- Cleans up the corresponding `match_tree` client method, `format_tree_match` formatter, and the `match_result` block inside `format_investigation`.
- Updates `claude_instructions.md` and `README.md` to show the list-first workflow.

## Test plan

- [x] \`uv run pytest tests/\` — 48 passed (3 match/--question tests dropped, 2 new tests added: \`test_trees_investigate_requires_tree_id\`, \`test_trees_match_subcommand_removed\`).
- [x] \`qluent trees match foo\` → \`No such command 'match'\`.
- [x] \`qluent trees investigate --help\` → \`TREE_ID\` shown as required positional, no \`--question\`.
- [ ] Smoke: \`qluent trees investigate revenue --period "last week" --json-output\` against a live project.

## Companion PR

Lands together with the qluent-plugin-cc PR that moves tree selection client-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)