### PR TITLE
Fix 5 pre-existing test failures (cwd-dependent login tests + stale version assertion)

### DIFF
--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -17,8 +17,9 @@ def _mock_browser_login(result: CallbackResult):
     return fake_browser_login
 
 
-def test_login_saves_config_on_success(monkeypatch, isolated_config):
+def test_login_saves_config_on_success(monkeypatch, isolated_config, tmp_path):
     _config_dir, config_file = isolated_config
+    monkeypatch.chdir(tmp_path)
 
     monkeypatch.setattr(
         "qluent_cli.auth.browser_login",
@@ -61,8 +62,9 @@ def test_login_shows_error_on_failure(monkeypatch, isolated_config):
     assert "Timed out" in result.output
 
 
-def test_login_local_flag_uses_local_url(monkeypatch, isolated_config):
+def test_login_local_flag_uses_local_url(monkeypatch, isolated_config, tmp_path):
     _config_dir, config_file = isolated_config
+    monkeypatch.chdir(tmp_path)
 
     fake = _mock_browser_login(
         CallbackResult(

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -107,7 +107,10 @@ def test_install_claude_plugin_returns_false_on_timeout(monkeypatch, capsys):
     assert "timed out" in err
 
 
-def test_login_install_plugin_flag_invokes_install(monkeypatch, isolated_config, fake_browser_login):
+def test_login_install_plugin_flag_invokes_install(
+    monkeypatch, isolated_config, fake_browser_login, tmp_path
+):
+    monkeypatch.chdir(tmp_path)
     called = []
     monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
     monkeypatch.setattr(
@@ -123,7 +126,10 @@ def test_login_install_plugin_flag_invokes_install(monkeypatch, isolated_config,
     assert plugin_module.PLUGIN_ID in result.output
 
 
-def test_login_no_install_plugin_skips(monkeypatch, isolated_config, fake_browser_login):
+def test_login_no_install_plugin_skips(
+    monkeypatch, isolated_config, fake_browser_login, tmp_path
+):
+    monkeypatch.chdir(tmp_path)
     called = []
     monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
     monkeypatch.setattr(
@@ -138,7 +144,9 @@ def test_login_no_install_plugin_skips(monkeypatch, isolated_config, fake_browse
     assert called == []
 
 
-def test_login_prompt_declined(monkeypatch, isolated_config, fake_browser_login):
+def test_login_prompt_declined(monkeypatch, isolated_config, fake_browser_login, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "CLAUDE.md").write_text("existing content")
     called = []
     monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
     monkeypatch.setattr(
@@ -147,7 +155,7 @@ def test_login_prompt_declined(monkeypatch, isolated_config, fake_browser_login)
         lambda: called.append("ran") or True,
     )
 
-    # First "n" declines CLAUDE.md overwrite (file exists in repo root),
+    # First "n" declines CLAUDE.md overwrite (we created one above),
     # second "n" declines plugin install.
     result = CliRunner().invoke(cli, ["login"], input="n\nn\n")
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -4,6 +4,7 @@ import json
 
 from click.testing import CliRunner
 
+from qluent_cli import __version__
 from qluent_cli import config as config_module
 from qluent_cli.main import cli
 
@@ -12,7 +13,7 @@ def test_version_outputs_package_version():
     result = CliRunner().invoke(cli, ["--version"])
 
     assert result.exit_code == 0
-    assert "qluent, version 0.1.8" in result.output
+    assert f"qluent, version {__version__}" in result.output
 
 
 def test_setup_saves_config_and_writes_claude_md(monkeypatch, isolated_config, tmp_path):


### PR DESCRIPTION
## Summary

Fixes 5 pre-existing test failures so the suite is green on `main`.

## Root causes

**Four `login` tests in `test_login.py` / `test_plugin.py`** failed because `qluent login` writes `CLAUDE.md` to the cwd. When the tests ran from the repo root (where a real `CLAUDE.md` lives), the overwrite prompt fired with no piped input, click aborted, and the CLI exited 1. Switching to `monkeypatch.chdir(tmp_path)` matches the pattern already established in `test_setup.py` for the analogous `setup` flow tests.

`test_login_prompt_declined` still exercises the overwrite-declined branch by writing its own `CLAUDE.md` into `tmp_path` first, so the original two-prompt flow is preserved.

**`test_version_outputs_package_version`** asserted a hard-coded `0.1.8` string. The package version is `0.1.9`. Switched the assertion to read `__version__` so future bumps don't break it.

## Test plan

- [x] `uv run python -m pytest` — 81 passed, 0 failed (was: 76 passed, 5 failed).
- [x] Verified `test_login_prompt_declined` still hits both prompts by creating `CLAUDE.md` in `tmp_path` explicitly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbhENWjMW2c9DspzKX3nCe)_