### PR TITLE
Move resolve_date_args to dates.py as resolve_windows -> DateWindows

### DIFF
--- a/src/qluent_cli/dates.py
+++ b/src/qluent_cli/dates.py
@@ -16,11 +16,66 @@ class DateWindow:
     date_from: date
     date_to: date
 
+    def __post_init__(self) -> None:
+        if self.date_from > self.date_to:
+            raise ValueError(
+                f"Invalid window: date_from {self.date_from} is after date_to {self.date_to}."
+            )
+
+    @property
+    def iso_from(self) -> str:
+        return self.date_from.isoformat()
+
+    @property
+    def iso_to(self) -> str:
+        return self.date_to.isoformat()
+
 
 @dataclass
 class DateWindows:
+    """A current window plus an aligned comparison window.
+
+    Invariants enforced by `DateWindow.__post_init__`:
+      * `current.date_from <= current.date_to`
+      * `comparison.date_from <= comparison.date_to`
+    """
+
     current: DateWindow
     comparison: DateWindow
+
+
+def resolve_windows(
+    period: str | None,
+    current_range: str | None,
+    compare_range: str | None,
+) -> DateWindows:
+    """Resolve CLI period / explicit-range options into a `DateWindows` pair.
+
+    Precedence:
+      1. Both `--current` and `--compare` provided -> use them verbatim.
+      2. Only `--current` provided -> derive comparison from inferred predecessor.
+      3. Otherwise -> infer both from the natural-language `period`
+         (defaulting to "last 7 days").
+    """
+    if current_range and compare_range:
+        return DateWindows(
+            current=_parse_range(current_range),
+            comparison=_parse_range(compare_range),
+        )
+    if current_range:
+        current = _parse_range(current_range)
+        inferred = infer_windows(f"{current.date_from} {current.date_to}")
+        return DateWindows(current=current, comparison=inferred.comparison)
+    return infer_windows(period or "last 7 days")
+
+
+def _parse_range(value: str) -> DateWindow:
+    parts = value.split(":")
+    if len(parts) != 2:
+        raise ValueError(
+            f"Invalid date range '{value}'. Use YYYY-MM-DD:YYYY-MM-DD."
+        )
+    return DateWindow(date.fromisoformat(parts[0]), date.fromisoformat(parts[1]))
 
 
 def infer_windows(period: str, today: date | None = None) -> DateWindows:

--- a/src/qluent_cli/elasticity.py
+++ b/src/qluent_cli/elasticity.py
@@ -9,8 +9,9 @@ import click
 
 from qluent_cli.client import QluentClient
 from qluent_cli.config import QluentConfig, load_config
+from qluent_cli.dates import resolve_windows
 from qluent_cli.formatters import format_elasticity
