### PR TITLE
Persist investigate/deep-dive runs with --last/--resume (closes #47)

### DIFF
--- a/src/qluent_cli/main.py
+++ b/src/qluent_cli/main.py
@@ -564,5 +564,171 @@ def mcp_serve() -> None:
 cli.add_command(mcp)
 
 
+@cli.group()
+def runs() -> None:
+    """Inspect, replay, and prune persisted investigate / deep-dive runs."""
+
+
+def _format_runs_table(records: list[Any]) -> str:
+    if not records:
+        return "No persisted runs."
+    rows = [("RUN_ID", "STARTED", "COMMAND", "TREE", "PERIOD")]
+    for r in records:
+        period = "-"
+        if r.period_start and r.period_end:
+            period = f"{r.period_start}..{r.period_end}"
+        rows.append(
+            (
+                r.run_id,
+                r.started_at,
+                r.command,
+                r.tree_id or "*",
+                period,
+            )
+        )
+    widths = [max(len(row[i]) for row in rows) for i in range(len(rows[0]))]
+    return "\n".join(
+        "  ".join(value.ljust(widths[i]) for i, value in enumerate(row))
+        for row in rows
+    )
+
+
+@runs.command("list")
+@click.option("--tree", "tree_id", default=None, help="Filter to a specific tree id.")
+@click.option(
+    "--command",
+    "command_filter",
+    default=None,
+    type=click.Choice(["trees investigate", "trees deep-dive"]),
+    help="Filter by command kind.",
+)
+@click.option(
+    "--since",
+    default=None,
+    help="Only runs started within this duration (e.g. '7d', '30d', '7 days ago').",
+)
+@click.option("--limit", default=None, type=click.IntRange(1, 1000), help="Cap the result count.")
+@click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
+def runs_list(
+    tree_id: str | None,
+    command_filter: str | None,
+    since: str | None,
+    limit: int | None,
+    as_json: bool,
+) -> None:
+    """List persisted runs newest-first."""
+    from qluent_cli import sessions
+
+    try:
+        records = sessions.list_runs(
+            tree_id=tree_id,
+            command=command_filter,
+            since=since,
+            limit=limit,
+        )
+    except ValueError as exc:
+        raise click.ClickException(str(exc))
+
+    if as_json:
+        payload = [
+            {
+                "run_id": r.run_id,
+                "command": r.command,
+                "tree_id": r.tree_id,
+                "period_start": r.period_start,
+                "period_end": r.period_end,
+                "comparison_start": r.comparison_start,
+                "comparison_end": r.comparison_end,
+                "started_at": r.started_at,
+                "profile": r.profile,
+                "client_safe": r.client_safe,
+                "path": str(r.path),
+            }
+            for r in records
+        ]
+        click.echo(json.dumps(payload, indent=2))
+        return
+
+    click.echo(_format_runs_table(records))
+
+
+@runs.command("show")
+@click.argument("run_id", required=False)
+@click.option("--last", "use_last", is_flag=True, help="Show the most recent matching run.")
+@click.option("--tree", "tree_id", default=None, help="When used with --last, filter to a tree id.")
+@click.option(
+    "--command",
+    "command_filter",
+    default=None,
+    type=click.Choice(["trees investigate", "trees deep-dive"]),
+    help="When used with --last, filter by command kind.",
+)
+@click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
+def runs_show(
+    run_id: str | None,
+    use_last: bool,
+    tree_id: str | None,
+    command_filter: str | None,
+    as_json: bool,
+) -> None:
+    """Print the stored result for a run."""
+    from qluent_cli import sessions
+
+    if not run_id and not use_last:
+        raise click.ClickException("Provide a RUN_ID or use --last.")
+    if run_id and use_last:
+        raise click.ClickException("Use either RUN_ID or --last, not both.")
+
+    if use_last:
+        record = sessions.find_last_run(command=command_filter, tree_id=tree_id)
+        if record is None:
+            raise click.ClickException("No persisted runs match.")
+    else:
+        record = sessions.get_run(run_id)
+        if record is None:
+            raise click.ClickException(f"No run found for run_id={run_id}")
+
+    payload = record.load()
+    if as_json:
+        click.echo(json.dumps(payload, indent=2))
+        return
+
+    click.echo(f"run_id: {record.run_id}")
+    click.echo(f"command: {record.command}")
+    if record.tree_id:
+        click.echo(f"tree: {record.tree_id}")
+    if record.period_start and record.period_end:
+        click.echo(f"period: {record.period_start}..{record.period_end}")
+    click.echo(f"started: {record.started_at}")
+    click.echo(f"path: {record.path}")
+    click.echo("")
+    click.echo(json.dumps(payload.get("result"), indent=2))
+
+
+@runs.command("prune")
+@click.option("--older-than", default=None, help="Remove runs older than this duration (e.g. '30d').")
+@click.option("--max", "max_runs", default=None, type=click.IntRange(0, 100000), help="Keep at most N most-recent runs.")
+@click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
+def runs_prune(older_than: str | None, max_runs: int | None, as_json: bool) -> None:
+    """Delete old runs by age and/or beyond a most-recent cap."""
+    from qluent_cli import sessions
+
+    if older_than is None and max_runs is None:
+        raise click.ClickException("Provide --older-than and/or --max.")
+
+    try:
+        removed = sessions.prune_runs(older_than=older_than, max_runs=max_runs)
+    except ValueError as exc:
+        raise click.ClickException(str(exc))
+
+    if as_json:
+        click.echo(json.dumps({"removed": [r.run_id for r in removed]}, indent=2))
+        return
+    click.echo(f"Removed {len(removed)} run(s).")
+
+
+cli.add_command(runs)
+
+
 if __name__ == "__main__":
     cli()

--- a/src/qluent_cli/sessions.py
+++ b/src/qluent_cli/sessions.py
@@ -52,6 +52,13 @@ _NATURAL_SECONDS = {
 }
 
 
+def _safe_filename_component(value: str | None) -> str:
+    if not value:
+        return "all"
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "_", value).strip("._")
+    return safe or "tree"
+
+
 def _sessions_dir() -> Path:
     return _config_module.CONFIG_DIR / "sessions"
 
