### PR TITLE
Add qluent claude update + subprocess timeouts

### DIFF
--- a/src/qluent_cli/main.py
+++ b/src/qluent_cli/main.py
@@ -414,6 +414,27 @@ def claude_init(target_path: str, force: bool) -> None:
     click.echo(_write_claude_file(Path(target_path), force=force))
 
 
+@claude.command("update")
+def claude_update() -> None:
+    """Refresh the qluent Claude Code plugin to the latest version."""
+    from qluent_cli.plugin import (
+        PLUGIN_ID,
+        claude_cli_available,
+        update_claude_plugin,
+    )
+
+    if not claude_cli_available():
+        raise click.ClickException(
+            "Claude Code CLI not found on PATH. Install it from https://claude.ai/code "
+            "and try again."
+        )
+
+    if not update_claude_plugin():
+        raise click.ClickException("Plugin update failed. See messages above.")
+
+    click.echo(f"Claude Code plugin up to date: {PLUGIN_ID}")
+
+
 cli.add_command(claude)
 
 if __name__ == "__main__":

--- a/src/qluent_cli/plugin.py
+++ b/src/qluent_cli/plugin.py
@@ -21,9 +21,20 @@ def claude_cli_available() -> bool:
     return shutil.which("claude") is not None
 
 
+_STEP_TIMEOUT_SECONDS = 180
+
+
 def _run(cmd: list[str]) -> tuple[bool, str]:
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_STEP_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return False, f"timed out after {_STEP_TIMEOUT_SECONDS}s"
     except OSError as exc:
         return False, str(exc)
     if result.returncode != 0:

--- a/src/qluent_cli/plugin.py
+++ b/src/qluent_cli/plugin.py
@@ -1,8 +1,8 @@
 """Claude Code plugin auto-install helpers.
 
-Wraps `claude plugin marketplace add` and `claude plugin install` so
-`qluent login` / `qluent setup` can offer to wire up the qluent plugin
-without the user having to run the slash commands manually.
+Wraps `claude plugin marketplace add` / `install` / `update` so qluent
+commands can wire up (or refresh) the Claude Code plugin without the user
+having to run the slash commands manually.
 """
 
 from __future__ import annotations
@@ -32,16 +32,7 @@ def _run(cmd: list[str]) -> tuple[bool, str]:
     return True, ""
 
 
-def install_claude_plugin() -> bool:
-    """Add the marketplace and install the plugin.
-
-    Both subcommands are idempotent — they exit 0 with an "already installed"
-    message when the marketplace/plugin is already on disk.
-    """
-    steps = (
-        ["claude", "plugin", "marketplace", "add", MARKETPLACE_SOURCE],
-        ["claude", "plugin", "install", PLUGIN_ID],
-    )
+def _run_steps(steps: tuple[list[str], ...]) -> bool:
     for cmd in steps:
         ok, message = _run(cmd)
         if not ok:
@@ -50,6 +41,30 @@ def install_claude_plugin() -> bool:
                 click.echo(f"  {message}", err=True)
             return False
     return True
+
+
+def install_claude_plugin() -> bool:
+    """Add the marketplace and install the plugin.
+
+    Both subcommands are idempotent — they exit 0 with an "already installed"
+    message when the marketplace/plugin is already on disk.
+    """
+    return _run_steps((
+        ["claude", "plugin", "marketplace", "add", MARKETPLACE_SOURCE],
+        ["claude", "plugin", "install", PLUGIN_ID],
+    ))
+
+
+def update_claude_plugin() -> bool:
+    """Refresh the marketplace and pull the latest plugin version.
+
+    Runs `claude plugin marketplace update <name>` then `claude plugin update
+    <plugin>`. No-ops cleanly when nothing has changed upstream.
+    """
+    return _run_steps((
+        ["claude", "plugin", "marketplace", "update", MARKETPLACE_NAME],
+        ["claude", "plugin", "update", PLUGIN_ID],
+    ))
 
 
 def _manual_hint() -> str:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -142,3 +142,61 @@ def test_login_prompt_declined(monkeypatch, isolated_config, fake_browser_login)
 
     assert result.exit_code == 0
     assert called == []
