### PR TITLE
Extract analyze_elasticity() business seam from Click adapter

### DIFF
--- a/src/qluent_cli/elasticity.py
+++ b/src/qluent_cli/elasticity.py
@@ -1,15 +1,70 @@
-"""Elasticity analysis command."""
+"""Elasticity analysis command and the underlying business seam."""
 
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import click
 
 from qluent_cli.client import QluentClient
-from qluent_cli.config import load_config
+from qluent_cli.config import QluentConfig, load_config
 from qluent_cli.formatters import format_elasticity
 from qluent_cli.utils import parse_filters, resolve_date_args
+
+
+def analyze_elasticity(
+    client: QluentClient,
+    config: QluentConfig,
+    *,
+    tree_id: str,
+    outcome: str,
+    lever: str,
+    current_from: str,
+    current_to: str,
+    comparison_from: str,
+    comparison_to: str,
+    dimension: str | None = None,
+    filters: dict[str, list[str]] | None = None,
+) -> dict[str, Any]:
+    """Run elasticity analysis and stamp the deterministic contract fields.
+
+    This is the business seam under the `qluent elasticity` CLI command and
+    the `qluent_elasticity` MCP tool. Both adapters call into here so they
+    cannot drift on contract shape, defaults, or provenance.
+    """
+    data = client.elasticity_tree(
+        tree_id,
+        current_from,
+        current_to,
+        comparison_from,
+        comparison_to,
+        outcome=outcome,
+        lever=lever,
+        dimension=dimension,
+        filters=filters or {},
+    )
+    data.setdefault("contract_kind", "elasticity_analysis")
+    data.setdefault("deterministic", True)
+    data.setdefault("tree_id", tree_id)
+    data.setdefault("outcome", outcome)
+    data.setdefault("lever", lever)
+    data.setdefault("dimension", dimension)
+    data.setdefault("current_window", {"date_from": current_from, "date_to": current_to})
+    data.setdefault("comparison_window", {"date_from": comparison_from, "date_to": comparison_to})
+    data.setdefault("evidence_type", "observed_correlation")
+    data.setdefault("warnings", [])
+    data.setdefault(
+        "provenance",
+        {
+            "source": "metric_tree_elasticity",
+            "project_uuid": config.project_uuid,
+            "tree_id": tree_id,
+            "outcome": outcome,
+            "lever": lever,
+        },
+    )
+    return data
 
 
 @click.command()
@@ -35,39 +90,20 @@ def elasticity(
 ) -> None:
     """Analyze observed elasticity between a lever and an outcome metric."""
     c_from, c_to, p_from, p_to = resolve_date_args(period, current_range, compare_range)
-    parsed_filters = parse_filters(filters)
     config = load_config()
     client = QluentClient(config)
