### PR TITLE
Add project-specific suggestions command

### DIFF
--- a/src/qluent_cli/claude_instructions.md
+++ b/src/qluent_cli/claude_instructions.md
@@ -7,6 +7,7 @@ questions about business performance, revenue drivers, cost breakdowns, and tren
 
 ```bash
 qluent trees list                                           # List available metric trees (start here for any natural-language question)
+qluent suggestions --json-output                           # Project-specific example questions and commands
 qluent trees get <tree_id>                                  # Show tree hierarchy
 qluent trees validate <tree_id>                             # Validate tree SQL contracts and dimensions
 qluent trees evaluate <tree_id> --period "last week"        # Evaluate with natural language period
@@ -38,6 +39,12 @@ If the user already named the tree (e.g. "investigate revenue last week"), run:
 
 ```bash
 qluent trees investigate <tree_id> --period "<period>" --json-output
+```
+
+If the user asked what they can do with the connected project, run:
+
+```bash
+qluent suggestions --json-output
 ```
 
 If the user asked a natural-language question without naming a tree, list the

--- a/src/qluent_cli/main.py
+++ b/src/qluent_cli/main.py
@@ -9,6 +9,7 @@ import click
 
 from qluent_cli.elasticity import elasticity
 from qluent_cli.rca import rca
+from qluent_cli.suggestions import suggestions
 from qluent_cli.trees import trees
 
 
@@ -253,6 +254,7 @@ def setup(claude_path: str, local: bool, force: bool) -> None:
 cli.add_command(trees)
 cli.add_command(rca)
 cli.add_command(elasticity)
+cli.add_command(suggestions)
 
 INSTRUCTIONS_FILENAME = "claude_instructions.md"
 

--- a/src/qluent_cli/suggestions.py
+++ b/src/qluent_cli/suggestions.py
@@ -1,0 +1,190 @@
+"""Project-specific suggestion command."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import click
+
+from qluent_cli.client import QluentClient
+from qluent_cli.config import load_config
+
+
+def _node_label(node: dict[str, Any]) -> str:
+    return str(node.get("label") or node.get("id") or "metric")
+
+
+def _node_id(node: dict[str, Any]) -> str:
+    return str(node.get("id") or node.get("node_id") or "")
+
+
+def _tree_dimensions(tree: dict[str, Any]) -> list[str]:
+    candidates = (
+        tree.get("dimensions")
+        or tree.get("supported_dimensions")
+        or tree.get("dimensions_declared")
+        or []
+    )
+    return [str(item) for item in candidates if item]
+
+
+def _metric_nodes(tree: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        node
+        for node in tree.get("nodes", [])
+        if node.get("kind") == "sql_metric" and (_node_id(node) or _node_label(node))
+    ]
+
+
+def _root_node(tree: dict[str, Any]) -> dict[str, Any] | None:
+    root_id = tree.get("root_node_id")
+    if root_id:
+        for node in tree.get("nodes", []):
+            if node.get("id") == root_id or node.get("node_id") == root_id:
+                return node
+    return (tree.get("nodes") or [None])[0]
+
+
+def build_suggestions(trees_data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Build deterministic project-specific example questions from tree metadata."""
+    trees = trees_data.get("trees") or []
+    suggestions: list[dict[str, Any]] = []
+
+    for index, tree in enumerate(trees):
+        tree_id = str(tree.get("id") or "")
+        if not tree_id:
+            continue
+        tree_label = str(tree.get("label") or tree_id)
+        root = _root_node(tree) or {}
+        root_label = _node_label(root) if root else tree_label
+        root_id = _node_id(root) or tree_id
+        metrics = _metric_nodes(tree)
+        dimensions = _tree_dimensions(tree)
+
+        suggestions.append(
+            {
+                "tree_id": tree_id,
+                "tree_label": tree_label,
+                "analysis_type": "rca",
+                "example_question": f"Why did {root_label} change last complete month?",
+                "recommended_command": (
+                    f'qluent trees investigate {tree_id} --period "last month" --json-output'
+                ),
+                "rationale": "Uses the tree RCA bundle for root-cause, trend, segment, and lever evidence.",
+            }
+        )
+        suggestions.append(
+            {
+                "tree_id": tree_id,
+                "tree_label": tree_label,
+                "analysis_type": "trend",
+                "example_question": f"Is {root_label} trending consistently over recent weeks?",
+                "recommended_command": (
+                    f"qluent trees trend {tree_id} --periods 4 --grain week --json-output"
+                ),
+                "rationale": "The tree supports multi-period evaluation through its root metric.",
+            }
+        )
+
+        if dimensions:
+            dimension = dimensions[0]
+            suggestions.append(
+                {
+                    "tree_id": tree_id,
+                    "tree_label": tree_label,
+                    "analysis_type": "segmentation",
+                    "example_question": (
+                        f"Which {dimension} segment concentrated the {root_label} movement?"
+                    ),
+                    "recommended_command": (
+                        f'qluent trees investigate {tree_id} --period "last month" '
+                        f"--segment-by {dimension} --json-output"
+                    ),
+                    "rationale": (
+                        f"Tree metadata exposes the `{dimension}` dimension for segment RCA."
+                    ),
+                }
+            )
+
+        if len(metrics) >= 2:
+            lever = metrics[0]
+            if _node_id(lever) == root_id and len(metrics) > 1:
+                lever = metrics[1]
+            suggestions.append(
+                {
+                    "tree_id": tree_id,
+                    "tree_label": tree_label,
+                    "analysis_type": "elasticity",
+                    "example_question": (
+                        f"Which lever should we inspect to move {root_label}?"
+                    ),
+                    "recommended_command": (
+                        f'qluent trees levers {tree_id} --period "last month" --json-output'
+                    ),
+                    "rationale": (
+                        f"Tree includes metric nodes such as `{_node_id(lever) or _node_label(lever)}` "
+                        "that can be ranked as levers when evaluation returns elasticities."
+                    ),
+                }
+            )
+
+        compare_target = next(
+            (
+                str(other.get("id"))
+                for offset, other in enumerate(trees)
+                if offset != index and other.get("id")
+            ),
+            None,
+        )
+        if compare_target:
+            suggestions.append(
+                {
+                    "tree_id": tree_id,
+                    "tree_label": tree_label,
+                    "analysis_type": "compare",
+                    "example_question": (
+                        f"Does {tree_label} move with {compare_target} over the same period?"
+                    ),
+                    "recommended_command": (
+                        f'qluent trees compare {tree_id} {compare_target} --period "last month" '
+                        "--json-output"
+                    ),
+                    "rationale": "Compare only uses tree ids advertised by the connected project.",
+                }
+            )
+
+    return suggestions
+
+
+def format_suggestions(suggestions: list[dict[str, Any]]) -> str:
+    if not suggestions:
+        return "No project-specific suggestions available."
+
+    lines: list[str] = []
+    current_tree: str | None = None
+    for suggestion in suggestions:
+        tree_label = str(suggestion["tree_label"])
+        if tree_label != current_tree:
+            if lines:
+                lines.append("")
+            lines.append(tree_label)
+            current_tree = tree_label
+        lines.append(f"- {suggestion['example_question']}")
+    return "\n".join(lines)
+
+
+@click.command()
+@click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
+def suggestions(as_json: bool) -> None:
+    """Show project-specific example questions for available metric trees."""
+    config = load_config()
+    client = QluentClient(config)
+    data = {
+        "suggestions": build_suggestions(client.list_trees()),
+    }
+
+    if as_json:
+        click.echo(json.dumps(data, indent=2))
+    else:
+        click.echo(format_suggestions(data["suggestions"]))

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from qluent_cli.config import QluentConfig
+from qluent_cli.main import cli
+from qluent_cli.suggestions import build_suggestions
+
+
+TREE_DATA = {
+    "trees": [
+        {
+            "id": "revenue",
+            "label": "Revenue",
+            "root_node_id": "net_revenue",
+            "dimensions": ["region", "channel"],
+            "nodes": [
+                {"id": "net_revenue", "label": "Net Revenue", "kind": "formula"},
+                {"id": "orders", "label": "Orders", "kind": "sql_metric"},
+                {"id": "aov", "label": "AOV", "kind": "sql_metric"},
+            ],
+        },
+        {
+            "id": "growth",
+            "label": "Growth",
+            "root_node_id": "active_users",
+            "nodes": [
+                {"id": "active_users", "label": "Active Users", "kind": "sql_metric"},
+                {"id": "frequency", "label": "Orders/User", "kind": "sql_metric"},
+            ],
+        },
+    ]
+}
+
+
+def test_build_suggestions_derives_examples_from_tree_metadata():
+    suggestions = build_suggestions(TREE_DATA)
+
+    assert {item["analysis_type"] for item in suggestions} >= {
+        "rca",
+        "segmentation",
+        "trend",
+        "elasticity",
+        "compare",
+    }
+    revenue_suggestions = [item for item in suggestions if item["tree_id"] == "revenue"]
+    assert any("Net Revenue" in item["example_question"] for item in revenue_suggestions)
+    assert any("--segment-by region" in item["recommended_command"] for item in revenue_suggestions)
+    assert any(
+        item["recommended_command"]
+        == 'qluent trees compare revenue growth --period "last month" --json-output'
+        for item in revenue_suggestions
+    )
+
+
+def test_suggestions_json_output_contains_agent_fields(monkeypatch):
+    monkeypatch.setattr(
+        "qluent_cli.suggestions.load_config",
+        lambda: QluentConfig(
+            api_key="qk_test",
+            api_url="https://api.example.com",
+            project_uuid="project-123",
+            user_email="user@example.com",
+        ),
+    )
+    monkeypatch.setattr("qluent_cli.suggestions.QluentClient.list_trees", lambda self: TREE_DATA)
+
+    result = CliRunner().invoke(cli, ["suggestions", "--json-output"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    first = payload["suggestions"][0]
+    assert {
+        "tree_id",
+        "tree_label",
+        "example_question",
+        "recommended_command",
+        "rationale",
+    } <= set(first)
+    assert first["tree_id"] == "revenue"
+
+
+def test_suggestions_human_output_groups_by_tree(monkeypatch):
+    monkeypatch.setattr(
+        "qluent_cli.suggestions.load_config",
+        lambda: QluentConfig(
+            api_key="qk_test",
+            api_url="https://api.example.com",
+            project_uuid="project-123",
+            user_email="user@example.com",
+        ),
+    )
+    monkeypatch.setattr("qluent_cli.suggestions.QluentClient.list_trees", lambda self: TREE_DATA)
+
+    result = CliRunner().invoke(cli, ["suggestions"])
+
+    assert result.exit_code == 0
+    assert "Revenue\n- Why did Net Revenue change last complete month?" in result.output
+    assert "Growth\n- Why did Active Users change last complete month?" in result.output


### PR DESCRIPTION
## Summary
- add `qluent suggestions` with human-readable and JSON output
- derive RCA, trend, segmentation, lever, and compare examples from connected tree metadata
- include tree id, tree label, example question, recommended command, and rationale for agent use
- update generated Claude instructions to use suggestions for first-run onboarding

Fixes #31.

## Tests
- `uv run pytest tests/test_suggestions.py tests/test_setup.py`
