### PR TITLE
Auto-install Claude Code plugin from qluent login

### DIFF
--- a/src/qluent_cli/main.py
+++ b/src/qluent_cli/main.py
@@ -261,7 +261,13 @@ def _confirm_and_write_claude_file(target: Path, *, force: bool) -> None:
     is_flag=True,
     help="Use the local API at http://localhost:8001 and local UI at http://localhost:5173.",
 )
-def login(local: bool) -> None:
+@click.option(
+    "--install-plugin/--no-install-plugin",
+    "install_plugin",
+    default=None,
+    help="Install the qluent Claude Code plugin without prompting (or skip the prompt).",
+)
+def login(local: bool, install_plugin: bool | None) -> None:
     """Log in via browser (opens qluent-ui for SSO authentication)."""
     from qluent_cli.auth import browser_login
     from qluent_cli.config import (
@@ -271,6 +277,7 @@ def login(local: bool) -> None:
         default_client_safe,
         save_config,
     )
+    from qluent_cli.plugin import offer_claude_plugin_install
 
     api_url = LOCAL_API_URL if local else DEFAULT_API_URL
 
@@ -294,6 +301,7 @@ def login(local: bool) -> None:
     click.echo(CONFIG_SAVED_MSG)
 
     _confirm_and_write_claude_file(Path("CLAUDE.md"), force=False)
+    offer_claude_plugin_install(install_plugin)
 
 
 @cli.command()
@@ -309,7 +317,15 @@ def login(local: bool) -> None:
     help="Use the local API at http://localhost:8001.",
 )
 @click.option("--force", is_flag=True, help="Overwrite an existing CLAUDE.md without prompting.")
-def setup(claude_path: str, local: bool, force: bool) -> None:
+@click.option(
+    "--install-plugin/--no-install-plugin",
+    "install_plugin",
+    default=None,
+    help="Install the qluent Claude Code plugin without prompting (or skip the prompt).",
+)
+def setup(
+    claude_path: str, local: bool, force: bool, install_plugin: bool | None
+) -> None:
     """Interactive first-run setup for client installations."""
     click.echo("Tip: Use 'qluent login' for browser-based login (recommended).\n")
 
@@ -321,6 +337,7 @@ def setup(claude_path: str, local: bool, force: bool) -> None:
         load_raw_config,
         save_config,
     )
+    from qluent_cli.plugin import offer_claude_plugin_install
 
     existing = load_raw_config()
 
@@ -357,11 +374,12 @@ def setup(claude_path: str, local: bool, force: bool) -> None:
         f"Write Claude Code instructions to {target}?",
         default=True,
     )
-    if not write_claude:
+    if write_claude:
+        _confirm_and_write_claude_file(target, force=force)
+    else:
         click.echo("Skipped CLAUDE.md generation")
-        return
 
-    _confirm_and_write_claude_file(target, force=force)
+    offer_claude_plugin_install(install_plugin)
 
 
 cli.add_command(trees)

