### PR TITLE
Add agent-neutral AGENTS.md instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ qluent login --local
 
 Hosted API URLs default to client-safe mode automatically. Localhost URLs default to full-access mode for development.
 
-## Claude Code Setup
+## Agent Setup (Claude Code, Codex CLI, Cursor, Continue, Zed)
 
 The easiest path is:
 
@@ -46,10 +46,21 @@ qluent login
 Or, if config is already present:
 
 ```bash
-qluent claude init
+qluent agents init                # writes AGENTS.md (default — read by Codex CLI, Cursor, Continue, Zed, Claude Code)
+qluent agents init --as claude    # writes CLAUDE.md instead
+qluent agents init --as both      # writes AGENTS.md + a tiny CLAUDE.md pointer
 ```
 
-That writes `CLAUDE.md` in the current directory so Claude Code can use the CLI correctly.
+The bundled instructions are agent-neutral and explain how to call the qluent
+CLI and interpret its JSON output. `qluent claude init` is kept as a thin alias
+for `qluent agents init --as claude` for back-compat.
+
+### Local override
+
+If a project needs to customize the bundled instructions without forking the
+CLI, drop an `AGENTS.override.md` in the same directory. Codex CLI (and other
+clients that follow the convention) prefer it over `AGENTS.md` for that run.
+`qluent agents init` never writes to or overwrites `AGENTS.override.md`.
 
 ## First Commands
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ qluent login
 Or, if config is already present:
 
 ```bash
-qluent agents init                # writes AGENTS.md (default — read by Codex CLI, Cursor, Continue, Zed, Claude Code)
+qluent agents init                # writes AGENTS.md (default — read by Codex CLI, Cursor, Continue, Zed)
 qluent agents init --as claude    # writes CLAUDE.md instead
-qluent agents init --as both      # writes AGENTS.md + a tiny CLAUDE.md pointer
+qluent agents init --as both      # writes AGENTS.md + a tiny CLAUDE.md importer
 ```
 
 The bundled instructions are agent-neutral and explain how to call the qluent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,4 +27,4 @@ build-backend = "setuptools.build_meta"
 where = ["src"]
 
 [tool.setuptools.package-data]
-qluent_cli = ["claude_instructions.md"]
+qluent_cli = ["agent_instructions.md"]

--- a/src/qluent_cli/agent_instructions.md
+++ b/src/qluent_cli/agent_instructions.md
@@ -29,10 +29,10 @@ for reproducible bundled trend analysis.
 Supported periods: "last week", "this week", "last month", "this month", "last quarter",
 "yesterday", "last 30 days", "week over week", "month over month", or explicit ISO dates.
 
-## Preferred Claude Code workflow
+## Preferred agent workflow
 
 **Pick a tree, then `investigate`.** The qluent server is deterministic and does
-not match natural-language questions to trees — Claude must select the tree
+not match natural-language questions to trees — the agent must select the tree
 client-side and pass it as an explicit positional argument.
 
 If the user already named the tree (e.g. "investigate revenue last week"), run:
@@ -82,7 +82,7 @@ Read the investigation bundle in this order:
 
 Use these rules:
 
-- Prefer `--json-output` when Claude Code is driving the workflow.
+- Prefer `--json-output` when an agent is driving the workflow.
 - If `agent.status = needs_more_data` or `partially_resolved`, run the first relevant command from `agent.recommended_next_steps` before inventing your own drill-down.
 - If `agent.status = resolved`, summarize the evidence and stop unless the user explicitly wants a deeper drill-down.
 - Always report the exact current and comparison windows you used.
@@ -194,3 +194,14 @@ Interpret them like this:
 Conclusion: "Revenue growth is decelerating. Last week's gain came from higher basket sizes
 in owned channels (Direct, Email), not from customer acquisition. Organic traffic continues
 to decline — investigate SEO or content changes."
