### PR TITLE
[codex] Stream progress for long-running CLI calls

### DIFF
--- a/src/qluent_cli/auth.py
+++ b/src/qluent_cli/auth.py
@@ -13,9 +13,8 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any
 from urllib.parse import urlencode, urlparse
 
-import click
-
 from qluent_cli.config import is_local_url
+from qluent_cli.output import echo_status
 
 LOGIN_TIMEOUT_SECONDS = 300  # 5 minutes
 LOGIN_PATH = "/cli-auth"
@@ -265,10 +264,10 @@ def browser_login(api_url: str) -> CallbackResult:
     server_thread.start()
 
     try:
-        click.echo("Opening browser to log in...")
+        echo_status("Opening browser to log in...")
         webbrowser.open(login_url)
-        click.echo(f"If the browser did not open, visit:\n\n  {login_url}\n")
-        click.echo("Waiting for login...")
+        echo_status(f"If the browser did not open, visit:\n\n  {login_url}\n")
+        echo_status("Waiting for login...")
 
         got_it = server.got_callback.wait(timeout=LOGIN_TIMEOUT_SECONDS)
         if not got_it:

--- a/src/qluent_cli/client.py
+++ b/src/qluent_cli/client.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import threading
+import time
+from collections.abc import Callable
 from typing import Any
 
 import httpx
@@ -10,6 +13,8 @@ from qluent_cli.config import QluentConfig
 
 
 _INVESTIGATE_TIMEOUT = 300.0
+_PROGRESS_INTERVAL_SECONDS = 30.0
+ProgressCallback = Callable[[str, float], None]
 
 
 class QluentClient:
@@ -128,6 +133,7 @@ class QluentClient:
         max_branching: int = 2,
         max_segments: int = 5,
         min_contribution_share: float = 0.1,
+        progress_callback: ProgressCallback | None = None,
     ) -> dict[str, Any]:
         """Run a full server-side investigation bundle."""
         body = self._rca_body(
@@ -142,13 +148,39 @@ class QluentClient:
             "trend_as_of": trend_as_of,
             "compare_trees": compare_trees or [],
         })
