### PR TITLE
chore: bump version to 0.1.9

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qluent/cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Install the Qluent CLI",
   "license": "UNLICENSED",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qluent-cli"
-version = "0.1.8"
+version = "0.1.9"
 description = "CLI for Qluent metric tree analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/qluent_cli/__init__.py
+++ b/src/qluent_cli/__init__.py
@@ -1,3 +1,3 @@
 """Qluent CLI — metric tree analysis from the command line."""
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"


### PR DESCRIPTION
Bumps `pyproject.toml`, `src/qluent_cli/__init__.py`, and `npm/package.json` from 0.1.8 to 0.1.9 to release the status/whoami/--version commands and recent additions on main.

After merge: push the `v0.1.9` tag to trigger the binary build workflow, then `npm publish --access restricted` from `npm/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)