+
+## Agent-specific notes
+
+For Claude Code: the qluent plugin exposes `/investigate`, `/trend`, `/compare-trees`, and
+`/rca` slash commands that wrap the workflow above. Prefer those over manually chaining the
+underlying CLI commands.
+
+For Codex CLI / Cursor / Continue / Zed (and any other MCP client): run `qluent mcp serve`
+and connect via the [Model Context Protocol](https://modelcontextprotocol.io). The MCP tools
+return the same JSON contracts as the CLI's `--json-output` mode, so the workflow rules
+above apply unchanged.

--- a/src/qluent_cli/main.py
+++ b/src/qluent_cli/main.py
@@ -239,25 +239,43 @@ def config(
     _print_saved_config(result)
 
 
-def _write_claude_file(path: Path, *, force: bool) -> str:
-    content = _load_claude_instructions().strip() + "\n"
+CLAUDE_POINTER_BODY = (
+    "# Qluent Metric Trees\n"
+    "\n"
+    "See [AGENTS.md](AGENTS.md) for the full qluent CLI usage guide.\n"
+    "Claude Code reads `AGENTS.md` automatically, so this file just points there.\n"
+)
+
+
+def _agent_file_content(kind: str) -> str:
+    if kind == "claude-pointer":
+        return CLAUDE_POINTER_BODY
+    return _load_agent_instructions().strip() + "\n"
+
+
+def _write_agent_file(path: Path, *, force: bool, kind: str = "agents") -> str:
+    content = _agent_file_content(kind)
     if path.exists():
         existing = path.read_text()
         if existing == content:
             return f"{path} is already up to date"
         if not force:
-            raise click.ClickException(f"{path} already exists. Re-run with --force to overwrite it.")
+            raise click.ClickException(
+                f"{path} already exists. Re-run with --force to overwrite it."
+            )
     path.write_text(content)
     return f"Wrote {path}"
 
 
-def _confirm_and_write_claude_file(target: Path, *, force: bool) -> None:
-    """Prompt to overwrite if needed, then write CLAUDE.md."""
+def _confirm_and_write_agent_file(
+    target: Path, *, force: bool, kind: str = "agents"
+) -> None:
+    """Prompt to overwrite if needed, then write the agent instructions file."""
     if target.exists() and not force:
         if not click.confirm(f"{target} already exists. Overwrite it?", default=False):
-            echo_status("Skipped CLAUDE.md generation")
+            echo_status(f"Skipped {target.name} generation")
             return
-    echo_status(_write_claude_file(target, force=force or target.exists()))
+    echo_status(_write_agent_file(target, force=force or target.exists(), kind=kind))
 
 
 @cli.command()
@@ -305,23 +323,26 @@ def login(local: bool, install_plugin: bool | None) -> None:
     echo_status(f"  Email:   {result.user_email}")
     echo_status(CONFIG_SAVED_MSG)
 
-    _confirm_and_write_claude_file(Path("CLAUDE.md"), force=False)
+    _confirm_and_write_agent_file(Path("AGENTS.md"), force=False)
     offer_claude_plugin_install(install_plugin)
 
 
 @cli.command()
 @click.option(
-    "--claude-path",
-    default="CLAUDE.md",
+    "--path",
+    "agents_path",
+    default="AGENTS.md",
     show_default=True,
-    help="Where to write the Claude Code instructions file.",
+    help="Where to write the agent instructions file.",
 )
 @click.option(
     "--local",
     is_flag=True,
     help="Use the local API at http://localhost:8001.",
 )
-@click.option("--force", is_flag=True, help="Overwrite an existing CLAUDE.md without prompting.")
+@click.option(
+    "--force", is_flag=True, help="Overwrite an existing instructions file without prompting."
+)
 @click.option(
     "--install-plugin/--no-install-plugin",
     "install_plugin",
@@ -329,7 +350,7 @@ def login(local: bool, install_plugin: bool | None) -> None:
     help="Install the qluent Claude Code plugin without prompting (or skip the prompt).",
 )
 def setup(
-    claude_path: str, local: bool, force: bool, install_plugin: bool | None
+    agents_path: str, local: bool, force: bool, install_plugin: bool | None
 ) -> None:
     """Interactive first-run setup for client installations."""
     echo_status("Tip: Use 'qluent login' for browser-based login (recommended).\n")
@@ -374,15 +395,15 @@ def setup(
     echo_status(CONFIG_SAVED_MSG)
     _print_saved_config(result)
 
-    target = Path(claude_path)
-    write_claude = click.confirm(
-        f"Write Claude Code instructions to {target}?",
+    target = Path(agents_path)
+    write_agents = click.confirm(
+        f"Write {target}?",
         default=True,
     )
-    if write_claude:
-        _confirm_and_write_claude_file(target, force=force)
+    if write_agents:
+        _confirm_and_write_agent_file(target, force=force)
     else:
-        echo_status("Skipped CLAUDE.md generation")
+        echo_status(f"Skipped {target.name} generation")
 
     offer_claude_plugin_install(install_plugin)
 
@@ -392,18 +413,78 @@ cli.add_command(rca)
 cli.add_command(elasticity)
 cli.add_command(suggestions)
 
-INSTRUCTIONS_FILENAME = "claude_instructions.md"
+INSTRUCTIONS_FILENAME = "agent_instructions.md"
 
 
-def _load_claude_instructions() -> str:
+def _load_agent_instructions() -> str:
     base = Path(getattr(sys, "_MEIPASS", Path(__file__).parent))
     return (base / INSTRUCTIONS_FILENAME).read_text()
 
 
 @cli.command()
 def instructions() -> None:
-    """Print a CLAUDE.md snippet for Claude Code integration."""
-    click.echo(_load_claude_instructions())
+    """Print the bundled AGENTS.md snippet for agent integrations."""
+    click.echo(_load_agent_instructions())
+
+
+def _agents_init_impl(*, as_kind: str, target_path: str | None, force: bool) -> None:
+    if as_kind == "agents":
+        path = Path(target_path or "AGENTS.md")
+        echo_status(_write_agent_file(path, force=force, kind="agents"))
+        return
+
+    if as_kind == "claude":
+        path = Path(target_path or "CLAUDE.md")
+        echo_status(_write_agent_file(path, force=force, kind="agents"))
+        return
+
+    if as_kind == "both":
+        if target_path:
+            raise click.ClickException(
+                "--path is incompatible with --as both. Run twice with --as agents and "
+                "--as claude if you need custom paths."
+            )
+        echo_status(_write_agent_file(Path("AGENTS.md"), force=force, kind="agents"))
+        echo_status(
+            _write_agent_file(Path("CLAUDE.md"), force=force, kind="claude-pointer")
+        )
+        return
+
+    raise click.ClickException(
+        f"Unknown --as value: {as_kind}. Use one of: agents, claude, both."
+    )
+
+
+@cli.group()
+def agents() -> None:
+    """Agent integration helpers (AGENTS.md, CLAUDE.md, ...)."""
+
+
+@agents.command("init")
+@click.option(
+    "--as",
+    "as_kind",
+    type=click.Choice(["agents", "claude", "both"]),
+    default="agents",
+    show_default=True,
+    help=(
+        "Which file flavor to write. 'agents' = AGENTS.md, 'claude' = CLAUDE.md "
+        "with the same content, 'both' = AGENTS.md plus a tiny CLAUDE.md pointer."
+    ),
+)
+@click.option(
+    "--path",
+    "target_path",
+    default=None,
+    help="Where to write the file (defaults: AGENTS.md or CLAUDE.md depending on --as).",
+)
+@click.option("--force", is_flag=True, help="Overwrite an existing file without prompting.")
+def agents_init(as_kind: str, target_path: str | None, force: bool) -> None:
+    """Write an agent instructions file (AGENTS.md by default)."""
+    _agents_init_impl(as_kind=as_kind, target_path=target_path, force=force)
+
+
+cli.add_command(agents)
 
 
 @cli.group()
@@ -412,11 +493,17 @@ def claude() -> None:
 
 
 @claude.command("init")
-@click.option("--path", "target_path", default="CLAUDE.md", show_default=True, help="Path to write CLAUDE.md")
+@click.option(
+    "--path",
+    "target_path",
+    default="CLAUDE.md",
+    show_default=True,
+    help="Path to write CLAUDE.md",
+)
 @click.option("--force", is_flag=True, help="Overwrite an existing CLAUDE.md")
 def claude_init(target_path: str, force: bool) -> None:
-    """Write a CLAUDE.md file for Claude Code."""
-    echo_status(_write_claude_file(Path(target_path), force=force))
+    """Alias for `qluent agents init --as claude` (writes CLAUDE.md)."""
+    _agents_init_impl(as_kind="claude", target_path=target_path, force=force)
 
 
 @claude.command("update")
@@ -464,6 +551,7 @@ def mcp_serve() -> None:
 
 
 cli.add_command(mcp)
+
 
 if __name__ == "__main__":
     cli()

--- a/src/qluent_cli/main.py
+++ b/src/qluent_cli/main.py
@@ -240,10 +240,11 @@ def config(
 
 
 CLAUDE_POINTER_BODY = (
-    "# Qluent Metric Trees\n"
+    "@AGENTS.md\n"
     "\n"
-    "See [AGENTS.md](AGENTS.md) for the full qluent CLI usage guide.\n"
-    "Claude Code reads `AGENTS.md` automatically, so this file just points there.\n"
+    "# Claude Code\n"
+    "\n"
+    "This file imports the shared qluent CLI usage guide from AGENTS.md.\n"
 )
 
 
@@ -336,6 +337,12 @@ def login(local: bool, install_plugin: bool | None) -> None:
     help="Where to write the agent instructions file.",
 )
 @click.option(
+    "--claude-path",
+    "claude_path",
+    hidden=True,
+    help="Deprecated alias for --path.",
+)
+@click.option(
     "--local",
     is_flag=True,
     help="Use the local API at http://localhost:8001.",
@@ -350,7 +357,11 @@ def login(local: bool, install_plugin: bool | None) -> None:
     help="Install the qluent Claude Code plugin without prompting (or skip the prompt).",
 )
 def setup(
-    agents_path: str, local: bool, force: bool, install_plugin: bool | None
+    agents_path: str,
+    claude_path: str | None,
+    local: bool,
+    force: bool,
+    install_plugin: bool | None,
 ) -> None:
     """Interactive first-run setup for client installations."""
     echo_status("Tip: Use 'qluent login' for browser-based login (recommended).\n")
@@ -395,7 +406,7 @@ def setup(
     echo_status(CONFIG_SAVED_MSG)
     _print_saved_config(result)
 
-    target = Path(agents_path)
+    target = Path(claude_path or agents_path)
     write_agents = click.confirm(
         f"Write {target}?",
         default=True,

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -146,7 +146,7 @@ def test_login_no_install_plugin_skips(
 
 def test_login_prompt_declined(monkeypatch, isolated_config, fake_browser_login, tmp_path):
     monkeypatch.chdir(tmp_path)
-    (tmp_path / "CLAUDE.md").write_text("existing content")
+    (tmp_path / "AGENTS.md").write_text("existing content")
     called = []
     monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
     monkeypatch.setattr(
@@ -155,7 +155,7 @@ def test_login_prompt_declined(monkeypatch, isolated_config, fake_browser_login,
         lambda: called.append("ran") or True,
     )
 
-    # First "n" declines CLAUDE.md overwrite (we created one above),
+    # First "n" declines AGENTS.md overwrite (we created one above),
     # second "n" declines plugin install.
     result = CliRunner().invoke(cli, ["login"], input="n\nn\n")
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -16,7 +16,7 @@ def test_version_outputs_package_version():
     assert f"qluent, version {__version__}" in result.output
 
 
-def test_setup_saves_config_and_writes_claude_md(monkeypatch, isolated_config, tmp_path):
+def test_setup_saves_config_and_writes_agents_md(monkeypatch, isolated_config, tmp_path):
     _config_dir, config_file = isolated_config
     monkeypatch.chdir(tmp_path)
 
@@ -40,9 +40,10 @@ def test_setup_saves_config_and_writes_claude_md(monkeypatch, isolated_config, t
         "user_email": "user@example.com",
         "client_safe": True,
     }
-    claude_md = tmp_path / "CLAUDE.md"
-    assert claude_md.exists()
-    assert "# Qluent Metric Trees" in claude_md.read_text()
+    agents_md = tmp_path / "AGENTS.md"
+    assert agents_md.exists()
+    assert "# Qluent Metric Trees" in agents_md.read_text()
+    assert not (tmp_path / "CLAUDE.md").exists()
 
 
 def test_setup_uses_production_default_api_url(monkeypatch, isolated_config, tmp_path):
@@ -61,7 +62,7 @@ def test_setup_uses_production_default_api_url(monkeypatch, isolated_config, tmp
     )
 
     assert result.exit_code == 0
-    assert "Skipped CLAUDE.md generation" in result.output
+    assert "Skipped AGENTS.md generation" in result.output
     saved = json.loads(config_file.read_text())
     assert saved["api_url"] == config_module.DEFAULT_API_URL
 
@@ -106,6 +107,72 @@ def test_claude_init_requires_force_to_overwrite(monkeypatch, tmp_path):
 
     assert result.exit_code != 0
     assert "already exists" in result.output
+
+
+def test_agents_init_default_writes_agents_md(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli, ["agents", "init"])
+
+    assert result.exit_code == 0
+    agents_md = tmp_path / "AGENTS.md"
+    assert agents_md.exists()
+    assert "# Qluent Metric Trees" in agents_md.read_text()
+    assert not (tmp_path / "CLAUDE.md").exists()
+
+
+def test_agents_init_as_claude_writes_claude_md(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli, ["agents", "init", "--as", "claude"])
+
+    assert result.exit_code == 0
+    claude_md = tmp_path / "CLAUDE.md"
+    assert claude_md.exists()
+    assert "# Qluent Metric Trees" in claude_md.read_text()
+    assert not (tmp_path / "AGENTS.md").exists()
+
+
+def test_agents_init_as_both_writes_agents_and_claude_pointer(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli, ["agents", "init", "--as", "both"])
+
+    assert result.exit_code == 0
+    agents_md = tmp_path / "AGENTS.md"
+    claude_md = tmp_path / "CLAUDE.md"
+    assert agents_md.exists()
+    assert claude_md.exists()
+    # AGENTS.md gets the full instructions; CLAUDE.md is a tiny pointer.
+    assert "Shapley" in agents_md.read_text()
+    pointer = claude_md.read_text()
+    assert "See [AGENTS.md](AGENTS.md)" in pointer
+    assert "Shapley" not in pointer
+
+
+def test_agents_init_requires_force_to_overwrite(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "AGENTS.md").write_text("existing")
+
+    result = CliRunner().invoke(cli, ["agents", "init"])
+
+    assert result.exit_code != 0
+    assert "already exists" in result.output
+
+    forced = CliRunner().invoke(cli, ["agents", "init", "--force"])
+    assert forced.exit_code == 0
+    assert "# Qluent Metric Trees" in (tmp_path / "AGENTS.md").read_text()
+
+
+def test_agents_init_as_both_rejects_custom_path(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(
+        cli, ["agents", "init", "--as", "both", "--path", "elsewhere.md"]
+    )
+
+    assert result.exit_code != 0
+    assert "incompatible" in result.output
 
 
 def test_status_outputs_connected_project_and_trees(monkeypatch):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -143,10 +143,10 @@ def test_agents_init_as_both_writes_agents_and_claude_pointer(monkeypatch, tmp_p
     claude_md = tmp_path / "CLAUDE.md"
     assert agents_md.exists()
     assert claude_md.exists()
-    # AGENTS.md gets the full instructions; CLAUDE.md is a tiny pointer.
+    # AGENTS.md gets the full instructions; CLAUDE.md imports it for Claude Code.
     assert "Shapley" in agents_md.read_text()
     pointer = claude_md.read_text()
-    assert "See [AGENTS.md](AGENTS.md)" in pointer
+    assert pointer.startswith("@AGENTS.md\n")
     assert "Shapley" not in pointer
 
 
@@ -173,6 +173,35 @@ def test_agents_init_as_both_rejects_custom_path(monkeypatch, tmp_path):
 
     assert result.exit_code != 0
     assert "incompatible" in result.output
+
+
+def test_setup_accepts_deprecated_claude_path_alias(
+    monkeypatch, isolated_config, tmp_path
+):
+    _config_dir, _config_file = isolated_config
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "setup",
+            "--no-install-plugin",
+            "--claude-path",
+            "CUSTOM_CLAUDE.md",
+        ],
+        input=(
+            "qk_test\n"
+            "project-123\n"
+            "user@example.com\n"
+            "\n"
+        ),
+    )
+
+    assert result.exit_code == 0
+    custom_path = tmp_path / "CUSTOM_CLAUDE.md"
+    assert custom_path.exists()
+    assert "# Qluent Metric Trees" in custom_path.read_text()
+    assert not (tmp_path / "AGENTS.md").exists()
 
 
 def test_status_outputs_connected_project_and_trees(monkeypatch):


### PR DESCRIPTION
Closes #50.

## Summary
- Rename `claude_instructions.md` → `agent_instructions.md` and rewrite the few Claude-specific phrasings to be agent-neutral. Add a short per-agent notes section pointing Claude Code users at the plugin and Codex/Cursor/Continue/Zed users at `qluent mcp serve`.
- New `qluent agents init` group:
  - default writes `AGENTS.md`
  - `--as claude` writes `CLAUDE.md` with the same content
  - `--as both` writes `AGENTS.md` plus a tiny `CLAUDE.md` pointer
- `qluent claude init` is kept as a thin alias for `qluent agents init --as claude` for back-compat.
- `qluent setup` and `qluent login` default to writing `AGENTS.md`. Setup prompt is now `"Write AGENTS.md? [Y/n]"` instead of mentioning Claude.
- README documents the new command and the `AGENTS.override.md` convention (Codex's pattern: an override file in the same directory wins over `AGENTS.md`; `qluent agents init` never touches it).
- `pyproject.toml` package-data updated for the renamed bundled file.

## Test plan
- [x] `uv run pytest` (109 passed)
- [x] `qluent agents init` writes `AGENTS.md`
- [x] `qluent agents init --as claude` writes `CLAUDE.md` with full instructions
- [x] `qluent agents init --as both` writes `AGENTS.md` + `CLAUDE.md` pointer
- [x] `qluent claude init` still writes `CLAUDE.md` (alias)
- [x] `qluent setup` first-run prompt is `Write AGENTS.md?` and the file is written

🤖 Generated with [Claude Code](https://claude.com/claude-code)