### PR TITLE
Add qluent status and whoami

### DIFF
--- a/src/qluent_cli/__init__.py
+++ b/src/qluent_cli/__init__.py
@@ -1,1 +1,3 @@
 """Qluent CLI — metric tree analysis from the command line."""
+
+__version__ = "0.1.8"

--- a/src/qluent_cli/main.py
+++ b/src/qluent_cli/main.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
+from typing import Any
 
 import click
 
+from qluent_cli.client import QluentClient
+from qluent_cli.config import load_config
 from qluent_cli.elasticity import elasticity
+from qluent_cli.formatters import format_tree_list
 from qluent_cli.rca import rca
 from qluent_cli.trees import trees
 
@@ -42,6 +47,112 @@ def _prompt_required(
         if value:
             return value
         click.echo(f"{label} is required")
+
+
+def _tree_metric_labels(tree: dict[str, Any]) -> list[str]:
+    nodes = tree.get("nodes") or []
+    return [
+        str(node.get("label") or node.get("id"))
+        for node in nodes
+        if node.get("kind") == "sql_metric" and (node.get("label") or node.get("id"))
+    ]
+
+
+def _build_status_payload() -> dict[str, Any]:
+    try:
+        config = load_config()
+    except SystemExit as exc:
+        return {
+            "connected": False,
+            "error": str(exc),
+            "login_command": "qluent login",
+        }
+
+    client = QluentClient(config)
+    trees_data = client.list_trees()
+    normalized_trees = []
+    for tree in trees_data.get("trees", []):
+        normalized_trees.append(
+            {
+                "id": tree.get("id"),
+                "label": tree.get("label") or tree.get("id"),
+                "description": tree.get("description"),
+                "metrics": _tree_metric_labels(tree),
+            }
+        )
+
+    first_tree = normalized_trees[0]["id"] if normalized_trees else "<tree_id>"
+    return {
+        "connected": True,
+        "project": {
+            "uuid": config.project_uuid,
+            "api_url": config.api_url,
+            "user_email": config.user_email,
+            "client_safe": config.client_safe,
+        },
+        "trees": normalized_trees,
+        "suggested_first_command": (
+            f'qluent trees investigate {first_tree} --period "last month" --json-output'
+        ),
+    }
+
+
+def _format_status(payload: dict[str, Any]) -> str:
+    if not payload.get("connected"):
+        lines = ["Not connected to Qluent"]
+        if payload.get("error"):
+            lines.extend(["", str(payload["error"])])
+        lines.extend(["", "Run: qluent login"])
+        return "\n".join(lines)
+
+    project = payload["project"]
+    lines = [
+        "Connected to Qluent",
+        "",
+        "Project",
+        f"  UUID: {project['uuid']}",
+        f"  API: {project['api_url']}",
+        f"  User: {project['user_email']}",
+        f"  Client safe: {project['client_safe']}",
+        "",
+        "Available trees",
+    ]
+    trees_payload = {"trees": payload.get("trees", [])}
+    if payload.get("trees"):
+        for tree in trees_payload["trees"]:
+            metrics = ", ".join(tree.get("metrics") or [])
+            detail = f"  {tree['id']}"
+            if metrics:
+                detail += f"             {metrics}"
+            elif tree.get("label"):
+                detail += f"             {tree['label']}"
+            lines.append(detail)
+    else:
+        lines.append(format_tree_list(trees_payload))
+    lines.extend(["", "Suggested first command", f"  {payload['suggested_first_command']}"])
+    return "\n".join(lines)
+
+
+def _print_status(as_json: bool) -> None:
+    payload = _build_status_payload()
+    if as_json:
+        click.echo(json.dumps(payload, indent=2))
+    else:
+        click.echo(_format_status(payload))
+
+
+@cli.command()
+@click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
+def status(as_json: bool) -> None:
+    """Show the connected project, API environment, user, and available trees."""
+    _print_status(as_json)
+
+
+@cli.command()
+@click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
+def whoami(as_json: bool) -> None:
+    """Alias for status."""
+    _print_status(as_json)
 
 
 @cli.command()

--- a/src/qluent_cli/main.py
+++ b/src/qluent_cli/main.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import click
 
+from qluent_cli import __version__
 from qluent_cli.client import QluentClient
 from qluent_cli.config import load_config
 from qluent_cli.elasticity import elasticity
@@ -18,6 +19,7 @@ from qluent_cli.trees import trees
 
 
 @click.group()
+@click.version_option(version=__version__, prog_name="qluent")
 def cli() -> None:
     """Qluent — metric tree analysis from the command line."""
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -8,6 +8,13 @@ from qluent_cli import config as config_module
 from qluent_cli.main import cli
 
 
+def test_version_outputs_package_version():
+    result = CliRunner().invoke(cli, ["--version"])
+
+    assert result.exit_code == 0
+    assert "qluent, version 0.1.8" in result.output
+
+
 def test_setup_saves_config_and_writes_claude_md(monkeypatch, isolated_config, tmp_path):
     _config_dir, config_file = isolated_config
     monkeypatch.chdir(tmp_path)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -97,3 +97,82 @@ def test_claude_init_requires_force_to_overwrite(monkeypatch, tmp_path):
 
     assert result.exit_code != 0
     assert "already exists" in result.output
+
+
+def test_status_outputs_connected_project_and_trees(monkeypatch):
+    monkeypatch.setattr(
+        "qluent_cli.main.load_config",
+        lambda: config_module.QluentConfig(
+            api_key="qk_test",
+            api_url="https://api.example.com",
+            project_uuid="project-123",
+            user_email="user@example.com",
+        ),
+    )
+
+    def mock_list_trees(self):
+        return {
+            "trees": [
+                {
+                    "id": "revenue",
+                    "label": "Revenue",
+                    "nodes": [
+                        {"id": "net_revenue", "label": "Net Revenue", "kind": "sql_metric"},
+                        {"id": "orders", "label": "Orders", "kind": "sql_metric"},
+                    ],
+                }
+            ]
+        }
+
+    monkeypatch.setattr("qluent_cli.main.QluentClient.list_trees", mock_list_trees)
+
+    result = CliRunner().invoke(cli, ["status"])
+
+    assert result.exit_code == 0
+    assert "Connected to Qluent" in result.output
+    assert "UUID: project-123" in result.output
+    assert "API: https://api.example.com" in result.output
+    assert "User: user@example.com" in result.output
+    assert "revenue" in result.output
+    assert "Net Revenue, Orders" in result.output
+    assert 'qluent trees investigate revenue --period "last month" --json-output' in result.output
+
+
+def test_whoami_json_outputs_agent_friendly_status(monkeypatch):
+    monkeypatch.setattr(
+        "qluent_cli.main.load_config",
+        lambda: config_module.QluentConfig(
+            api_key="qk_test",
+            api_url="https://api.example.com",
+            project_uuid="project-123",
+            user_email="user@example.com",
+            client_safe=True,
+        ),
+    )
+    monkeypatch.setattr("qluent_cli.main.QluentClient.list_trees", lambda self: {"trees": []})
+
+    result = CliRunner().invoke(cli, ["whoami", "--json-output"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["connected"] is True
+    assert payload["project"] == {
+        "uuid": "project-123",
+        "api_url": "https://api.example.com",
+        "user_email": "user@example.com",
+        "client_safe": True,
+    }
+    assert payload["trees"] == []
+
+
+def test_status_explains_login_when_not_configured(monkeypatch):
+    def missing_config():
+        raise SystemExit("No API key configured. Run: qluent login")
+
+    monkeypatch.setattr("qluent_cli.main.load_config", missing_config)
+
+    result = CliRunner().invoke(cli, ["status"])
+
+    assert result.exit_code == 0
+    assert "Not connected to Qluent" in result.output
+    assert "Run: qluent login" in result.output


### PR DESCRIPTION
## Summary
- add `qluent status` and `qluent whoami` with human-readable and JSON output
- include connected project context, API URL, user email, client-safe mode, available trees, and a suggested first command
- show a clear `qluent login` hint when config is missing

Fixes #32.

## Tests
- `uv run pytest tests/test_setup.py`
