### PR TITLE
Add qluent trees deep-dive for cross-tree investigations

### DIFF
--- a/src/qluent_cli/trees.py
+++ b/src/qluent_cli/trees.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import shlex
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date as dt_date
 from typing import Any
 
@@ -526,3 +527,134 @@ def investigate(
         click.echo(json.dumps(bundle, indent=2))
     else:
         click.echo(format_investigation(bundle))
+
+
+@trees.command(name="deep-dive")
+@click.option("--period", "-p", default=None, help='Period like "last week" or "this month"')
+@click.option("--current", "current_range", default=None, help="Current window as YYYY-MM-DD:YYYY-MM-DD")
+@click.option("--compare", "compare_range", default=None, help="Comparison window as YYYY-MM-DD:YYYY-MM-DD")
+@click.option(
+    "--tree",
+    "tree_ids",
+    multiple=True,
+    help="Limit to specific trees (repeatable). Defaults to every tree in the project.",
+)
+@click.option("--trend-periods", default=4, type=click.IntRange(1, 52))
+@click.option("--trend-grain", default="week", type=click.Choice(["week", "month"]))
+@click.option("--trend-as-of", default=None, help="Reference date for bundled trend as YYYY-MM-DD")
+@click.option("--max-depth", default=3, type=click.IntRange(1, 6))
+@click.option("--max-branches", default=2, type=click.IntRange(1, 10))
+@click.option("--max-segments", default=5, type=click.IntRange(1, 20))
+@click.option(
+    "--min-contribution-share",
+    default=0.1,
+    type=click.FloatRange(0.0, 1.0),
+)
+@click.option(
+    "--max-workers",
+    default=4,
+    type=click.IntRange(1, 8),
+    help="Maximum number of trees to investigate in parallel.",
+)
+@click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
+def deep_dive(
+    period: str | None,
+    current_range: str | None,
+    compare_range: str | None,
+    tree_ids: tuple[str, ...],
+    trend_periods: int,
+    trend_grain: str,
+    trend_as_of: str | None,
+    max_depth: int,
+    max_branches: int,
+    max_segments: int,
+    min_contribution_share: float,
+    max_workers: int,
+    as_json: bool,
+) -> None:
+    """Run investigations across every tree in parallel and bundle the results."""
+    client = QluentClient(load_config())
+    c_from, c_to, p_from, p_to = resolve_date_args(period, current_range, compare_range)
+
+    trees_data = client.list_trees()
+    available = [t.get("id") for t in trees_data.get("trees", []) if t.get("id")]
+
+    if tree_ids:
+        unknown = sorted(set(tree_ids) - set(available))
+        if unknown:
+            raise click.ClickException(
+                f"Unknown tree(s): {', '.join(unknown)}. Available: {', '.join(available)}"
+            )
+        targets = list(tree_ids)
+    else:
+        targets = available
+
+    if not targets:
+        raise click.ClickException("No trees available for this project.")
+
+    available_tree_ids, metrics_by_tree = _collect_tree_metadata(trees_data)
+
+    def _investigate(tid: str) -> dict[str, Any]:
+        bundle = client.investigate_tree(
+            tid,
+            c_from,
+            c_to,
+            p_from,
+            p_to,
+            trend_periods=trend_periods,
+            trend_grain=trend_grain,
+            trend_as_of=trend_as_of,
+            max_depth=max_depth,
+            max_branching=max_branches,
+            max_segments=max_segments,
+            min_contribution_share=min_contribution_share,
+        )
+        _sanitize_recommended_next_steps(
+            bundle,
+            available_tree_ids=available_tree_ids,
+            metrics_by_tree=metrics_by_tree,
+        )
+        return bundle
+
+    results: dict[str, dict[str, Any]] = {}
+    errors: dict[str, str] = {}
+    workers = min(max_workers, len(targets))
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {pool.submit(_investigate, tid): tid for tid in targets}
+        for future in as_completed(futures):
+            tid = futures[future]
+            try:
+                results[tid] = future.result()
+            except Exception as exc:
+                errors[tid] = f"{type(exc).__name__}: {exc}"
+
+    ordered_results = {tid: results[tid] for tid in targets if tid in results}
+
+    bundle = {
+        "period": {
+            "current_from": c_from,
+            "current_to": c_to,
+            "comparison_from": p_from,
+            "comparison_to": p_to,
+        },
+        "trees_requested": targets,
+        "trees": ordered_results,
+        "errors": errors,
+    }
+
+    if as_json:
+        click.echo(json.dumps(bundle, indent=2))
+        return
+
+    period_label = format_period_label(c_from, c_to, p_from, p_to)
+    click.echo(f"Deep-dive across {len(targets)} tree(s) — {period_label}")
+    click.echo("")
+    for tid in targets:
+        click.echo("=" * 72)
+        click.echo(f"Tree: {tid}")
+        click.echo("=" * 72)
+        if tid in ordered_results:
+            click.echo(format_investigation(ordered_results[tid]))
+        else:
+            click.echo(f"  Failed: {errors.get(tid, 'unknown error')}")
+        click.echo("")

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -652,3 +652,172 @@ def test_trees_match_subcommand_removed():
 
     assert result.exit_code != 0
     assert "no such command" in result.output.lower()
+
+
+def _stub_config(monkeypatch):
+    monkeypatch.setattr(
+        "qluent_cli.trees.load_config",
+        lambda: QluentConfig(
+            api_key="qk_test",
+            api_url="https://api.example.com",
+            project_uuid="project-123",
+            user_email="user@example.com",
+        ),
+    )
+
+
+def test_trees_deep_dive_runs_all_trees(monkeypatch):
+    _stub_config(monkeypatch)
+    monkeypatch.setattr(
+        "qluent_cli.trees.QluentClient.list_trees",
+        lambda self: {
+            "trees": [
+                {"id": "revenue", "nodes": []},
+                {"id": "growth", "nodes": []},
+                {"id": "operations", "nodes": []},
+            ]
+        },
+    )
+
+    calls: list[str] = []
+
+    def mock_investigate(self, tree_id, c_from, c_to, p_from, p_to, **kwargs):
+        calls.append(tree_id)
+        return {
+            "tree_id": tree_id,
+            "tree_label": tree_id.title(),
+            "agent": {"top_findings": [f"{tree_id} ok"]},
+        }
+
+    monkeypatch.setattr(
+        "qluent_cli.trees.QluentClient.investigate_tree", mock_investigate
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "trees",
+            "deep-dive",
+            "--current",
+            "2026-03-09:2026-03-15",
+            "--compare",
+            "2026-03-02:2026-03-08",
+            "--json-output",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["trees_requested"] == ["revenue", "growth", "operations"]
+    assert set(payload["trees"].keys()) == {"revenue", "growth", "operations"}
+    assert payload["errors"] == {}
+    assert sorted(calls) == ["growth", "operations", "revenue"]
+    assert payload["period"]["current_from"] == "2026-03-09"
+
+
+def test_trees_deep_dive_filters_to_requested_trees(monkeypatch):
+    _stub_config(monkeypatch)
+    monkeypatch.setattr(
+        "qluent_cli.trees.QluentClient.list_trees",
+        lambda self: {
+            "trees": [
+                {"id": "revenue", "nodes": []},
+                {"id": "growth", "nodes": []},
+            ]
+        },
+    )
+    calls: list[str] = []
+
+    def mock_investigate(self, tree_id, c_from, c_to, p_from, p_to, **kwargs):
+        calls.append(tree_id)
+        return {"tree_id": tree_id, "agent": {}}
+
+    monkeypatch.setattr(
+        "qluent_cli.trees.QluentClient.investigate_tree", mock_investigate
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "trees",
+            "deep-dive",
+            "--current",
+            "2026-03-09:2026-03-15",
+            "--compare",
+            "2026-03-02:2026-03-08",
+            "--tree",
+            "revenue",
+            "--json-output",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["trees_requested"] == ["revenue"]
+    assert calls == ["revenue"]
+
+
+def test_trees_deep_dive_rejects_unknown_tree(monkeypatch):
+    _stub_config(monkeypatch)
+    monkeypatch.setattr(
+        "qluent_cli.trees.QluentClient.list_trees",
+        lambda self: {"trees": [{"id": "revenue", "nodes": []}]},
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "trees",
+            "deep-dive",
+            "--current",
+            "2026-03-09:2026-03-15",
+            "--compare",
+            "2026-03-02:2026-03-08",
+            "--tree",
+            "missing",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Unknown tree(s): missing" in result.output
+
+
+def test_trees_deep_dive_captures_per_tree_errors(monkeypatch):
+    _stub_config(monkeypatch)
+    monkeypatch.setattr(
+        "qluent_cli.trees.QluentClient.list_trees",
+        lambda self: {
+            "trees": [
+                {"id": "revenue", "nodes": []},
+                {"id": "growth", "nodes": []},
+            ]
+        },
+    )
+
+    def mock_investigate(self, tree_id, c_from, c_to, p_from, p_to, **kwargs):
+        if tree_id == "growth":
+            raise RuntimeError("upstream timeout")
+        return {"tree_id": tree_id, "agent": {}}
+
+    monkeypatch.setattr(
+        "qluent_cli.trees.QluentClient.investigate_tree", mock_investigate
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "trees",
+            "deep-dive",
+            "--current",
+            "2026-03-09:2026-03-15",
+            "--compare",
+            "2026-03-02:2026-03-08",
+            "--json-output",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert "revenue" in payload["trees"]
+    assert "growth" not in payload["trees"]
+    assert payload["errors"] == {"growth": "RuntimeError: upstream timeout"}


### PR DESCRIPTION
## Summary
- New `qluent trees deep-dive` command runs `investigate_tree` against every tree in the project in parallel (`ThreadPoolExecutor`, `--max-workers` cap) and bundles the results into one payload — `{period, trees_requested, trees, errors}`.
- `--tree` repeatable filter limits the run to a subset.
- Per-tree errors are captured (`{type}: {message}`) rather than failing the whole bundle, so a single broken tree doesn't kill the run.
- This is the deterministic CLI half of a forthcoming `/qluent:deep-dive` skill in `qluent-plugin-cc` that will synthesize the cross-tree narrative from `--json-output`.

## Test plan
- [x] `uv run pytest tests/test_trees.py -k deep_dive` — 4 tests pass (all-trees, filter, unknown tree rejected, per-tree error captured)
- [x] Full suite: `uv run pytest` — 74 pass (1 pre-existing version-string test deselected)
- [ ] Manual: `qluent trees deep-dive --period "last week" --json-output | jq '.trees | keys'` against a real project
- [ ] Manual: confirm parallel wall-clock is ~max(per-tree) not sum

🤖 Generated with [Claude Code](https://claude.com/claude-code)