-from qluent_cli.utils import parse_filters, resolve_date_args
+from qluent_cli.utils import parse_filters
 
 
 def analyze_elasticity(
@@ -89,7 +90,7 @@ def elasticity(
     as_json: bool,
 ) -> None:
     """Analyze observed elasticity between a lever and an outcome metric."""
-    c_from, c_to, p_from, p_to = resolve_date_args(period, current_range, compare_range)
+    windows = resolve_windows(period, current_range, compare_range)
     config = load_config()
     client = QluentClient(config)
     data = analyze_elasticity(
@@ -99,10 +100,10 @@ def elasticity(
         outcome=outcome,
         lever=lever,
         dimension=dimension,
-        current_from=c_from,
-        current_to=c_to,
-        comparison_from=p_from,
-        comparison_to=p_to,
+        current_from=windows.current.iso_from,
+        current_to=windows.current.iso_to,
+        comparison_from=windows.comparison.iso_from,
+        comparison_to=windows.comparison.iso_to,
         filters=parse_filters(filters),
     )
 

--- a/src/qluent_cli/mcp_server.py
+++ b/src/qluent_cli/mcp_server.py
@@ -16,11 +16,12 @@ from typing import Any, Awaitable, Callable
 from qluent_cli import __version__
 from qluent_cli.client import QluentClient
 from qluent_cli.config import QluentConfig, load_config
+from qluent_cli.dates import resolve_windows
 from qluent_cli.elasticity import analyze_elasticity
 from qluent_cli.rca_contracts import enrich_rca_output
 from qluent_cli.runs import run_investigation
 from qluent_cli.suggestions import build_suggestions
-from qluent_cli.utils import parse_filters, resolve_date_args
+from qluent_cli.utils import parse_filters
 
 
 SERVER_NAME = "qluent"
@@ -54,7 +55,13 @@ def _resolve_dates(
     current_range: str | None,
     compare_range: str | None,
 ) -> tuple[str, str, str, str]:
-    return resolve_date_args(period, current_range, compare_range)
+    windows = resolve_windows(period, current_range, compare_range)
+    return (
+        windows.current.iso_from,
+        windows.current.iso_to,
+        windows.comparison.iso_from,
+        windows.comparison.iso_to,
+    )
 
 
 def _filter_schema() -> dict[str, Any]:

--- a/src/qluent_cli/rca.py
+++ b/src/qluent_cli/rca.py
@@ -8,9 +8,10 @@ import click
 
 from qluent_cli.client import QluentClient
 from qluent_cli.config import load_config
+from qluent_cli.dates import resolve_windows
 from qluent_cli.rca_contracts import enrich_rca_output
 from qluent_cli.formatters import format_root_cause
-from qluent_cli.utils import parse_filters, resolve_date_args
+from qluent_cli.utils import parse_filters
 
 
 @click.group()
@@ -51,7 +52,9 @@ def analyze(
     as_json: bool,
 ) -> None:
     """Run deterministic root-cause analysis for a metric tree."""
-    c_from, c_to, p_from, p_to = resolve_date_args(period, current_range, compare_range)
+    windows = resolve_windows(period, current_range, compare_range)
+    c_from, c_to = windows.current.iso_from, windows.current.iso_to
+    p_from, p_to = windows.comparison.iso_from, windows.comparison.iso_to
     parsed_filters = parse_filters(filters)
 
     config = load_config()

--- a/src/qluent_cli/trees.py
+++ b/src/qluent_cli/trees.py
@@ -30,7 +30,8 @@ from qluent_cli.formatters import (
     format_tree_list,
     format_tree_validation,
 )
-from qluent_cli.utils import parse_filters, resolve_date_args
+from qluent_cli.dates import resolve_windows
+from qluent_cli.utils import parse_filters
 
 
 @click.group()
@@ -310,7 +311,9 @@ def evaluate(
     """Evaluate a metric tree over date windows."""
     if as_json and contract_output:
         raise click.ClickException("Use either --json-output or --contract-output, not both.")
-    c_from, c_to, p_from, p_to = resolve_date_args(period, current_range, compare_range)
+    windows = resolve_windows(period, current_range, compare_range)
+    c_from, c_to = windows.current.iso_from, windows.current.iso_to
+    p_from, p_to = windows.comparison.iso_from, windows.comparison.iso_to
     config = load_config()
     client = QluentClient(config)
     data = client.evaluate_tree(tree_id, c_from, c_to, p_from, p_to)
@@ -348,7 +351,9 @@ def levers(
     as_json: bool,
 ) -> None:
     """Quantify top lever impacts from tree elasticities."""
-    c_from, c_to, p_from, p_to = resolve_date_args(period, current_range, compare_range)
+    windows = resolve_windows(period, current_range, compare_range)
+    c_from, c_to = windows.current.iso_from, windows.current.iso_to
+    p_from, p_to = windows.comparison.iso_from, windows.comparison.iso_to
     client = QluentClient(load_config())
     evaluation = client.evaluate_tree(tree_id, c_from, c_to, p_from, p_to)
     data = _build_lever_analysis(evaluation, top_n=top, scenarios=scenarios)
@@ -393,7 +398,9 @@ def compare(
     as_json: bool,
 ) -> None:
     """Compare multiple metric trees side by side for the same period."""
-    c_from, c_to, p_from, p_to = resolve_date_args(period, current_range, compare_range)
+    windows = resolve_windows(period, current_range, compare_range)
+    c_from, c_to = windows.current.iso_from, windows.current.iso_to
+    p_from, p_to = windows.comparison.iso_from, windows.comparison.iso_to
 
     client = QluentClient(load_config())
     results: list[tuple[str, dict[str, Any]]] = []
@@ -466,7 +473,9 @@ def investigate(
     config = load_config()
     client = QluentClient(config)
     parsed_filters = parse_filters(filters)
-    c_from, c_to, p_from, p_to = resolve_date_args(period, current_range, compare_range)
+    windows = resolve_windows(period, current_range, compare_range)
+    c_from, c_to = windows.current.iso_from, windows.current.iso_to
+    p_from, p_to = windows.comparison.iso_from, windows.comparison.iso_to
     period_label = format_period_label(c_from, c_to, p_from, p_to)
     reporter = RunReporter(
         command="investigate",
@@ -619,7 +628,9 @@ def deep_dive(
 
     config = load_config()
     client = QluentClient(config)
-    c_from, c_to, p_from, p_to = resolve_date_args(period, current_range, compare_range)
+    windows = resolve_windows(period, current_range, compare_range)
+    c_from, c_to = windows.current.iso_from, windows.current.iso_to
+    p_from, p_to = windows.comparison.iso_from, windows.comparison.iso_to
 
     trees_data = client.list_trees()
     available = [t.get("id") for t in trees_data.get("trees", []) if t.get("id")]

--- a/src/qluent_cli/utils.py
+++ b/src/qluent_cli/utils.py
@@ -24,29 +24,3 @@ def parse_filters(filter_args: tuple[str, ...]) -> dict[str, list[str]]:
             )
         filters.setdefault(cleaned_key, []).append(cleaned_value)
     return filters
-
-
-def resolve_date_args(
-    period: str | None,
-    current_range: str | None,
-    compare_range: str | None,
-) -> tuple[str, str, str, str]:
-    """Resolve date arguments into (c_from, c_to, p_from, p_to) strings."""
-    from qluent_cli.dates import infer_windows
-
-    if current_range and compare_range:
-        c_from, c_to = current_range.split(":")
-        p_from, p_to = compare_range.split(":")
-    elif current_range:
-        c_from, c_to = current_range.split(":")
-        windows = infer_windows(f"{c_from} {c_to}")
-        p_from = str(windows.comparison.date_from)
-        p_to = str(windows.comparison.date_to)
-    else:
-        period_text = period or "last 7 days"
-        windows = infer_windows(period_text)
-        c_from = str(windows.current.date_from)
-        c_to = str(windows.current.date_to)
-        p_from = str(windows.comparison.date_from)
-        p_to = str(windows.comparison.date_to)
-    return c_from, c_to, p_from, p_to

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from qluent_cli.dates import DateWindow, DateWindows, resolve_windows
+
+
+def test_date_window_rejects_inverted_range():
+    with pytest.raises(ValueError, match="after date_to"):
+        DateWindow(date(2026, 4, 30), date(2026, 4, 1))
+
+
+def test_date_window_iso_strings():
+    w = DateWindow(date(2026, 3, 1), date(2026, 3, 31))
+    assert w.iso_from == "2026-03-01"
+    assert w.iso_to == "2026-03-31"
+
+
+def test_resolve_windows_explicit_current_and_compare():
+    windows = resolve_windows(None, "2026-03-01:2026-03-31", "2026-02-01:2026-02-28")
+    assert isinstance(windows, DateWindows)
+    assert windows.current.iso_from == "2026-03-01"
+    assert windows.current.iso_to == "2026-03-31"
+    assert windows.comparison.iso_from == "2026-02-01"
+    assert windows.comparison.iso_to == "2026-02-28"
+
+
+def test_resolve_windows_only_current_infers_comparison():
+    windows = resolve_windows(None, "2026-03-09:2026-03-15", None)
+    assert windows.current.iso_from == "2026-03-09"
+    assert windows.current.iso_to == "2026-03-15"
+    assert windows.comparison.iso_from == "2026-03-02"
+    assert windows.comparison.iso_to == "2026-03-08"
+
+
+def test_resolve_windows_invalid_range_format():
+    with pytest.raises(ValueError, match="YYYY-MM-DD"):
+        resolve_windows(None, "2026-03-01", "2026-02-01:2026-02-28")
+
+
+def test_resolve_windows_inverted_explicit_range_raises():
+    with pytest.raises(ValueError, match="after date_to"):
+        resolve_windows(None, "2026-03-31:2026-03-01", "2026-02-01:2026-02-28")


### PR DESCRIPTION
## Summary

Closes #61.

Callers were unpacking a 4-tuple of ISO date strings returned by a helper in `utils.py` that had to import `dates.py` at runtime. The shape was implicit and the date-handling code was split between two modules without a clear reason.

- Move the resolver to `dates.py` as `resolve_windows`, returning the existing `DateWindows` dataclass directly.
- Validate `date_from <= date_to` in `DateWindow.__post_init__`, so the invariant is enforced at construction instead of leaking through to whatever uses the tuple downstream.
- Add `iso_from` / `iso_to` properties so callers can get the wire format without `str(...)` casts.
- Update every caller (`trees.py`, `rca.py`, `elasticity.py`, `mcp_server.py`) to consume the dataclass.

## Test plan

- [x] `uv run pytest` — 157 passing (151 existing + 6 new in `tests/test_dates.py`)
- [x] New tests cover: invariant enforcement, ISO accessors, explicit dual-range path, current-only inference path, malformed range, inverted range


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wra47NtSXXSywB3Btp6ACC)_