@@ -174,7 +181,7 @@ def record_run(
 
     base = _sessions_dir() / f"{now:%Y/%m/%d}"
     base.mkdir(parents=True, exist_ok=True)
-    file_name = f"{tree_id or 'all'}-{run_id}.json"
+    file_name = f"{_safe_filename_component(tree_id)}-{run_id}.json"
     path = base / file_name
 
     file_payload = {

--- a/src/qluent_cli/sessions.py
+++ b/src/qluent_cli/sessions.py
@@ -1,0 +1,361 @@
+"""Persist successful investigate / deep-dive runs to disk.
+
+Runs are written to ``~/.qluent/sessions/YYYY/MM/DD/<tree>-<run_id>.json``
+and indexed in a SQLite database at ``~/.qluent/sessions/index.db`` so
+``qluent runs list`` and ``--last`` / ``--resume`` lookups stay cheap.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import secrets
+import sqlite3
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from qluent_cli import config as _config_module
+
+
+INVESTIGATE_COMMAND = "trees investigate"
+DEEP_DIVE_COMMAND = "trees deep-dive"
+KNOWN_COMMANDS = (INVESTIGATE_COMMAND, DEEP_DIVE_COMMAND)
+
+
+# Crockford base32 (no I, L, O, U) — gives a time-sortable, unambiguous ID.
+_BASE32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+_RUN_ID_RE = re.compile(r"^[0-9A-Z]{16}$")
+_DURATION_SHORT_RE = re.compile(r"^\s*(\d+)\s*([smhdwy])\s*$", re.IGNORECASE)
+_DURATION_NATURAL_RE = re.compile(
+    r"^\s*(\d+)\s*(second|minute|hour|day|week|month|year)s?\s*(ago)?\s*$",
+    re.IGNORECASE,
+)
+_DURATION_SECONDS = {
+    "s": 1,
+    "m": 60,
+    "h": 3600,
+    "d": 86400,
+    "w": 604800,
+    "y": 31536000,
+}
+_NATURAL_SECONDS = {
+    "second": 1,
+    "minute": 60,
+    "hour": 3600,
+    "day": 86400,
+    "week": 604800,
+    "month": 30 * 86400,
+    "year": 365 * 86400,
+}
+
+
+def _sessions_dir() -> Path:
+    return _config_module.CONFIG_DIR / "sessions"
+
+
+def _index_path() -> Path:
+    return _sessions_dir() / "index.db"
+
+
+def _encode_base32(value: int, length: int) -> str:
+    chars: list[str] = []
+    for _ in range(length):
+        chars.append(_BASE32[value & 0x1F])
+        value >>= 5
+    return "".join(reversed(chars))
+
+
+def generate_run_id(now_ms: int | None = None) -> str:
+    """Return a 16-char Crockford-base32 ID. 10 chars time prefix + 6 random."""
+    ts = int(time.time() * 1000) if now_ms is None else now_ms
+    time_part = _encode_base32(ts, 10)
+    random_part = "".join(_BASE32[secrets.randbelow(32)] for _ in range(6))
+    return time_part + random_part
+
+
+def is_valid_run_id(value: str) -> bool:
+    return bool(_RUN_ID_RE.match(value))
+
+
+@dataclass
+class RunRecord:
+    run_id: str
+    command: str
+    tree_id: str | None
+    period_start: str | None
+    period_end: str | None
+    comparison_start: str | None
+    comparison_end: str | None
+    started_at: str
+    profile: str | None
+    client_safe: bool
+    path: Path
+
+    def load(self) -> dict[str, Any]:
+        with open(self.path) as f:
+            return json.load(f)
+
+
+def _connect() -> sqlite3.Connection:
+    index = _index_path()
+    index.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(index))
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS runs (
+            run_id TEXT PRIMARY KEY,
+            command TEXT NOT NULL,
+            tree_id TEXT,
+            period_start TEXT,
+            period_end TEXT,
+            comparison_start TEXT,
+            comparison_end TEXT,
+            started_at TEXT NOT NULL,
+            profile TEXT,
+            client_safe INTEGER NOT NULL DEFAULT 0,
+            path TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_runs_started ON runs(started_at DESC)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_runs_command_tree ON runs(command, tree_id, started_at DESC)"
+    )
+    return conn
+
+
+def _row_to_record(row: sqlite3.Row) -> RunRecord:
+    return RunRecord(
+        run_id=row["run_id"],
+        command=row["command"],
+        tree_id=row["tree_id"],
+        period_start=row["period_start"],
+        period_end=row["period_end"],
+        comparison_start=row["comparison_start"],
+        comparison_end=row["comparison_end"],
+        started_at=row["started_at"],
+        profile=row["profile"],
+        client_safe=bool(row["client_safe"]),
+        path=Path(row["path"]),
+    )
+
+
+def _now_iso() -> tuple[datetime, str]:
+    now = datetime.now(timezone.utc)
+    return now, _iso(now)
+
+
+def _iso(value: datetime) -> str:
+    return value.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def record_run(
+    *,
+    command: str,
+    tree_id: str | None,
+    period_start: str | None,
+    period_end: str | None,
+    comparison_start: str | None,
+    comparison_end: str | None,
+    profile: str | None,
+    client_safe: bool,
+    args: dict[str, Any],
+    payload: Any,
+) -> RunRecord:
+    """Persist a successful run. Writes the JSON file then indexes it."""
+    now, started_at = _now_iso()
+    run_id = generate_run_id(int(now.timestamp() * 1000))
+
+    base = _sessions_dir() / f"{now:%Y/%m/%d}"
+    base.mkdir(parents=True, exist_ok=True)
+    file_name = f"{tree_id or 'all'}-{run_id}.json"
+    path = base / file_name
+
+    file_payload = {
+        "run_id": run_id,
+        "command": command,
+        "tree_id": tree_id,
+        "period": {
+            "current_from": period_start,
+            "current_to": period_end,
+            "comparison_from": comparison_start,
+            "comparison_to": comparison_end,
+        },
+        "profile": profile,
+        "client_safe": client_safe,
+        "started_at": started_at,
+        "args": args,
+        "result": payload,
+    }
+    with open(path, "w") as f:
+        json.dump(file_payload, f, indent=2, default=str)
+
+    try:
+        with _connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO runs (
+                    run_id, command, tree_id,
+                    period_start, period_end,
+                    comparison_start, comparison_end,
+                    started_at, profile, client_safe, path
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run_id,
+                    command,
+                    tree_id,
+                    period_start,
+                    period_end,
+                    comparison_start,
+                    comparison_end,
+                    started_at,
+                    profile,
+                    1 if client_safe else 0,
+                    str(path),
+                ),
+            )
+    except Exception:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+    return RunRecord(
+        run_id=run_id,
+        command=command,
+        tree_id=tree_id,
+        period_start=period_start,
+        period_end=period_end,
+        comparison_start=comparison_start,
+        comparison_end=comparison_end,
+        started_at=started_at,
+        profile=profile,
+        client_safe=client_safe,
+        path=path,
+    )
+
+
+def get_run(run_id: str) -> RunRecord | None:
+    if not _index_path().exists():
+        return None
+    with _connect() as conn:
+        row = conn.execute(
+            "SELECT * FROM runs WHERE run_id = ?", (run_id,)
+        ).fetchone()
+    return _row_to_record(row) if row else None
+
+
+def find_last_run(
+    *,
+    command: str | None = None,
+    tree_id: str | None = None,
+) -> RunRecord | None:
+    if not _index_path().exists():
+        return None
+    clauses: list[str] = []
+    params: list[Any] = []
+    if command:
+        clauses.append("command = ?")
+        params.append(command)
+    if tree_id:
+        clauses.append("tree_id = ?")
+        params.append(tree_id)
+    where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+    sql = f"SELECT * FROM runs {where} ORDER BY started_at DESC LIMIT 1"
+    with _connect() as conn:
+        row = conn.execute(sql, params).fetchone()
+    return _row_to_record(row) if row else None
+
+
+def list_runs(
+    *,
+    tree_id: str | None = None,
+    command: str | None = None,
+    since: str | None = None,
+    limit: int | None = None,
+) -> list[RunRecord]:
+    if not _index_path().exists():
+        return []
+    clauses: list[str] = []
+    params: list[Any] = []
+    if tree_id:
+        clauses.append("tree_id = ?")
+        params.append(tree_id)
+    if command:
+        clauses.append("command = ?")
+        params.append(command)
+    if since:
+        cutoff = relative_cutoff(since)
+        clauses.append("started_at >= ?")
+        params.append(_iso(cutoff))
+    where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+    sql = f"SELECT * FROM runs {where} ORDER BY started_at DESC"
+    if limit is not None:
+        sql += f" LIMIT {int(limit)}"
+    with _connect() as conn:
+        rows = conn.execute(sql, params).fetchall()
+    return [_row_to_record(r) for r in rows]
+
+
+def parse_relative_seconds(value: str) -> int:
+    """Parse '30d', '12h', '7 days ago' into a positive number of seconds."""
+    short = _DURATION_SHORT_RE.match(value)
+    if short:
+        return _DURATION_SECONDS[short.group(2).lower()] * int(short.group(1))
+    natural = _DURATION_NATURAL_RE.match(value)
+    if natural:
+        return _NATURAL_SECONDS[natural.group(2).lower()] * int(natural.group(1))
+    raise ValueError(
+        f"Invalid duration '{value}'. Use forms like '30d', '12h', or '7 days ago'."
+    )
+
+
+def relative_cutoff(value: str) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(seconds=parse_relative_seconds(value))
+
+
+def prune_runs(
+    *, older_than: str | None = None, max_runs: int | None = None
+) -> list[RunRecord]:
+    """Delete runs older than ``older_than`` and beyond the ``max_runs`` cap."""
+    if not _index_path().exists():
+        return []
+
+    removed: list[RunRecord] = []
+    with _connect() as conn:
+        if older_than:
+            cutoff = relative_cutoff(older_than)
+            rows = conn.execute(
+                "SELECT * FROM runs WHERE started_at < ?", (_iso(cutoff),)
+            ).fetchall()
+            for row in rows:
+                _delete_file(row["path"])
+                conn.execute("DELETE FROM runs WHERE run_id = ?", (row["run_id"],))
+                removed.append(_row_to_record(row))
+
+        if max_runs is not None:
+            rows = conn.execute(
+                "SELECT * FROM runs ORDER BY started_at DESC LIMIT -1 OFFSET ?",
+                (max_runs,),
+            ).fetchall()
+            for row in rows:
+                _delete_file(row["path"])
+                conn.execute("DELETE FROM runs WHERE run_id = ?", (row["run_id"],))
+                removed.append(_row_to_record(row))
+
+    return removed
+
+
+def _delete_file(path: str) -> None:
+    try:
+        Path(path).unlink()
+    except FileNotFoundError:
+        pass

--- a/src/qluent_cli/trees.py
+++ b/src/qluent_cli/trees.py
@@ -160,13 +160,13 @@ class _RunReporter:
             prefix = f"[qluent] {tree_id} " if tree_id else "[qluent] "
             echo_status(f"{prefix}received, formatting...")
 
-    def complete(self, result: dict[str, Any]) -> None:
+    def complete(self, result: dict[str, Any], *, run_id: str | None = None) -> None:
         if not self.stream:
             return
         self._emit_jsonl(
             {
                 "type": "run.completed",
-                "run_id": self.run_id,
+                "run_id": run_id or self.run_id,
                 "elapsed_ms": int((time.monotonic() - self.started_at) * 1000),
                 "result": result,
             }
@@ -711,7 +711,7 @@ def investigate(
     )
 
     if stream:
-        reporter.complete(bundle)
+        reporter.complete(bundle, run_id=record.run_id if record else None)
         return
     _emit_investigation(
         bundle,
@@ -912,7 +912,7 @@ def deep_dive(
         )
 
     if stream:
-        reporter.complete(bundle)
+        reporter.complete(bundle, run_id=record.run_id if record else None)
         return
 
     _emit_deep_dive(

--- a/src/qluent_cli/trees.py
+++ b/src/qluent_cli/trees.py
@@ -13,8 +13,9 @@ from typing import Any
 
 import click
 
+from qluent_cli import sessions
 from qluent_cli.client import QluentClient
-from qluent_cli.config import load_config
+from qluent_cli.config import QluentConfig, load_config
 from qluent_cli.output import echo_status
 from qluent_cli.tree_contracts import build_tree_query_contract
 from qluent_cli.formatters import (
@@ -34,6 +35,52 @@ from qluent_cli.utils import parse_filters, resolve_date_args
 @click.group()
 def trees() -> None:
     """Metric tree commands."""
+
+
+def _profile_for(config: QluentConfig) -> str:
+    return f"{config.user_email}@{config.api_url}"
+
+
+def _resume_or_last(
+    *,
+    command: str,
+    resume: str | None,
+    use_last: bool,
+    tree_id: str | None,
+) -> sessions.RunRecord | None:
+    """Resolve --resume / --last to a stored run; raises if requested but missing."""
+    if resume and use_last:
+        raise click.ClickException("Use either --resume or --last, not both.")
+    if resume:
+        record = sessions.get_run(resume)
+        if record is None:
+            raise click.ClickException(f"No run found for run_id={resume}")
+        if record.command != command:
+            raise click.ClickException(
+                f"Run {resume} is a {record.command!r} run, not {command!r}."
+            )
+        if tree_id and record.tree_id and record.tree_id != tree_id:
+            raise click.ClickException(
+                f"Run {resume} is for tree {record.tree_id!r}, not {tree_id!r}."
+            )
+        return record
+    if use_last:
+        record = sessions.find_last_run(command=command, tree_id=tree_id)
+        if record is None:
+            target = f" for {tree_id}" if tree_id else ""
+            raise click.ClickException(
+                f"No prior {command!r} run{target} found. Run it once to populate the cache."
+            )
+        return record
+    return None
+
+
+def _persist_run_safely(**kwargs):
+    try:
+        return sessions.record_run(**kwargs)
+    except Exception as exc:
+        click.echo(f"Warning: failed to persist run: {exc}", err=True)
+        return None
 
 
 _DEFAULT_LEVER_SCENARIOS = (0.01, 0.05, 0.10)
@@ -559,6 +606,8 @@ def compare(
 )
 @click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
 @click.option("--stream", is_flag=True, help="Emit JSONL progress events and the final result.")
+@click.option("--resume", "resume", default=None, help="Re-print a previously persisted run by run_id (no API call).")
+@click.option("--last", "use_last", is_flag=True, help="Re-print the most recent investigate of this tree (no API call).")
 def investigate(
     tree_id: str,
     period: str | None,
@@ -576,9 +625,23 @@ def investigate(
     min_contribution_share: float,
     as_json: bool,
     stream: bool,
+    resume: str | None,
+    use_last: bool,
 ) -> None:
     """Run a deterministic multi-step investigation bundle for a tree."""
-    client = QluentClient(load_config())
+    cached = _resume_or_last(
+        command=sessions.INVESTIGATE_COMMAND,
+        resume=resume,
+        use_last=use_last,
+        tree_id=tree_id,
+    )
+    if cached is not None:
+        bundle = cached.load().get("result") or {}
+        _emit_investigation(bundle, as_json=as_json, run_id=cached.run_id, from_cache=True)
+        return
+
+    config = load_config()
+    client = QluentClient(config)
     parsed_filters = parse_filters(filters)
     c_from, c_to, p_from, p_to = resolve_date_args(period, current_range, compare_range)
     period_label = format_period_label(c_from, c_to, p_from, p_to)
@@ -620,13 +683,57 @@ def investigate(
         metrics_by_tree=metrics_by_tree,
     )
 
+    record = _persist_run_safely(
+        command=sessions.INVESTIGATE_COMMAND,
+        tree_id=tree_id,
+        period_start=c_from,
+        period_end=c_to,
+        comparison_start=p_from,
+        comparison_end=p_to,
+        profile=_profile_for(config),
+        client_safe=config.client_safe,
+        args={
+            "period": period,
+            "current": current_range,
+            "compare": compare_range,
+            "trend_periods": trend_periods,
+            "trend_grain": trend_grain,
+            "trend_as_of": trend_as_of,
+            "segment_by": list(segment_by),
+            "filters": parsed_filters,
+            "compare_trees": list(compare_trees),
+            "max_depth": max_depth,
+            "max_branches": max_branches,
+            "max_segments": max_segments,
+            "min_contribution_share": min_contribution_share,
+        },
+        payload=bundle,
+    )
+
     if stream:
         reporter.complete(bundle)
         return
+    _emit_investigation(
+        bundle,
+        as_json=as_json,
+        run_id=record.run_id if record else None,
+    )
+
+
+def _emit_investigation(
+    bundle: dict[str, Any],
+    *,
+    as_json: bool,
+    run_id: str | None,
+    from_cache: bool = False,
+) -> None:
     if as_json:
         click.echo(json.dumps(bundle, indent=2))
     else:
         click.echo(format_investigation(bundle))
+        if run_id:
+            tag = "(cached)" if from_cache else "(saved)"
+            click.echo(f"\nrun_id: {run_id} {tag}")
 
 
 @trees.command(name="deep-dive")
@@ -658,6 +765,8 @@ def investigate(
 )
 @click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
 @click.option("--stream", is_flag=True, help="Emit JSONL progress events and the final result.")
+@click.option("--resume", "resume", default=None, help="Re-print a previously persisted run by run_id (no API call).")
+@click.option("--last", "use_last", is_flag=True, help="Re-print the most recent deep-dive (no API call).")
 def deep_dive(
     period: str | None,
     current_range: str | None,
@@ -673,9 +782,23 @@ def deep_dive(
     max_workers: int,
     as_json: bool,
     stream: bool,
+    resume: str | None,
+    use_last: bool,
 ) -> None:
     """Run investigations across every tree in parallel and bundle the results."""
-    client = QluentClient(load_config())
+    cached = _resume_or_last(
+        command=sessions.DEEP_DIVE_COMMAND,
+        resume=resume,
+        use_last=use_last,
+        tree_id=None,
+    )
+    if cached is not None:
+        bundle = cached.load().get("result") or {}
+        _emit_deep_dive(bundle, as_json=as_json, run_id=cached.run_id, from_cache=True)
+        return
+
+    config = load_config()
+    client = QluentClient(config)
     c_from, c_to, p_from, p_to = resolve_date_args(period, current_range, compare_range)
 
     trees_data = client.list_trees()
@@ -760,14 +883,66 @@ def deep_dive(
         "errors": errors,
     }
 
+    record: sessions.RunRecord | None = None
+    if ordered_results:
+        record = _persist_run_safely(
+            command=sessions.DEEP_DIVE_COMMAND,
+            tree_id=None,
+            period_start=c_from,
+            period_end=c_to,
+            comparison_start=p_from,
+            comparison_end=p_to,
+            profile=_profile_for(config),
+            client_safe=config.client_safe,
+            args={
+                "period": period,
+                "current": current_range,
+                "compare": compare_range,
+                "tree_ids": list(tree_ids),
+                "trend_periods": trend_periods,
+                "trend_grain": trend_grain,
+                "trend_as_of": trend_as_of,
+                "max_depth": max_depth,
+                "max_branches": max_branches,
+                "max_segments": max_segments,
+                "min_contribution_share": min_contribution_share,
+                "max_workers": max_workers,
+            },
+            payload=bundle,
+        )
+
     if stream:
         reporter.complete(bundle)
         return
 
+    _emit_deep_dive(
+        bundle,
+        as_json=as_json,
+        run_id=record.run_id if record else None,
+    )
+
+
+def _emit_deep_dive(
+    bundle: dict[str, Any],
+    *,
+    as_json: bool,
+    run_id: str | None,
+    from_cache: bool = False,
+) -> None:
     if as_json:
         click.echo(json.dumps(bundle, indent=2))
         return
 
+    period = bundle.get("period") or {}
+    targets = bundle.get("trees_requested") or list((bundle.get("trees") or {}).keys())
+    ordered_results = bundle.get("trees") or {}
+    errors = bundle.get("errors") or {}
+    period_label = format_period_label(
+        period.get("current_from") or "",
+        period.get("current_to") or "",
+        period.get("comparison_from") or "",
+        period.get("comparison_to") or "",
+    )
     click.echo(f"Deep-dive across {len(targets)} tree(s) — {period_label}")
     click.echo("")
     for tid in targets:
@@ -779,3 +954,6 @@ def deep_dive(
         else:
             click.echo(f"  Failed: {errors.get(tid, 'unknown error')}")
         click.echo("")
+    if run_id:
+        tag = "(cached)" if from_cache else "(saved)"
+        click.echo(f"run_id: {run_id} {tag}")

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -87,6 +87,17 @@ def test_record_run_writes_file_and_indexes(isolated_config):
     assert body["result"] == {"tree_id": "revenue", "delta": 10}
 
 
+def test_record_run_sanitizes_tree_id_for_filename(isolated_config):
+    record = _record(tree_id="../sales/revenue", payload={"tree_id": "../sales/revenue"})
+
+    assert record.tree_id == "../sales/revenue"
+    assert record.path.name.endswith(f"-{record.run_id}.json")
+    assert record.path.name.startswith("sales_revenue-")
+    assert record.path.parent == isolated_config[0] / "sessions" / record.started_at[:4] / record.started_at[5:7] / record.started_at[8:10]
+    body = json.loads(record.path.read_text())
+    assert body["tree_id"] == "../sales/revenue"
+
+
 def test_get_run_returns_none_when_missing(isolated_config):
     assert sessions.get_run("01234567ABCDEFGH") is None
 
@@ -300,6 +311,63 @@ def test_investigate_persists_run_and_resumable(isolated_config, monkeypatch):
     )
     assert last.exit_code == 0, last.output
     assert len(api_calls) == 1
+
+
+def test_investigate_stream_completion_run_id_is_resumable(isolated_config, monkeypatch):
+    _stub_config(monkeypatch)
+    monkeypatch.setattr(
+        "qluent_cli.trees.QluentClient.list_trees",
+        lambda self: {"trees": [{"id": "revenue", "nodes": []}]},
+    )
+
+    api_calls: list[str] = []
+
+    def mock_investigate(self, tree_id, c_from, c_to, p_from, p_to, **kwargs):
+        api_calls.append(tree_id)
+        return {
+            "tree_id": tree_id,
+            "tree_label": "Revenue",
+            "agent": {"top_findings": ["grew 10%"]},
+        }
+
+    monkeypatch.setattr(
+        "qluent_cli.trees.QluentClient.investigate_tree", mock_investigate
+    )
+
+    runner = CliRunner()
+    streamed = runner.invoke(
+        cli,
+        [
+            "trees",
+            "investigate",
+            "revenue",
+            "--current",
+            "2026-03-09:2026-03-15",
+            "--compare",
+            "2026-03-02:2026-03-08",
+            "--json-output",
+            "--stream",
+        ],
+    )
+    assert streamed.exit_code == 0, streamed.output
+    events = [json.loads(line) for line in streamed.output.splitlines()]
+    completed = events[-1]
+    assert completed["type"] == "run.completed"
+
+    resumed = runner.invoke(
+        cli,
+        [
+            "trees",
+            "investigate",
+            "revenue",
+            "--resume",
+            completed["run_id"],
+            "--json-output",
+        ],
+    )
+    assert resumed.exit_code == 0, resumed.output
+    assert len(api_calls) == 1
+    assert json.loads(resumed.output)["tree_id"] == "revenue"
 
 
 def test_investigate_failure_does_not_persist(isolated_config, monkeypatch):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,403 @@
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from click.testing import CliRunner
+
+from qluent_cli import sessions
+from qluent_cli.config import QluentConfig
+from qluent_cli.main import cli
+
+
+# -------------------------- pure-function tests --------------------------
+
+
+def test_generate_run_id_is_well_formed():
+    run_id = sessions.generate_run_id()
+    assert sessions.is_valid_run_id(run_id)
+    assert len(run_id) == 16
+
+
+def test_generate_run_id_is_time_sortable():
+    earlier = sessions.generate_run_id(now_ms=1_700_000_000_000)
+    later = sessions.generate_run_id(now_ms=1_700_000_001_000)
+    assert earlier < later
+
+
+def test_parse_relative_seconds_short_forms():
+    assert sessions.parse_relative_seconds("30d") == 30 * 86400
+    assert sessions.parse_relative_seconds("12h") == 12 * 3600
+    assert sessions.parse_relative_seconds("2w") == 14 * 86400
+
+
+def test_parse_relative_seconds_natural_form():
+    assert sessions.parse_relative_seconds("7 days ago") == 7 * 86400
+    assert sessions.parse_relative_seconds("1 hour") == 3600
+
+
+def test_parse_relative_seconds_rejects_garbage():
+    with pytest.raises(ValueError):
+        sessions.parse_relative_seconds("yesterday")
+
+
+# -------------------------- record / retrieve --------------------------
+
+
+def _record(
+    *,
+    command: str = sessions.INVESTIGATE_COMMAND,
+    tree_id: str | None = "revenue",
+    payload: dict | None = None,
+    profile: str = "ludvig@qluent.com@https://api.example.com",
+    period_start: str | None = "2026-04-21",
+    period_end: str | None = "2026-04-27",
+    comparison_start: str | None = "2026-04-14",
+    comparison_end: str | None = "2026-04-20",
+    args: dict | None = None,
+    client_safe: bool = True,
+) -> sessions.RunRecord:
+    return sessions.record_run(
+        command=command,
+        tree_id=tree_id,
+        period_start=period_start,
+        period_end=period_end,
+        comparison_start=comparison_start,
+        comparison_end=comparison_end,
+        profile=profile,
+        client_safe=client_safe,
+        args=args or {},
+        payload=payload or {"tree_id": tree_id, "agent": {}},
+    )
+
+
+def test_record_run_writes_file_and_indexes(isolated_config):
+    record = _record(payload={"tree_id": "revenue", "delta": 10})
+
+    assert record.path.exists()
+    fetched = sessions.get_run(record.run_id)
+    assert fetched is not None
+    assert fetched.run_id == record.run_id
+    assert fetched.tree_id == "revenue"
+    assert fetched.client_safe is True
+    body = json.loads(record.path.read_text())
+    assert body["run_id"] == record.run_id
+    assert body["result"] == {"tree_id": "revenue", "delta": 10}
+
+
+def test_get_run_returns_none_when_missing(isolated_config):
+    assert sessions.get_run("01234567ABCDEFGH") is None
+
+
+def test_find_last_run_filters_by_command_and_tree(isolated_config):
+    inv_revenue = _record(command=sessions.INVESTIGATE_COMMAND, tree_id="revenue")
+    time.sleep(0.005)
+    _record(command=sessions.INVESTIGATE_COMMAND, tree_id="growth")
+    time.sleep(0.005)
+    deep = _record(command=sessions.DEEP_DIVE_COMMAND, tree_id=None)
+
+    last_inv_revenue = sessions.find_last_run(
+        command=sessions.INVESTIGATE_COMMAND, tree_id="revenue"
+    )
+    assert last_inv_revenue is not None
+    assert last_inv_revenue.run_id == inv_revenue.run_id
+
+    last_deep = sessions.find_last_run(command=sessions.DEEP_DIVE_COMMAND)
+    assert last_deep is not None
+    assert last_deep.run_id == deep.run_id
+
+
+def test_list_runs_filters_and_orders(isolated_config):
+    a = _record(tree_id="revenue")
+    time.sleep(0.005)
+    b = _record(tree_id="growth")
+    time.sleep(0.005)
+    c = _record(tree_id="revenue")
+
+    all_runs = sessions.list_runs()
+    assert [r.run_id for r in all_runs] == [c.run_id, b.run_id, a.run_id]
+
+    revenue_runs = sessions.list_runs(tree_id="revenue")
+    assert {r.run_id for r in revenue_runs} == {a.run_id, c.run_id}
+
+    capped = sessions.list_runs(limit=1)
+    assert len(capped) == 1
+
+
+def test_list_runs_since_filters(isolated_config):
+    old = _record(tree_id="revenue")
+    cutoff_iso = sessions._iso(datetime.now(timezone.utc) - timedelta(days=10))
+    with sessions._connect() as conn:
+        conn.execute(
+            "UPDATE runs SET started_at = ? WHERE run_id = ?",
+            (cutoff_iso, old.run_id),
+        )
+    fresh = _record(tree_id="growth")
+
+    recent = sessions.list_runs(since="3d")
+    assert [r.run_id for r in recent] == [fresh.run_id]
+
+
+def test_prune_older_than_removes_old_runs(isolated_config):
+    old = _record(tree_id="revenue")
+    cutoff_iso = sessions._iso(datetime.now(timezone.utc) - timedelta(days=10))
+    with sessions._connect() as conn:
+        conn.execute(
+            "UPDATE runs SET started_at = ? WHERE run_id = ?",
+            (cutoff_iso, old.run_id),
+        )
+    fresh = _record(tree_id="growth")
+
+    removed = sessions.prune_runs(older_than="3d")
+    assert [r.run_id for r in removed] == [old.run_id]
+    assert sessions.get_run(old.run_id) is None
+    assert not old.path.exists()
+    assert sessions.get_run(fresh.run_id) is not None
+
+
+def test_prune_max_runs_keeps_most_recent(isolated_config):
+    a = _record(tree_id="revenue")
+    time.sleep(0.005)
+    b = _record(tree_id="revenue")
+    time.sleep(0.005)
+    c = _record(tree_id="revenue")
+
+    removed = sessions.prune_runs(max_runs=2)
+    removed_ids = {r.run_id for r in removed}
+    assert removed_ids == {a.run_id}
+    assert sessions.get_run(a.run_id) is None
+    assert sessions.get_run(b.run_id) is not None
+    assert sessions.get_run(c.run_id) is not None
+
+
+# -------------------------- CLI integration --------------------------
+
+
+def _stub_config(monkeypatch):
+    monkeypatch.setattr(
+        "qluent_cli.trees.load_config",
+        lambda: QluentConfig(
+            api_key="qk_test",
+            api_url="https://api.example.com",
+            project_uuid="project-123",
+            user_email="user@example.com",
+            client_safe=False,
+        ),
+    )
+
+
+def test_runs_list_empty_says_so(isolated_config):
+    result = CliRunner().invoke(cli, ["runs", "list"])
+    assert result.exit_code == 0
+    assert "No persisted runs." in result.output
+
+
+def test_runs_list_filters_by_tree(isolated_config):
+    _record(tree_id="revenue")
+    time.sleep(0.005)
+    _record(tree_id="growth")
+
+    result = CliRunner().invoke(cli, ["runs", "list", "--tree", "revenue", "--json-output"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert len(payload) == 1
+    assert payload[0]["tree_id"] == "revenue"
+
+
+def test_runs_show_by_id(isolated_config):
+    record = _record(payload={"tree_id": "revenue", "delta": 5})
+    result = CliRunner().invoke(cli, ["runs", "show", record.run_id, "--json-output"])
+    assert result.exit_code == 0
+    body = json.loads(result.output)
+    assert body["result"] == {"tree_id": "revenue", "delta": 5}
+
+
+def test_runs_show_last(isolated_config):
+    _record(tree_id="revenue", payload={"tag": "older"})
+    time.sleep(0.005)
+    newer = _record(tree_id="revenue", payload={"tag": "newer"})
+
+    result = CliRunner().invoke(
+        cli,
+        ["runs", "show", "--last", "--tree", "revenue", "--json-output"],
+    )
+    assert result.exit_code == 0
+    body = json.loads(result.output)
+    assert body["run_id"] == newer.run_id
+    assert body["result"]["tag"] == "newer"
+
+
+def test_runs_show_requires_run_id_or_last(isolated_config):
+    result = CliRunner().invoke(cli, ["runs", "show"])
+    assert result.exit_code != 0
+    assert "Provide a RUN_ID or use --last" in result.output
+
+
+def test_runs_prune_requires_at_least_one_flag(isolated_config):
+    result = CliRunner().invoke(cli, ["runs", "prune"])
+    assert result.exit_code != 0
+    assert "Provide --older-than" in result.output
+
+
+def test_investigate_persists_run_and_resumable(isolated_config, monkeypatch):
+    _stub_config(monkeypatch)
+    monkeypatch.setattr(
+        "qluent_cli.trees.QluentClient.list_trees",
+        lambda self: {"trees": [{"id": "revenue", "nodes": []}]},
+    )
+
+    api_calls: list[str] = []
+
+    def mock_investigate(self, tree_id, c_from, c_to, p_from, p_to, **kwargs):
+        api_calls.append(tree_id)
+        return {
+            "tree_id": tree_id,
+            "tree_label": "Revenue",
+            "agent": {"top_findings": ["grew 10%"]},
+        }
+
+    monkeypatch.setattr(
+        "qluent_cli.trees.QluentClient.investigate_tree", mock_investigate
+    )
+
+    runner = CliRunner()
+    first = runner.invoke(
+        cli,
+        [
+            "trees",
+            "investigate",
+            "revenue",
+            "--current",
+            "2026-03-09:2026-03-15",
+            "--compare",
+            "2026-03-02:2026-03-08",
+            "--json-output",
+        ],
+    )
+    assert first.exit_code == 0, first.output
+    assert len(api_calls) == 1
+
+    records = sessions.list_runs(
+        tree_id="revenue", command=sessions.INVESTIGATE_COMMAND
+    )
+    assert len(records) == 1
+    run_id = records[0].run_id
+
+    resumed = runner.invoke(
+        cli,
+        ["trees", "investigate", "revenue", "--resume", run_id, "--json-output"],
+    )
+    assert resumed.exit_code == 0, resumed.output
+    assert len(api_calls) == 1  # cache hit, no new API call
+    payload = json.loads(resumed.output)
+    assert payload["tree_id"] == "revenue"
+
+    last = runner.invoke(
+        cli,
+        ["trees", "investigate", "revenue", "--last", "--json-output"],
+    )
+    assert last.exit_code == 0, last.output
+    assert len(api_calls) == 1
+
+
+def test_investigate_failure_does_not_persist(isolated_config, monkeypatch):
+    _stub_config(monkeypatch)
+    monkeypatch.setattr(
+        "qluent_cli.trees.QluentClient.list_trees",
+        lambda self: {"trees": [{"id": "revenue", "nodes": []}]},
+    )
+
+    def boom(self, tree_id, c_from, c_to, p_from, p_to, **kwargs):
+        raise RuntimeError("server down")
+
+    monkeypatch.setattr("qluent_cli.trees.QluentClient.investigate_tree", boom)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "trees",
+            "investigate",
+            "revenue",
+            "--current",
+            "2026-03-09:2026-03-15",
+            "--compare",
+            "2026-03-02:2026-03-08",
+            "--json-output",
+        ],
+    )
+    assert result.exit_code != 0
+    assert sessions.list_runs() == []
+
+
+def test_investigate_resume_rejects_wrong_tree(isolated_config, monkeypatch):
+    _stub_config(monkeypatch)
+    record = _record(tree_id="revenue", command=sessions.INVESTIGATE_COMMAND)
+
+    monkeypatch.setattr(
+        "qluent_cli.trees.QluentClient.list_trees",
+        lambda self: {"trees": [{"id": "growth", "nodes": []}]},
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["trees", "investigate", "growth", "--resume", record.run_id, "--json-output"],
+    )
+    assert result.exit_code != 0
+    assert "is for tree 'revenue'" in result.output
+
+
+def test_investigate_last_with_no_runs_errors(isolated_config, monkeypatch):
+    _stub_config(monkeypatch)
+    result = CliRunner().invoke(
+        cli, ["trees", "investigate", "revenue", "--last", "--json-output"]
+    )
+    assert result.exit_code != 0
+    assert "No prior 'trees investigate' run" in result.output
+
+
+def test_deep_dive_persists_run(isolated_config, monkeypatch):
+    _stub_config(monkeypatch)
+    monkeypatch.setattr(
+        "qluent_cli.trees.QluentClient.list_trees",
+        lambda self: {
+            "trees": [
+                {"id": "revenue", "nodes": []},
+                {"id": "growth", "nodes": []},
+            ]
+        },
+    )
+
+    def mock_investigate(self, tree_id, c_from, c_to, p_from, p_to, **kwargs):
+        return {"tree_id": tree_id, "agent": {}}
+
+    monkeypatch.setattr(
+        "qluent_cli.trees.QluentClient.investigate_tree", mock_investigate
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "trees",
+            "deep-dive",
+            "--current",
+            "2026-03-09:2026-03-15",
+            "--compare",
+            "2026-03-02:2026-03-08",
+            "--json-output",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    records = sessions.list_runs(command=sessions.DEEP_DIVE_COMMAND)
+    assert len(records) == 1
+    assert records[0].tree_id is None
+
+    resumed = runner.invoke(
+        cli,
+        ["trees", "deep-dive", "--last", "--json-output"],
+    )
+    assert resumed.exit_code == 0, resumed.output
+    payload = json.loads(resumed.output)
+    assert set(payload["trees"].keys()) == {"revenue", "growth"}


### PR DESCRIPTION
## Summary
- New `~/.qluent/sessions/` store: every successful `qluent trees investigate` / `qluent trees deep-dive` writes its bundle to `YYYY/MM/DD/<tree>-<run_id>.json` and indexes it in a SQLite database (`index.db`) keyed on run_id, command, tree, and started_at.
- `investigate` and `deep-dive` gain `--resume <run_id>` and `--last` flags that re-print a stored bundle with **no API call**.
- New `qluent runs` Click group: `list`, `show [--last]`, `prune --older-than 30d --max N`.
- Failed runs are not persisted; persistence failures emit a warning and never break the CLI.

Closes #47.

## Test plan
- [x] `uv run pytest` — 149/149 passing locally (23 new in `tests/test_sessions.py`)
- [ ] `qluent trees investigate <tree>` once, then `qluent trees investigate <tree> --last` returns the same bundle without hitting the API
- [ ] `qluent runs list --tree <tree>` shows the run; `qluent runs show <run_id>` prints it
- [ ] `qluent runs prune --older-than 30d` deletes old entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)