-        resp = self._client.post(
+        resp = self._post_with_progress(
             f"{self._base}/metric-trees/{tree_id}/investigate/",
             json=body,
             timeout=_INVESTIGATE_TIMEOUT,
+            progress_callback=progress_callback,
         )
         resp.raise_for_status()
         return resp.json()
+
+    def _post_with_progress(
+        self,
+        url: str,
+        *,
+        json: dict[str, Any],
+        timeout: float,
+        progress_callback: ProgressCallback | None,
+    ) -> httpx.Response:
+        if progress_callback is None:
+            return self._client.post(url, json=json, timeout=timeout)
+
+        started = time.monotonic()
+        done = threading.Event()
+
+        def tick() -> None:
+            while not done.wait(_PROGRESS_INTERVAL_SECONDS):
+                progress_callback("awaiting_api", time.monotonic() - started)
+
+        thread = threading.Thread(target=tick, daemon=True)
+        thread.start()
+        try:
+            return self._client.post(url, json=json, timeout=timeout)
+        finally:
+            done.set()
 
     def root_cause_tree(
         self,

--- a/src/qluent_cli/main.py
+++ b/src/qluent_cli/main.py
@@ -17,12 +17,17 @@ from qluent_cli.formatters import format_tree_list
 from qluent_cli.rca import rca
 from qluent_cli.suggestions import suggestions
 from qluent_cli.trees import trees
+from qluent_cli.output import echo_status
 
 
 @click.group()
+@click.option("--quiet", is_flag=True, help="Suppress non-result status output.")
 @click.version_option(version=__version__, prog_name="qluent")
-def cli() -> None:
+@click.pass_context
+def cli(ctx: click.Context, quiet: bool) -> None:
     """Qluent — metric tree analysis from the command line."""
+    ctx.ensure_object(dict)
+    ctx.obj["quiet"] = quiet
 
 
 def _print_saved_config(data: dict[str, object]) -> None:
@@ -32,7 +37,7 @@ def _print_saved_config(data: dict[str, object]) -> None:
     for key, value in data.items():
         if key in hidden:
             continue
-        click.echo(f"  {key}: {mask_key(value) if key == 'api_key' else value}")
+        echo_status(f"  {key}: {mask_key(value) if key == 'api_key' else value}")
 
 
 def _prompt_required(
@@ -49,7 +54,7 @@ def _prompt_required(
         ).strip()
         if value:
             return value
-        click.echo(f"{label} is required")
+        echo_status(f"{label} is required")
 
 
 def _tree_metric_labels(tree: dict[str, Any]) -> list[str]:
@@ -216,7 +221,7 @@ def config(
                 )
             _print_saved_config(data)
         else:
-            click.echo("No config file found. Run: qluent setup")
+            echo_status("No config file found. Run: qluent setup")
         return
 
     result = save_config(
@@ -230,7 +235,7 @@ def config(
         result["client_safe"] = default_client_safe(
             str(result.get("api_url") or DEFAULT_API_URL)
         )
-    click.echo(CONFIG_SAVED_MSG)
+    echo_status(CONFIG_SAVED_MSG)
     _print_saved_config(result)
 
 
@@ -250,9 +255,9 @@ def _confirm_and_write_claude_file(target: Path, *, force: bool) -> None:
     """Prompt to overwrite if needed, then write CLAUDE.md."""
     if target.exists() and not force:
         if not click.confirm(f"{target} already exists. Overwrite it?", default=False):
-            click.echo("Skipped CLAUDE.md generation")
+            echo_status("Skipped CLAUDE.md generation")
             return
-    click.echo(_write_claude_file(target, force=force or target.exists()))
+    echo_status(_write_claude_file(target, force=force or target.exists()))
 
 
 @cli.command()
@@ -295,10 +300,10 @@ def login(local: bool, install_plugin: bool | None) -> None:
         client_safe=client_safe,
     )
 
-    click.echo("Logged in successfully!")
-    click.echo(f"  Project: {result.project_uuid}")
-    click.echo(f"  Email:   {result.user_email}")
-    click.echo(CONFIG_SAVED_MSG)
+    echo_status("Logged in successfully!")
+    echo_status(f"  Project: {result.project_uuid}")
+    echo_status(f"  Email:   {result.user_email}")
+    echo_status(CONFIG_SAVED_MSG)
 
     _confirm_and_write_claude_file(Path("CLAUDE.md"), force=False)
     offer_claude_plugin_install(install_plugin)
@@ -327,7 +332,7 @@ def setup(
     claude_path: str, local: bool, force: bool, install_plugin: bool | None
 ) -> None:
     """Interactive first-run setup for client installations."""
-    click.echo("Tip: Use 'qluent login' for browser-based login (recommended).\n")
+    echo_status("Tip: Use 'qluent login' for browser-based login (recommended).\n")
 
     from qluent_cli.config import (
         CONFIG_SAVED_MSG,
@@ -366,7 +371,7 @@ def setup(
         user_email=user_email,
         client_safe=client_safe,
     )
-    click.echo(CONFIG_SAVED_MSG)
+    echo_status(CONFIG_SAVED_MSG)
     _print_saved_config(result)
 
     target = Path(claude_path)
@@ -377,7 +382,7 @@ def setup(
     if write_claude:
         _confirm_and_write_claude_file(target, force=force)
     else:
-        click.echo("Skipped CLAUDE.md generation")
+        echo_status("Skipped CLAUDE.md generation")
 
     offer_claude_plugin_install(install_plugin)
 
@@ -411,7 +416,7 @@ def claude() -> None:
 @click.option("--force", is_flag=True, help="Overwrite an existing CLAUDE.md")
 def claude_init(target_path: str, force: bool) -> None:
     """Write a CLAUDE.md file for Claude Code."""
-    click.echo(_write_claude_file(Path(target_path), force=force))
+    echo_status(_write_claude_file(Path(target_path), force=force))
 
 
 @claude.command("update")
@@ -432,7 +437,7 @@ def claude_update() -> None:
     if not update_claude_plugin():
         raise click.ClickException("Plugin update failed. See messages above.")
 
-    click.echo(f"Claude Code plugin up to date: {PLUGIN_ID}")
+    echo_status(f"Claude Code plugin up to date: {PLUGIN_ID}")
 
 
 cli.add_command(claude)

--- a/src/qluent_cli/output.py
+++ b/src/qluent_cli/output.py
@@ -1,0 +1,24 @@
+"""Output helpers for stdout/stderr discipline."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import click
+
+
+def is_quiet() -> bool:
+    """Return whether non-result chatter should be suppressed."""
+    ctx = click.get_current_context(silent=True)
+    while ctx is not None:
+        if isinstance(ctx.obj, dict) and ctx.obj.get("quiet"):
+            return True
+        ctx = ctx.parent
+    return False
+
+
+def echo_status(message: Any = "", **kwargs: Any) -> None:
+    """Emit a status message to stderr unless quiet mode is active."""
+    if is_quiet():
+        return
+    click.echo(message, err=True, **kwargs)

--- a/src/qluent_cli/plugin.py
+++ b/src/qluent_cli/plugin.py
@@ -12,6 +12,8 @@ import subprocess
 
 import click
 
+from qluent_cli.output import echo_status
+
 MARKETPLACE_SOURCE = "qluent/qluent-plugin-cc"
 MARKETPLACE_NAME = "qluent-metric-trees"
 PLUGIN_ID = f"qluent@{MARKETPLACE_NAME}"
@@ -47,9 +49,9 @@ def _run_steps(steps: tuple[list[str], ...]) -> bool:
     for cmd in steps:
         ok, message = _run(cmd)
         if not ok:
-            click.echo(f"  Failed: {' '.join(cmd[1:])}", err=True)
+            echo_status(f"  Failed: {' '.join(cmd[1:])}")
             if message:
-                click.echo(f"  {message}", err=True)
+                echo_status(f"  {message}")
             return False
     return True
 
@@ -99,9 +101,9 @@ def offer_claude_plugin_install(install_plugin: bool | None) -> None:
 
     if not claude_cli_available():
         if install_plugin is True:
-            click.echo(_manual_hint())
+            echo_status(_manual_hint())
         else:
-            click.echo("Claude Code CLI not detected. " + _manual_hint())
+            echo_status("Claude Code CLI not detected. " + _manual_hint())
         return
 
     if install_plugin is None:
@@ -111,4 +113,4 @@ def offer_claude_plugin_install(install_plugin: bool | None) -> None:
             return
 
     if install_claude_plugin():
-        click.echo(f"Claude Code plugin ready: {PLUGIN_ID}")
+        echo_status(f"Claude Code plugin ready: {PLUGIN_ID}")

--- a/src/qluent_cli/trees.py
+++ b/src/qluent_cli/trees.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import json
 import shlex
+import threading
+import time
+import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date as dt_date
 from typing import Any
@@ -12,6 +15,7 @@ import click
 
 from qluent_cli.client import QluentClient
 from qluent_cli.config import load_config
+from qluent_cli.output import echo_status
 from qluent_cli.tree_contracts import build_tree_query_contract
 from qluent_cli.formatters import (
     format_comparison,
@@ -47,6 +51,83 @@ _LEVER_KEYWORDS = (
     "increase",
     "decrease",
 )
+
+
+class _RunReporter:
+    def __init__(
+        self,
+        *,
+        command: str,
+        stream: bool,
+        tree_id: str | None = None,
+        tree_count: int | None = None,
+        period_label: str,
+    ) -> None:
+        self.command = command
+        self.stream = stream
+        self.tree_id = tree_id
+        self.tree_count = tree_count
+        self.period_label = period_label
+        self.run_id = str(uuid.uuid4())
+        self.started_at = time.monotonic()
+        self._lock = threading.Lock()
+
+    def start(self) -> None:
+        if self.stream:
+            payload: dict[str, Any] = {
+                "type": "run.started",
+                "run_id": self.run_id,
+                "command": self.command,
+                "period": self.period_label,
+            }
+            if self.tree_id is not None:
+                payload["tree"] = self.tree_id
+            if self.tree_count is not None:
+                payload["tree_count"] = self.tree_count
+            self._emit_jsonl(payload)
+            return
+
+        target = self.tree_id or f"{self.tree_count} tree(s)"
+        echo_status(f"[qluent] {self.command} {target} period={self.period_label} starting...")
+
+    def progress(self, stage: str, *, tree_id: str | None = None, elapsed: float | None = None) -> None:
+        elapsed_ms = int(((elapsed or (time.monotonic() - self.started_at)) * 1000))
+        if self.stream:
+            payload: dict[str, Any] = {
+                "type": "run.progress",
+                "run_id": self.run_id,
+                "stage": stage,
+                "elapsed_ms": elapsed_ms,
+            }
+            if tree_id is not None:
+                payload["tree"] = tree_id
+            self._emit_jsonl(payload)
+            return
+
+        if stage == "awaiting_api":
+            seconds = max(0, round(elapsed_ms / 1000))
+            suffix = f" ({seconds}s)" if seconds else ""
+            prefix = f"[qluent] {tree_id} " if tree_id else "[qluent] "
+            echo_status(f"{prefix}awaiting response...{suffix}")
+        elif stage == "formatting":
+            prefix = f"[qluent] {tree_id} " if tree_id else "[qluent] "
+            echo_status(f"{prefix}received, formatting...")
+
+    def complete(self, result: dict[str, Any]) -> None:
+        if not self.stream:
+            return
+        self._emit_jsonl(
+            {
+                "type": "run.completed",
+                "run_id": self.run_id,
+                "elapsed_ms": int((time.monotonic() - self.started_at) * 1000),
+                "result": result,
+            }
+        )
+
+    def _emit_jsonl(self, payload: dict[str, Any]) -> None:
+        with self._lock:
+            click.echo(json.dumps(payload, separators=(",", ":")))
 
 
 def _is_lever_question(question: str | None) -> bool:
@@ -477,6 +558,7 @@ def compare(
     help="Minimum absolute direct contribution share required to follow a child branch in RCA",
 )
 @click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
+@click.option("--stream", is_flag=True, help="Emit JSONL progress events and the final result.")
 def investigate(
     tree_id: str,
     period: str | None,
@@ -493,12 +575,24 @@ def investigate(
     max_segments: int,
     min_contribution_share: float,
     as_json: bool,
+    stream: bool,
 ) -> None:
     """Run a deterministic multi-step investigation bundle for a tree."""
     client = QluentClient(load_config())
     parsed_filters = parse_filters(filters)
     c_from, c_to, p_from, p_to = resolve_date_args(period, current_range, compare_range)
+    period_label = format_period_label(c_from, c_to, p_from, p_to)
+    reporter = _RunReporter(
+        command="investigate",
+        stream=stream,
+        tree_id=tree_id,
+        period_label=period_label,
+    )
+    if stream or not as_json:
+        reporter.start()
     available_tree_ids, metrics_by_tree = _collect_tree_metadata(client.list_trees())
+    if stream or not as_json:
+        reporter.progress("awaiting_api")
 
     bundle = client.investigate_tree(
         tree_id,
@@ -516,13 +610,19 @@ def investigate(
         max_branching=max_branches,
         max_segments=max_segments,
         min_contribution_share=min_contribution_share,
+        progress_callback=lambda stage, elapsed: reporter.progress(stage, elapsed=elapsed),
     )
+    if stream or not as_json:
+        reporter.progress("formatting")
     _sanitize_recommended_next_steps(
         bundle,
         available_tree_ids=available_tree_ids,
         metrics_by_tree=metrics_by_tree,
     )
 
+    if stream:
+        reporter.complete(bundle)
+        return
     if as_json:
         click.echo(json.dumps(bundle, indent=2))
     else:
@@ -557,6 +657,7 @@ def investigate(
     help="Maximum number of trees to investigate in parallel.",
 )
 @click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
+@click.option("--stream", is_flag=True, help="Emit JSONL progress events and the final result.")
 def deep_dive(
     period: str | None,
     current_range: str | None,
@@ -571,6 +672,7 @@ def deep_dive(
     min_contribution_share: float,
     max_workers: int,
     as_json: bool,
+    stream: bool,
 ) -> None:
     """Run investigations across every tree in parallel and bundle the results."""
     client = QluentClient(load_config())
@@ -593,8 +695,19 @@ def deep_dive(
         raise click.ClickException("No trees available for this project.")
 
     available_tree_ids, metrics_by_tree = _collect_tree_metadata(trees_data)
+    period_label = format_period_label(c_from, c_to, p_from, p_to)
+    reporter = _RunReporter(
+        command="deep-dive",
+        stream=stream,
+        tree_count=len(targets),
+        period_label=period_label,
+    )
+    if stream or not as_json:
+        reporter.start()
 
     def _investigate(tid: str) -> dict[str, Any]:
+        if stream or not as_json:
+            reporter.progress("awaiting_api", tree_id=tid)
         bundle = client.investigate_tree(
             tid,
             c_from,
@@ -608,7 +721,12 @@ def deep_dive(
             max_branching=max_branches,
             max_segments=max_segments,
             min_contribution_share=min_contribution_share,
+            progress_callback=lambda stage, elapsed: reporter.progress(
+                stage, tree_id=tid, elapsed=elapsed
+            ),
         )
+        if stream or not as_json:
+            reporter.progress("formatting", tree_id=tid)
         _sanitize_recommended_next_steps(
             bundle,
             available_tree_ids=available_tree_ids,
@@ -642,11 +760,14 @@ def deep_dive(
         "errors": errors,
     }
 
+    if stream:
+        reporter.complete(bundle)
+        return
+
     if as_json:
         click.echo(json.dumps(bundle, indent=2))
         return
 
-    period_label = format_period_label(c_from, c_to, p_from, p_to)
     click.echo(f"Deep-dive across {len(targets)} tree(s) — {period_label}")
     click.echo("")
     for tid in targets:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -63,9 +63,9 @@ def test_offer_install_prints_hint_when_claude_missing(monkeypatch, capsys):
 
     plugin_module.offer_claude_plugin_install(None)
 
-    out = capsys.readouterr().out
-    assert "Claude Code CLI not detected" in out
-    assert "claude plugin marketplace add" in out
+    err = capsys.readouterr().err
+    assert "Claude Code CLI not detected" in err
+    assert "claude plugin marketplace add" in err
 
 
 def test_install_claude_plugin_runs_both_steps(monkeypatch):

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -252,7 +252,7 @@ def test_trees_levers_outputs_ranked_scenarios(monkeypatch):
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["tree_id"] == "revenue"
     assert payload["scenarios"] == [0.02, 0.1]
     assert [lever["node_id"] for lever in payload["top_levers"]] == [
@@ -328,7 +328,7 @@ def test_trees_evaluate_contract_output_includes_value_metadata(monkeypatch):
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["schema_version"] == "qluent.tree_query.v1"
     assert payload["deterministic"] is True
     assert payload["agent_interpretation"] is None
@@ -508,7 +508,7 @@ def test_trees_investigate_delegates_to_server(monkeypatch):
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["tree_id"] == "revenue"
     assert payload["agent"]["status"] == "resolved"
     assert len(investigate_calls) == 1
@@ -576,7 +576,7 @@ def test_trees_investigate_converts_metric_compare_recommendation(monkeypatch):
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     steps = payload["agent"]["recommended_next_steps"]
     assert (
         steps[0]["command"]
@@ -634,10 +634,90 @@ def test_trees_investigate_strips_invalid_compare_recommendation(monkeypatch):
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     step = payload["agent"]["recommended_next_steps"][0]
     assert "command" not in step
     assert "compare targets must be available tree ids: growth, revenue" in step["why"]
+
+
+def test_trees_investigate_keeps_json_on_stdout_and_progress_on_stderr(monkeypatch):
+    _stub_config(monkeypatch)
+    monkeypatch.setattr(
+        "qluent_cli.trees.QluentClient.list_trees",
+        lambda self: {"trees": [{"id": "revenue", "nodes": []}]},
+    )
+    def mock_investigate(self, tree_id, c_from, c_to, p_from, p_to, **kwargs):
+        kwargs["progress_callback"]("awaiting_api", 30.0)
+        return {
+            "tree_id": tree_id,
+            "agent": {},
+        }
+
+    monkeypatch.setattr("qluent_cli.trees.QluentClient.investigate_tree", mock_investigate)
+
+    result = CliRunner().invoke(
+        cli,
+        ["trees", "investigate", "revenue", "--period", "last month", "--json-output"],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output[result.output.index("{") :])["tree_id"] == "revenue"
+    assert "[qluent] awaiting response" in result.output
+
+
+def test_quiet_suppresses_investigate_progress(monkeypatch):
+    _stub_config(monkeypatch)
+    monkeypatch.setattr(
+        "qluent_cli.trees.QluentClient.list_trees",
+        lambda self: {"trees": [{"id": "revenue", "nodes": []}]},
+    )
+    monkeypatch.setattr(
+        "qluent_cli.trees.QluentClient.investigate_tree",
+        lambda self, tree_id, c_from, c_to, p_from, p_to, **kwargs: {
+            "tree_id": tree_id,
+            "agent": {},
+        },
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["--quiet", "trees", "investigate", "revenue", "--period", "last month", "--json-output"],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["tree_id"] == "revenue"
+    assert "[qluent]" not in result.output
+
+
+def test_trees_investigate_stream_emits_jsonl(monkeypatch):
+    _stub_config(monkeypatch)
+    monkeypatch.setattr(
+        "qluent_cli.trees.QluentClient.list_trees",
+        lambda self: {"trees": [{"id": "revenue", "nodes": []}]},
+    )
+    monkeypatch.setattr(
+        "qluent_cli.trees.QluentClient.investigate_tree",
+        lambda self, tree_id, c_from, c_to, p_from, p_to, **kwargs: {
+            "tree_id": tree_id,
+            "agent": {"status": "resolved"},
+        },
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["trees", "investigate", "revenue", "--period", "last month", "--json-output", "--stream"],
+    )
+
+    assert result.exit_code == 0
+    events = [json.loads(line) for line in result.output.splitlines()]
+    assert [event["type"] for event in events] == [
+        "run.started",
+        "run.progress",
+        "run.progress",
+        "run.completed",
+    ]
+    assert events[0]["tree"] == "revenue"
+    assert events[-1]["result"]["agent"]["status"] == "resolved"
 
 
 def test_trees_investigate_requires_tree_id():
@@ -707,7 +787,7 @@ def test_trees_deep_dive_runs_all_trees(monkeypatch):
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["trees_requested"] == ["revenue", "growth", "operations"]
     assert set(payload["trees"].keys()) == {"revenue", "growth", "operations"}
     assert payload["errors"] == {}
@@ -752,7 +832,7 @@ def test_trees_deep_dive_filters_to_requested_trees(monkeypatch):
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["trees_requested"] == ["revenue"]
     assert calls == ["revenue"]
 
@@ -817,7 +897,7 @@ def test_trees_deep_dive_captures_per_tree_errors(monkeypatch):
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert "revenue" in payload["trees"]
     assert "growth" not in payload["trees"]
     assert payload["errors"] == {"growth": "RuntimeError: upstream timeout"}


### PR DESCRIPTION
## Summary

Closes #45.

- Adds a quiet-aware stderr output helper and global --quiet flag for non-result chatter.
- Moves login/setup/config/plugin status messages to stderr while keeping command results on stdout.
- Adds progress callbacks around long-running investigate API calls, with ~30s awaiting-response ticks.
- Adds --stream JSONL envelopes for trees investigate and trees deep-dive with run.started, run.progress, and run.completed events.
- Covers stdout/stderr separation, quiet mode, and JSONL streaming in tests.

## Validation

- uv run pytest