### PR TITLE
chore: bump version to 0.1.8

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qluent/cli",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Install the Qluent CLI",
   "license": "UNLICENSED",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qluent-cli"
-version = "0.1.7"
+version = "0.1.8"
 description = "CLI for Qluent metric tree analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -346,7 +346,7 @@ wheels = [
 
 [[package]]
 name = "qluent-cli"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml`, `npm/package.json`, and `uv.lock` to 0.1.8
- Includes #28 (deterministic tree and rca agent contracts) and #29 (refactor agent contract helpers) since 0.1.7

## Test plan
- [ ] CI green
- [ ] After merge, tag `v0.1.8` to trigger binary build + GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)