-    data = client.elasticity_tree(
-        tree_id,
-        c_from,
-        c_to,
-        p_from,
-        p_to,
+    data = analyze_elasticity(
+        client,
+        config,
+        tree_id=tree_id,
         outcome=outcome,
         lever=lever,
         dimension=dimension,
-        filters=parsed_filters,
-    )
-    data.setdefault("contract_kind", "elasticity_analysis")
-    data.setdefault("deterministic", True)
-    data.setdefault("tree_id", tree_id)
-    data.setdefault("outcome", outcome)
-    data.setdefault("lever", lever)
-    data.setdefault("dimension", dimension)
-    data.setdefault("current_window", {"date_from": c_from, "date_to": c_to})
-    data.setdefault("comparison_window", {"date_from": p_from, "date_to": p_to})
-    data.setdefault("evidence_type", "observed_correlation")
-    data.setdefault("warnings", [])
-    data.setdefault(
-        "provenance",
-        {
-            "source": "metric_tree_elasticity",
-            "project_uuid": config.project_uuid,
-            "tree_id": tree_id,
-            "outcome": outcome,
-            "lever": lever,
-        },
+        current_from=c_from,
+        current_to=c_to,
+        comparison_from=p_from,
+        comparison_to=p_to,
+        filters=parse_filters(filters),
     )
 
     if as_json:

--- a/src/qluent_cli/mcp_server.py
+++ b/src/qluent_cli/mcp_server.py
@@ -16,6 +16,7 @@ from typing import Any, Awaitable, Callable
 from qluent_cli import __version__
 from qluent_cli.client import QluentClient
 from qluent_cli.config import QluentConfig, load_config
+from qluent_cli.elasticity import analyze_elasticity
 from qluent_cli.rca_contracts import enrich_rca_output
 from qluent_cli.suggestions import build_suggestions
 from qluent_cli.trees import _collect_tree_metadata, _sanitize_recommended_next_steps
@@ -394,42 +395,19 @@ async def _elasticity(client: QluentClient, config: QluentConfig, args: dict[str
     c_from, c_to, p_from, p_to = _resolve_dates(
         args.get("period"), args.get("current"), args.get("compare")
     )
-    tree_id = args["tree_id"]
-    outcome = args["outcome"]
-    lever = args["lever"]
-    dimension = args.get("dimension")
-    data = client.elasticity_tree(
-        tree_id,
-        c_from,
-        c_to,
-        p_from,
-        p_to,
-        outcome=outcome,
-        lever=lever,
-        dimension=dimension,
+    return analyze_elasticity(
+        client,
+        config,
+        tree_id=args["tree_id"],
+        outcome=args["outcome"],
+        lever=args["lever"],
+        dimension=args.get("dimension"),
+        current_from=c_from,
+        current_to=c_to,
+        comparison_from=p_from,
+        comparison_to=p_to,
         filters=_filters_from_arg(args.get("filters")),
     )
-    data.setdefault("contract_kind", "elasticity_analysis")
-    data.setdefault("deterministic", True)
-    data.setdefault("tree_id", tree_id)
-    data.setdefault("outcome", outcome)
-    data.setdefault("lever", lever)
-    data.setdefault("dimension", dimension)
-    data.setdefault("current_window", {"date_from": c_from, "date_to": c_to})
-    data.setdefault("comparison_window", {"date_from": p_from, "date_to": p_to})
-    data.setdefault("evidence_type", "observed_correlation")
-    data.setdefault("warnings", [])
-    data.setdefault(
-        "provenance",
-        {
-            "source": "metric_tree_elasticity",
-            "project_uuid": config.project_uuid,
-            "tree_id": tree_id,
-            "outcome": outcome,
-            "lever": lever,
-        },
-    )
-    return data
 
 
 async def _suggestions(client: QluentClient, _config: QluentConfig, args: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_elasticity.py
+++ b/tests/test_elasticity.py
@@ -5,7 +5,112 @@ import json
 from click.testing import CliRunner
 
 from qluent_cli.config import QluentConfig
+from qluent_cli.elasticity import analyze_elasticity
 from qluent_cli.main import cli
+
+
+class _StubClient:
+    def __init__(self, payload):
+        self.payload = payload
+        self.captured = {}
+
+    def elasticity_tree(
+        self,
+        tree_id,
+        current_from,
+        current_to,
+        comparison_from,
+        comparison_to,
+        *,
+        outcome,
+        lever,
+        dimension,
+        filters,
+    ):
+        self.captured = {
+            "tree_id": tree_id,
+            "current_from": current_from,
+            "current_to": current_to,
+            "comparison_from": comparison_from,
+            "comparison_to": comparison_to,
+            "outcome": outcome,
+            "lever": lever,
+            "dimension": dimension,
+            "filters": filters,
+        }
+        return dict(self.payload)
+
+
+def test_analyze_elasticity_stamps_contract_defaults_without_click():
+    config = QluentConfig(
+        api_key="qk_test",
+        api_url="https://api.example.com",
+        project_uuid="project-123",
+        user_email="user@example.com",
+    )
+    client = _StubClient({"results": [{"segment": "Nordics", "elasticity": 0.3}]})
+
+    data = analyze_elasticity(
+        client,
+        config,
+        tree_id="revenue",
+        outcome="net_revenue",
+        lever="voucher_cost",
+        dimension="region",
+        current_from="2026-03-01",
+        current_to="2026-03-31",
+        comparison_from="2026-02-01",
+        comparison_to="2026-02-28",
+        filters={"country": ["SE"]},
+    )
+
+    assert client.captured["filters"] == {"country": ["SE"]}
+    assert client.captured["dimension"] == "region"
+    assert data["contract_kind"] == "elasticity_analysis"
+    assert data["deterministic"] is True
+    assert data["evidence_type"] == "observed_correlation"
+    assert data["warnings"] == []
+    assert data["current_window"] == {"date_from": "2026-03-01", "date_to": "2026-03-31"}
+    assert data["comparison_window"] == {"date_from": "2026-02-01", "date_to": "2026-02-28"}
+    assert data["provenance"] == {
+        "source": "metric_tree_elasticity",
+        "project_uuid": "project-123",
+        "tree_id": "revenue",
+        "outcome": "net_revenue",
+        "lever": "voucher_cost",
+    }
+
+
+def test_analyze_elasticity_does_not_overwrite_server_provided_fields():
+    config = QluentConfig(
+        api_key="qk_test",
+        api_url="https://api.example.com",
+        project_uuid="project-123",
+        user_email="user@example.com",
+    )
+    client = _StubClient(
+        {
+            "evidence_type": "experimental",
+            "warnings": ["server-issued warning"],
+            "provenance": {"source": "server-override"},
+        }
+    )
+
+    data = analyze_elasticity(
+        client,
+        config,
+        tree_id="revenue",
+        outcome="net_revenue",
+        lever="voucher_cost",
+        current_from="2026-03-01",
+        current_to="2026-03-31",
+        comparison_from="2026-02-01",
+        comparison_to="2026-02-28",
+    )
+
+    assert data["evidence_type"] == "experimental"
+    assert data["warnings"] == ["server-issued warning"]
+    assert data["provenance"] == {"source": "server-override"}
 
 
 def test_elasticity_command_outputs_agent_ready_json(monkeypatch):


### PR DESCRIPTION
## Summary

Closes #62.

The elasticity command was a single function mixing Click decoration, option parsing, the client call, and contract stamping. There was no seam between "what an elasticity analysis is" and "how the CLI exposes it" — tests could only enter through `CliRunner`, and the MCP server duplicated the contract-defaults logic.

- Introduce `analyze_elasticity(client, config, ...) -> dict` in `elasticity.py`. It owns the call into `client.elasticity_tree` and the deterministic contract defaults / provenance stamping.
- The Click command becomes a thin adapter (parse options → call → format).
- The MCP `_elasticity` handler now calls the same seam, removing the duplicated `setdefault` ladder.

## Test plan

- [x] `uv run pytest` — 153 passing
- [x] New `test_analyze_elasticity_stamps_contract_defaults_without_click` exercises the seam directly (no `CliRunner`).
- [x] New `test_analyze_elasticity_does_not_overwrite_server_provided_fields` regression-tests that `setdefault` semantics are preserved (server-provided `evidence_type`, `warnings`, `provenance` win).
- [x] Existing CLI integration test still passes.
- [x] MCP `_elasticity` handler still produces the same payload (covered by existing `tests/test_mcp_server.py`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wra47NtSXXSywB3Btp6ACC)_