--- a/src/qluent_cli/plugin.py
+++ b/src/qluent_cli/plugin.py
@@ -1,0 +1,88 @@
+"""Claude Code plugin auto-install helpers.
+
+Wraps `claude plugin marketplace add` and `claude plugin install` so
+`qluent login` / `qluent setup` can offer to wire up the qluent plugin
+without the user having to run the slash commands manually.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+import click
+
+MARKETPLACE_SOURCE = "qluent/qluent-plugin-cc"
+MARKETPLACE_NAME = "qluent-metric-trees"
+PLUGIN_ID = f"qluent@{MARKETPLACE_NAME}"
+
+
+def claude_cli_available() -> bool:
+    return shutil.which("claude") is not None
+
+
+def _run(cmd: list[str]) -> tuple[bool, str]:
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    except OSError as exc:
+        return False, str(exc)
+    if result.returncode != 0:
+        message = (result.stderr or result.stdout or "").strip()
+        return False, message or f"exit {result.returncode}"
+    return True, ""
+
+
+def install_claude_plugin() -> bool:
+    """Add the marketplace and install the plugin.
+
+    Both subcommands are idempotent — they exit 0 with an "already installed"
+    message when the marketplace/plugin is already on disk.
+    """
+    steps = (
+        ["claude", "plugin", "marketplace", "add", MARKETPLACE_SOURCE],
+        ["claude", "plugin", "install", PLUGIN_ID],
+    )
+    for cmd in steps:
+        ok, message = _run(cmd)
+        if not ok:
+            click.echo(f"  Failed: {' '.join(cmd[1:])}", err=True)
+            if message:
+                click.echo(f"  {message}", err=True)
+            return False
+    return True
+
+
+def _manual_hint() -> str:
+    return (
+        "Install Claude Code (https://claude.ai/code), then run:\n"
+        f"  claude plugin marketplace add {MARKETPLACE_SOURCE}\n"
+        f"  claude plugin install {PLUGIN_ID}"
+    )
+
+
+def offer_claude_plugin_install(install_plugin: bool | None) -> None:
+    """Install (or skip) the qluent Claude Code plugin.
+
+    install_plugin:
+      - True  : install without prompting
+      - False : skip silently
+      - None  : prompt (default Yes)
+    """
+    if install_plugin is False:
+        return
+
+    if not claude_cli_available():
+        if install_plugin is True:
+            click.echo(_manual_hint())
+        else:
+            click.echo("Claude Code CLI not detected. " + _manual_hint())
+        return
+
+    if install_plugin is None:
+        if not click.confirm(
+            "Install the qluent plugin in Claude Code?", default=True
+        ):
+            return
+
+    if install_claude_plugin():
+        click.echo(f"Claude Code plugin ready: {PLUGIN_ID}")

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -32,7 +32,7 @@ def test_login_saves_config_on_success(monkeypatch, isolated_config):
         ),
     )
 
-    result = CliRunner().invoke(cli, ["login"])
+    result = CliRunner().invoke(cli, ["login", "--no-install-plugin"])
 
     assert result.exit_code == 0
     assert "Logged in successfully" in result.output
@@ -54,7 +54,7 @@ def test_login_shows_error_on_failure(monkeypatch, isolated_config):
         ),
     )
 
-    result = CliRunner().invoke(cli, ["login"])
+    result = CliRunner().invoke(cli, ["login", "--no-install-plugin"])
 
     assert result.exit_code != 0
     assert "Login failed" in result.output
@@ -74,7 +74,7 @@ def test_login_local_flag_uses_local_url(monkeypatch, isolated_config):
     )
     monkeypatch.setattr("qluent_cli.auth.browser_login", fake)
 
-    result = CliRunner().invoke(cli, ["login", "--local"])
+    result = CliRunner().invoke(cli, ["login", "--local", "--no-install-plugin"])
 
     assert result.exit_code == 0
     assert fake.called_with_url == config_module.LOCAL_API_URL  # type: ignore[attr-defined]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+from click.testing import CliRunner
+
+from qluent_cli import plugin as plugin_module
+from qluent_cli.auth import CallbackResult
+from qluent_cli.main import cli
+
+
+@pytest.fixture
+def fake_browser_login(monkeypatch):
+    def fake(api_url: str) -> CallbackResult:
+        return CallbackResult(
+            success=True,
+            api_key="qk_plugin_test",
+            project_uuid="proj-plugin",
+            user_email="plugin@test.com",
+        )
+
+    monkeypatch.setattr("qluent_cli.auth.browser_login", fake)
+
+
+def _completed(returncode: int = 0, stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout="", stderr=stderr
+    )
+
+
+def test_offer_install_skips_when_flag_false(monkeypatch):
+    called = SimpleNamespace(value=False)
+    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
+    monkeypatch.setattr(
+        plugin_module,
+        "install_claude_plugin",
+        lambda: setattr(called, "value", True) or True,
+    )
+
+    plugin_module.offer_claude_plugin_install(False)
+
+    assert called.value is False
+
+
+def test_offer_install_runs_when_flag_true(monkeypatch):
+    calls = []
+    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
+    monkeypatch.setattr(
+        plugin_module,
+        "install_claude_plugin",
+        lambda: calls.append("ran") or True,
+    )
+
+    plugin_module.offer_claude_plugin_install(True)
+
+    assert calls == ["ran"]
+
+
+def test_offer_install_prints_hint_when_claude_missing(monkeypatch, capsys):
+    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: False)
+
+    plugin_module.offer_claude_plugin_install(None)
+
+    out = capsys.readouterr().out
+    assert "Claude Code CLI not detected" in out
+    assert "claude plugin marketplace add" in out
+
+
+def test_install_claude_plugin_runs_both_steps(monkeypatch):
+    commands = []
+
+    def fake_run(cmd, capture_output, text, check):
+        commands.append(cmd)
+        return _completed()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert plugin_module.install_claude_plugin() is True
+    assert commands == [
+        ["claude", "plugin", "marketplace", "add", plugin_module.MARKETPLACE_SOURCE],
+        ["claude", "plugin", "install", plugin_module.PLUGIN_ID],
+    ]
+
+
+def test_install_claude_plugin_returns_false_on_step_failure(monkeypatch, capsys):
+    def fake_run(cmd, capture_output, text, check):
+        return _completed(returncode=1, stderr="boom")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert plugin_module.install_claude_plugin() is False
+    err = capsys.readouterr().err
+    assert "Failed: plugin marketplace add" in err
+    assert "boom" in err
+
+
+def test_login_install_plugin_flag_invokes_install(monkeypatch, isolated_config, fake_browser_login):
+    called = []
+    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
+    monkeypatch.setattr(
+        plugin_module,
+        "install_claude_plugin",
+        lambda: called.append("ran") or True,
+    )
+
+    result = CliRunner().invoke(cli, ["login", "--install-plugin"])
+
+    assert result.exit_code == 0
+    assert called == ["ran"]
+    assert plugin_module.PLUGIN_ID in result.output
+
+
+def test_login_no_install_plugin_skips(monkeypatch, isolated_config, fake_browser_login):
+    called = []
+    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
+    monkeypatch.setattr(
+        plugin_module,
+        "install_claude_plugin",
+        lambda: called.append("ran") or True,
+    )
+
+    result = CliRunner().invoke(cli, ["login", "--no-install-plugin"])
+
+    assert result.exit_code == 0
+    assert called == []
+
+
+def test_login_prompt_declined(monkeypatch, isolated_config, fake_browser_login):
+    called = []
+    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
+    monkeypatch.setattr(
+        plugin_module,
+        "install_claude_plugin",
+        lambda: called.append("ran") or True,
+    )
+
+    # First "n" declines CLAUDE.md overwrite (file exists in repo root),
+    # second "n" declines plugin install.
+    result = CliRunner().invoke(cli, ["login"], input="n\nn\n")
+
+    assert result.exit_code == 0
+    assert called == []

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -21,7 +21,7 @@ def test_setup_saves_config_and_writes_claude_md(monkeypatch, isolated_config, t
 
     result = CliRunner().invoke(
         cli,
-        ["setup"],
+        ["setup", "--no-install-plugin"],
         input=(
             "qk_test\n"
             "project-123\n"
@@ -50,7 +50,7 @@ def test_setup_uses_production_default_api_url(monkeypatch, isolated_config, tmp
 
     result = CliRunner().invoke(
         cli,
-        ["setup"],
+        ["setup", "--no-install-plugin"],
         input=(
             "qk_test\n"
             "project-123\n"
@@ -60,6 +60,7 @@ def test_setup_uses_production_default_api_url(monkeypatch, isolated_config, tmp
     )
 
     assert result.exit_code == 0
+    assert "Skipped CLAUDE.md generation" in result.output
     saved = json.loads(config_file.read_text())
     assert saved["api_url"] == config_module.DEFAULT_API_URL
 
@@ -70,7 +71,7 @@ def test_setup_local_flag_prefills_local_api_url(monkeypatch, isolated_config, t
 
     result = CliRunner().invoke(
         cli,
-        ["setup", "--local"],
+        ["setup", "--local", "--no-install-plugin"],
         input=(
             "qk_test\n"
             "project-123\n"

--- a/uv.lock
+++ b/uv.lock
@@ -346,7 +346,7 @@ wheels = [
 
 [[package]]
 name = "qluent-cli"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- After `qluent login` (and `qluent setup`), prompt to install the Claude Code plugin via `claude plugin marketplace add qluent/qluent-plugin-cc` + `claude plugin install qluent@qluent-metric-trees` — removes the manual `/plugin marketplace add` + `/reload-plugins` step from the first-run flow.
- Both subcommands are idempotent (exit 0 with "already installed"), so re-running is safe.
- Adds `--install-plugin` / `--no-install-plugin` flags for non-interactive use; prints a manual-install hint when the `claude` CLI is missing from PATH.

## Test plan
- [x] `uv run pytest` (70 passed, 1 pre-existing version-string test deselected)
- [ ] Manual: fresh shell with `claude` on PATH, run `qluent login`, accept prompt, verify `claude plugin list` shows `qluent@qluent-metric-trees`
- [ ] Manual: re-run `qluent login --install-plugin`, confirm idempotent ("already installed" messages, exit 0)
- [ ] Manual: temporarily hide `claude` from PATH, run `qluent login`, confirm hint is printed and login still succeeds
- [ ] Manual: `qluent login --no-install-plugin` skips silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)