+
+
+def test_update_claude_plugin_runs_both_steps(monkeypatch):
+    commands = []
+
+    def fake_run(cmd, capture_output, text, check):
+        commands.append(cmd)
+        return _completed()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert plugin_module.update_claude_plugin() is True
+    assert commands == [
+        ["claude", "plugin", "marketplace", "update", plugin_module.MARKETPLACE_NAME],
+        ["claude", "plugin", "update", plugin_module.PLUGIN_ID],
+    ]
+
+
+def test_update_claude_plugin_returns_false_on_step_failure(monkeypatch, capsys):
+    def fake_run(cmd, capture_output, text, check):
+        return _completed(returncode=1, stderr="network down")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert plugin_module.update_claude_plugin() is False
+    err = capsys.readouterr().err
+    assert "Failed: plugin marketplace update" in err
+    assert "network down" in err
+
+
+def test_claude_update_command_succeeds(monkeypatch):
+    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
+    monkeypatch.setattr(plugin_module, "update_claude_plugin", lambda: True)
+
+    result = CliRunner().invoke(cli, ["claude", "update"])
+
+    assert result.exit_code == 0
+    assert plugin_module.PLUGIN_ID in result.output
+    assert "up to date" in result.output
+
+
+def test_claude_update_command_fails_when_claude_missing(monkeypatch):
+    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: False)
+
+    result = CliRunner().invoke(cli, ["claude", "update"])
+
+    assert result.exit_code != 0
+    assert "Claude Code CLI not found" in result.output
+
+
+def test_claude_update_command_fails_on_step_error(monkeypatch):
+    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
+    monkeypatch.setattr(plugin_module, "update_claude_plugin", lambda: False)
+
+    result = CliRunner().invoke(cli, ["claude", "update"])
+
+    assert result.exit_code != 0
+    assert "Plugin update failed" in result.output

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -71,7 +71,7 @@ def test_offer_install_prints_hint_when_claude_missing(monkeypatch, capsys):
 def test_install_claude_plugin_runs_both_steps(monkeypatch):
     commands = []
 
-    def fake_run(cmd, capture_output, text, check):
+    def fake_run(cmd, **_kwargs):
         commands.append(cmd)
         return _completed()
 
@@ -85,7 +85,7 @@ def test_install_claude_plugin_runs_both_steps(monkeypatch):
 
 
 def test_install_claude_plugin_returns_false_on_step_failure(monkeypatch, capsys):
-    def fake_run(cmd, capture_output, text, check):
+    def fake_run(cmd, **_kwargs):
         return _completed(returncode=1, stderr="boom")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -94,6 +94,17 @@ def test_install_claude_plugin_returns_false_on_step_failure(monkeypatch, capsys
     err = capsys.readouterr().err
     assert "Failed: plugin marketplace add" in err
     assert "boom" in err
+
+
+def test_install_claude_plugin_returns_false_on_timeout(monkeypatch, capsys):
+    def fake_run(cmd, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=plugin_module._STEP_TIMEOUT_SECONDS)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert plugin_module.install_claude_plugin() is False
+    err = capsys.readouterr().err
+    assert "timed out" in err
 
 
 def test_login_install_plugin_flag_invokes_install(monkeypatch, isolated_config, fake_browser_login):
@@ -147,7 +158,7 @@ def test_login_prompt_declined(monkeypatch, isolated_config, fake_browser_login)
 def test_update_claude_plugin_runs_both_steps(monkeypatch):
     commands = []
 
-    def fake_run(cmd, capture_output, text, check):
+    def fake_run(cmd, **_kwargs):
         commands.append(cmd)
         return _completed()
 
@@ -161,7 +172,7 @@ def test_update_claude_plugin_runs_both_steps(monkeypatch):
 
 
 def test_update_claude_plugin_returns_false_on_step_failure(monkeypatch, capsys):
-    def fake_run(cmd, capture_output, text, check):
+    def fake_run(cmd, **_kwargs):
         return _completed(returncode=1, stderr="network down")
 
     monkeypatch.setattr(subprocess, "run", fake_run)


### PR DESCRIPTION
## Summary

Brings the `qluent claude update` command and the subprocess timeout fix to `main`. Both were originally on PR #41, which was inadvertently merged into its stacked base (`feat/auto-install-claude-plugin`) instead of `main`, leaving them orphaned. This re-PRs them off the current `main` (which has #39 and #40 merged).

## Changes

- **New `qluent claude update` command** — wraps `claude plugin marketplace update qluent-metric-trees` + `claude plugin update qluent@qluent-metric-trees`. Idempotent on no-op.
- **180s subprocess timeout** on plugin install/update steps — prevents indefinite hangs if `claude` blocks. Surfaces a clear "timed out" error instead.
- Keeps `qluent login` as install-if-missing only (no auto-update on login) — matches the brew/gh convention where install and upgrade are separate verbs.

## Test plan
- [x] `uv run pytest tests/test_plugin.py` — 14 pass (covers update steps, step-failure, **timeout path (new)**, missing CLI, and the new CLI command in success/missing/failure modes)
- [x] Manual: `uv run qluent claude update` against the real Claude CLI — outputs "Claude Code plugin up to date: qluent@qluent-metric-trees"

🤖 Generated with [Claude Code](https://claude.com/claude-code)