### PR TITLE
Hoist tree-run orchestration into runs.py; CLI and MCP become adapters

### DIFF
--- a/src/qluent_cli/mcp_server.py
+++ b/src/qluent_cli/mcp_server.py
@@ -17,8 +17,8 @@ from qluent_cli import __version__
 from qluent_cli.client import QluentClient
 from qluent_cli.config import QluentConfig, load_config
 from qluent_cli.rca_contracts import enrich_rca_output
+from qluent_cli.runs import run_investigation
 from qluent_cli.suggestions import build_suggestions
-from qluent_cli.trees import _collect_tree_metadata, _sanitize_recommended_next_steps
 from qluent_cli.utils import parse_filters, resolve_date_args
 
 
@@ -76,15 +76,6 @@ def _filter_schema() -> dict[str, Any]:
             "'dimension=value' strings."
         ),
     }
-
-
-def _sanitize_bundle(bundle: dict[str, Any], trees_data: dict[str, Any]) -> None:
-    available_tree_ids, metrics_by_tree = _collect_tree_metadata(trees_data)
-    _sanitize_recommended_next_steps(
-        bundle,
-        available_tree_ids=available_tree_ids,
-        metrics_by_tree=metrics_by_tree,
-    )
 
 
 def _tool_definitions() -> list[dict[str, Any]]:
@@ -293,12 +284,13 @@ async def _investigate(client: QluentClient, _config: QluentConfig, args: dict[s
     c_from, c_to, p_from, p_to = _resolve_dates(
         args.get("period"), args.get("current"), args.get("compare")
     )
-    bundle = client.investigate_tree(
-        args["tree_id"],
-        c_from,
-        c_to,
-        p_from,
-        p_to,
+    return run_investigation(
+        client,
+        tree_id=args["tree_id"],
+        current_from=c_from,
+        current_to=c_to,
+        comparison_from=p_from,
+        comparison_to=p_to,
         trend_periods=int(args.get("trend_periods", 4)),
         trend_grain=str(args.get("trend_grain", "week")),
         trend_as_of=args.get("trend_as_of"),
@@ -310,8 +302,6 @@ async def _investigate(client: QluentClient, _config: QluentConfig, args: dict[s
         max_segments=int(args.get("max_segments", 5)),
         min_contribution_share=float(args.get("min_contribution_share", 0.1)),
     )
-    _sanitize_bundle(bundle, client.list_trees())
-    return bundle
 
 
 async def _deep_dive(client: QluentClient, _config: QluentConfig, args: dict[str, Any]) -> dict[str, Any]:
@@ -337,12 +327,14 @@ async def _deep_dive(client: QluentClient, _config: QluentConfig, args: dict[str
     errors: dict[str, str] = {}
     for tid in targets:
         try:
-            bundle = client.investigate_tree(
-                tid,
-                c_from,
-                c_to,
-                p_from,
-                p_to,
+            results[tid] = run_investigation(
+                client,
+                tree_id=tid,
+                current_from=c_from,
+                current_to=c_to,
+                comparison_from=p_from,
+                comparison_to=p_to,
+                trees_data=trees_data,
                 trend_periods=int(args.get("trend_periods", 4)),
                 trend_grain=str(args.get("trend_grain", "week")),
                 trend_as_of=args.get("trend_as_of"),
@@ -351,8 +343,6 @@ async def _deep_dive(client: QluentClient, _config: QluentConfig, args: dict[str
                 max_segments=int(args.get("max_segments", 5)),
                 min_contribution_share=float(args.get("min_contribution_share", 0.1)),
             )
-            _sanitize_bundle(bundle, trees_data)
-            results[tid] = bundle
         except Exception as exc:
             errors[tid] = f"{type(exc).__name__}: {exc}"
 

--- a/src/qluent_cli/runs.py
+++ b/src/qluent_cli/runs.py
@@ -1,0 +1,281 @@
+"""Run lifecycle for tree investigations.
+
+A *run* is one execution of an investigation against the Qluent API. Whether
+it is launched from `qluent trees investigate`, `qluent trees deep-dive`, or
+the `qluent_investigate` / `qluent_deep_dive` MCP tools, the same lifecycle
+applies:
+
+    start -> progress -> server-call -> sanitize -> complete
+
+This module owns that lifecycle. `trees.py` (Click command) and `mcp_server.py`
+(MCP tool) are thin adapters over the public interface here. There is no
+private-import coupling between the two adapters.
+
+Public surface:
+    * `RunReporter` - emits start/progress/complete to stderr or JSONL stdout.
+    * `collect_tree_metadata` - indexes `list_trees()` output for sanitization.
+    * `sanitize_recommended_next_steps` - cleans agent next-step suggestions in
+      an investigation bundle.
+    * `run_investigation` - orchestrates a single tree investigation: client
+      call + sanitization. Used by both adapters.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import threading
+import time
+import uuid
+from typing import Any
+
+import click
+
+from qluent_cli.client import ProgressCallback, QluentClient
+from qluent_cli.output import echo_status
+
+
+class RunReporter:
+    """Emit run lifecycle events to stderr (human) or stdout JSONL (stream).
+
+    A reporter is created once per run and tracks elapsed time from
+    construction. Concurrent calls (e.g. from the deep-dive thread pool) are
+    serialized via an internal lock so JSONL events never interleave.
+    """
+
+    def __init__(
+        self,
+        *,
+        command: str,
+        stream: bool,
+        tree_id: str | None = None,
+        tree_count: int | None = None,
+        period_label: str,
+    ) -> None:
+        self.command = command
+        self.stream = stream
+        self.tree_id = tree_id
+        self.tree_count = tree_count
+        self.period_label = period_label
+        self.run_id = str(uuid.uuid4())
+        self.started_at = time.monotonic()
+        self._lock = threading.Lock()
+
+    def start(self) -> None:
+        if self.stream:
+            payload: dict[str, Any] = {
+                "type": "run.started",
+                "run_id": self.run_id,
+                "command": self.command,
+                "period": self.period_label,
+            }
+            if self.tree_id is not None:
+                payload["tree"] = self.tree_id
+            if self.tree_count is not None:
+                payload["tree_count"] = self.tree_count
+            self._emit_jsonl(payload)
+            return
+
+        target = self.tree_id or f"{self.tree_count} tree(s)"
+        echo_status(f"[qluent] {self.command} {target} period={self.period_label} starting...")
+
+    def progress(
+        self,
+        stage: str,
+        *,
+        tree_id: str | None = None,
+        elapsed: float | None = None,
+    ) -> None:
+        elapsed_ms = int(((elapsed or (time.monotonic() - self.started_at)) * 1000))
+        if self.stream:
+            payload: dict[str, Any] = {
+                "type": "run.progress",
+                "run_id": self.run_id,
+                "stage": stage,
+                "elapsed_ms": elapsed_ms,
+            }
+            if tree_id is not None:
+                payload["tree"] = tree_id
+            self._emit_jsonl(payload)
+            return
+
+        if stage == "awaiting_api":
+            seconds = max(0, round(elapsed_ms / 1000))
+            suffix = f" ({seconds}s)" if seconds else ""
+            prefix = f"[qluent] {tree_id} " if tree_id else "[qluent] "
+            echo_status(f"{prefix}awaiting response...{suffix}")
+        elif stage == "formatting":
+            prefix = f"[qluent] {tree_id} " if tree_id else "[qluent] "
+            echo_status(f"{prefix}received, formatting...")
+
+    def complete(self, result: dict[str, Any], *, run_id: str | None = None) -> None:
+        if not self.stream:
+            return
+        self._emit_jsonl(
+            {
+                "type": "run.completed",
+                "run_id": run_id or self.run_id,
+                "elapsed_ms": int((time.monotonic() - self.started_at) * 1000),
+                "result": result,
+            }
+        )
+
+    def _emit_jsonl(self, payload: dict[str, Any]) -> None:
+        with self._lock:
+            click.echo(json.dumps(payload, separators=(",", ":")))
+
+
+def collect_tree_metadata(
+    trees_data: dict[str, Any],
+) -> tuple[set[str], dict[str, set[str]]]:
+    """Index `list_trees()` output for next-step sanitization.
+
+    Returns `(available_tree_ids, metrics_by_tree)`:
+        * `available_tree_ids` - the set of valid tree ids in the project.
+        * `metrics_by_tree`    - tree id -> set of metric/node ids it exposes.
+    """
+    tree_ids: set[str] = set()
+    metrics_by_tree: dict[str, set[str]] = {}
+    for tree in trees_data.get("trees") or []:
+        tree_id = tree.get("id")
+        if not tree_id:
+            continue
+        tree_id = str(tree_id)
+        tree_ids.add(tree_id)
+        metrics: set[str] = set()
+        for node in tree.get("nodes") or []:
+            node_id = node.get("id") or node.get("node_id")
+            if node_id:
+                metrics.add(str(node_id))
+        metrics_by_tree[tree_id] = metrics
+    return tree_ids, metrics_by_tree
+
+
+def _option_start(tokens: list[str]) -> int:
+    for index, token in enumerate(tokens):
+        if token.startswith("-"):
+            return index
+    return len(tokens)
+
+
+def _convert_metric_compare_command(
+    *,
+    primary_tree: str,
+    metric_id: str,
+    option_tokens: list[str],
+) -> str:
+    command = ["qluent", "rca", "analyze", primary_tree, "--metric", metric_id]
+    command.extend(option_tokens)
+    return " ".join(shlex.quote(token) for token in command)
+
+
+def sanitize_recommended_next_steps(
+    bundle: dict[str, Any],
+    *,
+    available_tree_ids: set[str],
+    metrics_by_tree: dict[str, set[str]],
+) -> None:
+    """In-place: drop or rewrite agent-recommended `qluent trees compare`
+    commands that target non-tree ids.
+
+    Two cases are rewritten in place rather than discarded:
+      * `compare <tree> <metric>` where `<metric>` is a node id in `<tree>` -
+        rewritten to `rca analyze <tree> --metric <metric>`.
+
+    Anything else with unknown targets has its `command` removed and a
+    diagnostic appended to `why`.
+    """
+    agent = bundle.get("agent")
+    if not isinstance(agent, dict):
+        return
+
+    next_steps = agent.get("recommended_next_steps")
+    if not isinstance(next_steps, list):
+        return
+
+    for step in next_steps:
+        if not isinstance(step, dict):
+            continue
+        command = step.get("command")
+        if not isinstance(command, str) or not command.strip():
+            continue
+        try:
+            tokens = shlex.split(command)
+        except ValueError:
+            step.pop("command", None)
+            step["why"] = (step.get("why") or "Recommended command was malformed.").rstrip()
+            continue
+        if tokens[:3] != ["qluent", "trees", "compare"]:
+            continue
+
+        start = _option_start(tokens[3:])
+        tree_args = tokens[3 : 3 + start]
+        option_tokens = tokens[3 + start :]
+        invalid_targets = [target for target in tree_args if target not in available_tree_ids]
+        if not invalid_targets:
+            continue
+
+        primary_tree = tree_args[0] if tree_args else str(bundle.get("tree_id") or "")
+        if (
+            len(tree_args) == 2
+            and len(invalid_targets) == 1
+            and primary_tree in available_tree_ids
+            and invalid_targets[0] in metrics_by_tree.get(primary_tree, set())
+        ):
+            metric_id = invalid_targets[0]
+            step["command"] = _convert_metric_compare_command(
+                primary_tree=primary_tree,
+                metric_id=metric_id,
+                option_tokens=option_tokens,
+            )
+            step["why"] = (
+                (step.get("why") or "").rstrip()
+                + f" Converted from compare because `{metric_id}` is a metric in `{primary_tree}`, not a tree id."
+            ).strip()
+            continue
+
+        step.pop("command", None)
+        step["why"] = (
+            (step.get("why") or "").rstrip()
+            + " No executable command emitted because compare targets must be available tree ids: "
+            + ", ".join(sorted(available_tree_ids))
+            + "."
+        ).strip()
+
+
+def run_investigation(
+    client: QluentClient,
+    *,
+    tree_id: str,
+    current_from: str,
+    current_to: str,
+    comparison_from: str,
+    comparison_to: str,
+    trees_data: dict[str, Any] | None = None,
+    progress_callback: ProgressCallback | None = None,
+    **investigation_kwargs: Any,
+) -> dict[str, Any]:
+    """Run one tree investigation and return the sanitized bundle.
+
+    The single shared seam between the CLI and MCP adapters. `trees_data`
+    is used to validate agent-recommended next steps; if `None`, it is
+    fetched via `client.list_trees()`.
+    """
+    if trees_data is None:
+        trees_data = client.list_trees()
+    bundle = client.investigate_tree(
+        tree_id,
+        current_from,
+        current_to,
+        comparison_from,
+        comparison_to,
+        progress_callback=progress_callback,
+        **investigation_kwargs,
+    )
+    available_tree_ids, metrics_by_tree = collect_tree_metadata(trees_data)
+    sanitize_recommended_next_steps(
+        bundle,
+        available_tree_ids=available_tree_ids,
+        metrics_by_tree=metrics_by_tree,
+    )
+    return bundle

--- a/src/qluent_cli/trees.py
+++ b/src/qluent_cli/trees.py
@@ -1,12 +1,13 @@
-"""Metric tree commands — list, evaluate, trend, compare, investigate."""
+"""Metric tree commands — list, evaluate, trend, compare, investigate.
+
+Run lifecycle (start / progress / sanitize / complete) lives in `runs.py`.
+The Click commands here are adapters: they parse options, drive the lifecycle
+module, and render output.
+"""
 
 from __future__ import annotations
 
 import json
-import shlex
-import threading
-import time
-import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date as dt_date
 from typing import Any
@@ -16,7 +17,7 @@ import click
 from qluent_cli import sessions
 from qluent_cli.client import QluentClient
 from qluent_cli.config import QluentConfig, load_config
-from qluent_cli.output import echo_status
+from qluent_cli.runs import RunReporter, run_investigation
 from qluent_cli.tree_contracts import build_tree_query_contract
 from qluent_cli.formatters import (
     format_comparison,
@@ -98,83 +99,6 @@ _LEVER_KEYWORDS = (
     "increase",
     "decrease",
 )
-
-
-class _RunReporter:
-    def __init__(
-        self,
-        *,
-        command: str,
-        stream: bool,
-        tree_id: str | None = None,
-        tree_count: int | None = None,
-        period_label: str,
-    ) -> None:
-        self.command = command
-        self.stream = stream
-        self.tree_id = tree_id
-        self.tree_count = tree_count
-        self.period_label = period_label
-        self.run_id = str(uuid.uuid4())
-        self.started_at = time.monotonic()
-        self._lock = threading.Lock()
-
-    def start(self) -> None:
-        if self.stream:
-            payload: dict[str, Any] = {
-                "type": "run.started",
-                "run_id": self.run_id,
-                "command": self.command,
-                "period": self.period_label,
-            }
-            if self.tree_id is not None:
-                payload["tree"] = self.tree_id
-            if self.tree_count is not None:
-                payload["tree_count"] = self.tree_count
-            self._emit_jsonl(payload)
-            return
-
-        target = self.tree_id or f"{self.tree_count} tree(s)"
-        echo_status(f"[qluent] {self.command} {target} period={self.period_label} starting...")
-
-    def progress(self, stage: str, *, tree_id: str | None = None, elapsed: float | None = None) -> None:
-        elapsed_ms = int(((elapsed or (time.monotonic() - self.started_at)) * 1000))
-        if self.stream:
-            payload: dict[str, Any] = {
-                "type": "run.progress",
-                "run_id": self.run_id,
-                "stage": stage,
-                "elapsed_ms": elapsed_ms,
-            }
-            if tree_id is not None:
-                payload["tree"] = tree_id
-            self._emit_jsonl(payload)
-            return
-
-        if stage == "awaiting_api":
-            seconds = max(0, round(elapsed_ms / 1000))
-            suffix = f" ({seconds}s)" if seconds else ""
-            prefix = f"[qluent] {tree_id} " if tree_id else "[qluent] "
-            echo_status(f"{prefix}awaiting response...{suffix}")
-        elif stage == "formatting":
-            prefix = f"[qluent] {tree_id} " if tree_id else "[qluent] "
-            echo_status(f"{prefix}received, formatting...")
-
-    def complete(self, result: dict[str, Any], *, run_id: str | None = None) -> None:
-        if not self.stream:
-            return
-        self._emit_jsonl(
-            {
-                "type": "run.completed",
-                "run_id": run_id or self.run_id,
-                "elapsed_ms": int((time.monotonic() - self.started_at) * 1000),
-                "result": result,
-            }
-        )
-
-    def _emit_jsonl(self, payload: dict[str, Any]) -> None:
-        with self._lock:
-            click.echo(json.dumps(payload, separators=(",", ":")))
 
 
 def _is_lever_question(question: str | None) -> bool:
@@ -325,107 +249,6 @@ def _collect_trend_evaluations(
         )
         evaluations.append(data)
     return evaluations
-
-
-def _collect_tree_metadata(trees_data: dict[str, Any]) -> tuple[set[str], dict[str, set[str]]]:
-    tree_ids: set[str] = set()
-    metrics_by_tree: dict[str, set[str]] = {}
-    for tree in trees_data.get("trees") or []:
-        tree_id = tree.get("id")
-        if not tree_id:
-            continue
-        tree_id = str(tree_id)
-        tree_ids.add(tree_id)
-        metrics: set[str] = set()
-        for node in tree.get("nodes") or []:
-            node_id = node.get("id") or node.get("node_id")
-            if node_id:
-                metrics.add(str(node_id))
-        metrics_by_tree[tree_id] = metrics
-    return tree_ids, metrics_by_tree
-
-
-def _option_start(tokens: list[str]) -> int:
-    for index, token in enumerate(tokens):
-        if token.startswith("-"):
-            return index
-    return len(tokens)
-
-
-def _convert_metric_compare_command(
-    *,
-    primary_tree: str,
-    metric_id: str,
-    option_tokens: list[str],
-) -> str:
-    command = ["qluent", "rca", "analyze", primary_tree, "--metric", metric_id]
-    command.extend(option_tokens)
-    return " ".join(shlex.quote(token) for token in command)
-
-
-def _sanitize_recommended_next_steps(
-    bundle: dict[str, Any],
-    *,
-    available_tree_ids: set[str],
-    metrics_by_tree: dict[str, set[str]],
-) -> None:
-    agent = bundle.get("agent")
-    if not isinstance(agent, dict):
-        return
-
-    next_steps = agent.get("recommended_next_steps")
-    if not isinstance(next_steps, list):
-        return
-
-    for step in next_steps:
-        if not isinstance(step, dict):
-            continue
-        command = step.get("command")
-        if not isinstance(command, str) or not command.strip():
-            continue
-        try:
-            tokens = shlex.split(command)
-        except ValueError:
-            step.pop("command", None)
-            step["why"] = (step.get("why") or "Recommended command was malformed.").rstrip()
-            continue
-        if tokens[:3] != ["qluent", "trees", "compare"]:
-            continue
-
-        start = _option_start(tokens[3:])
-        tree_args = tokens[3 : 3 + start]
-        option_tokens = tokens[3 + start :]
-        invalid_targets = [target for target in tree_args if target not in available_tree_ids]
-        if not invalid_targets:
-            continue
-
-        primary_tree = tree_args[0] if tree_args else str(bundle.get("tree_id") or "")
-        if (
-            len(tree_args) == 2
-            and len(invalid_targets) == 1
-            and primary_tree in available_tree_ids
-            and invalid_targets[0] in metrics_by_tree.get(primary_tree, set())
-        ):
-            metric_id = invalid_targets[0]
-            step["command"] = _convert_metric_compare_command(
-                primary_tree=primary_tree,
-                metric_id=metric_id,
-                option_tokens=option_tokens,
-            )
-            step["why"] = (
-                (step.get("why") or "").rstrip()
-                + f" Converted from compare because `{metric_id}` is a metric in `{primary_tree}`, not a tree id."
-            ).strip()
-            continue
-
-        step.pop("command", None)
-        step["why"] = (
-            (step.get("why") or "").rstrip()
-            + " No executable command emitted because compare targets must be available tree ids: "
-            + ", ".join(sorted(available_tree_ids))
-            + "."
-        ).strip()
-
 
 
 @trees.command(name="list")
@@ -645,7 +468,7 @@ def investigate(
     parsed_filters = parse_filters(filters)
     c_from, c_to, p_from, p_to = resolve_date_args(period, current_range, compare_range)
     period_label = format_period_label(c_from, c_to, p_from, p_to)
-    reporter = _RunReporter(
+    reporter = RunReporter(
         command="investigate",
         stream=stream,
         tree_id=tree_id,
@@ -653,16 +476,19 @@ def investigate(
     )
     if stream or not as_json:
         reporter.start()
-    available_tree_ids, metrics_by_tree = _collect_tree_metadata(client.list_trees())
+    trees_data = client.list_trees()
     if stream or not as_json:
         reporter.progress("awaiting_api")
 
-    bundle = client.investigate_tree(
-        tree_id,
-        c_from,
-        c_to,
-        p_from,
-        p_to,
+    bundle = run_investigation(
+        client,
+        tree_id=tree_id,
+        current_from=c_from,
+        current_to=c_to,
+        comparison_from=p_from,
+        comparison_to=p_to,
+        trees_data=trees_data,
+        progress_callback=lambda stage, elapsed: reporter.progress(stage, elapsed=elapsed),
         trend_periods=trend_periods,
         trend_grain=trend_grain,
         trend_as_of=trend_as_of,
@@ -673,15 +499,9 @@ def investigate(
         max_branching=max_branches,
         max_segments=max_segments,
         min_contribution_share=min_contribution_share,
-        progress_callback=lambda stage, elapsed: reporter.progress(stage, elapsed=elapsed),
     )
     if stream or not as_json:
         reporter.progress("formatting")
-    _sanitize_recommended_next_steps(
-        bundle,
-        available_tree_ids=available_tree_ids,
-        metrics_by_tree=metrics_by_tree,
-    )
 
     record = _persist_run_safely(
         command=sessions.INVESTIGATE_COMMAND,
@@ -817,9 +637,8 @@ def deep_dive(
     if not targets:
         raise click.ClickException("No trees available for this project.")
 
-    available_tree_ids, metrics_by_tree = _collect_tree_metadata(trees_data)
     period_label = format_period_label(c_from, c_to, p_from, p_to)
-    reporter = _RunReporter(
+    reporter = RunReporter(
         command="deep-dive",
         stream=stream,
         tree_count=len(targets),
@@ -831,12 +650,17 @@ def deep_dive(
     def _investigate(tid: str) -> dict[str, Any]:
         if stream or not as_json:
             reporter.progress("awaiting_api", tree_id=tid)
-        bundle = client.investigate_tree(
-            tid,
-            c_from,
-            c_to,
-            p_from,
-            p_to,
+        bundle = run_investigation(
+            client,
+            tree_id=tid,
+            current_from=c_from,
+            current_to=c_to,
+            comparison_from=p_from,
+            comparison_to=p_to,
+            trees_data=trees_data,
+            progress_callback=lambda stage, elapsed: reporter.progress(
+                stage, tree_id=tid, elapsed=elapsed
+            ),
             trend_periods=trend_periods,
             trend_grain=trend_grain,
             trend_as_of=trend_as_of,
@@ -844,17 +668,9 @@ def deep_dive(
             max_branching=max_branches,
             max_segments=max_segments,
             min_contribution_share=min_contribution_share,
-            progress_callback=lambda stage, elapsed: reporter.progress(
-                stage, tree_id=tid, elapsed=elapsed
-            ),
         )
         if stream or not as_json:
             reporter.progress("formatting", tree_id=tid)
-        _sanitize_recommended_next_steps(
-            bundle,
-            available_tree_ids=available_tree_ids,
-            metrics_by_tree=metrics_by_tree,
-        )
         return bundle
 
     results: dict[str, dict[str, Any]] = {}

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -198,7 +198,8 @@ def test_dispatch_investigate_forwards_rca_options():
             config=CONFIG,
         )
     )
-    kwargs = client.calls[0][2]
+    investigate_call = next(c for c in client.calls if c[0] == "investigate_tree")
+    kwargs = investigate_call[2]
     assert kwargs["segment_by"] == ["region"]
     assert kwargs["filters"] == {"region": ["EU"]}
     assert kwargs["max_depth"] == 2

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -1,0 +1,239 @@
+"""Tests for the run-lifecycle module — exercise the seam directly, no CliRunner."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from qluent_cli.runs import (
+    RunReporter,
+    collect_tree_metadata,
+    run_investigation,
+    sanitize_recommended_next_steps,
+)
+
+
+TREE_DATA: dict[str, Any] = {
+    "trees": [
+        {
+            "id": "revenue",
+            "label": "Revenue",
+            "nodes": [
+                {"id": "net_revenue"},
+                {"id": "orders"},
+                {"node_id": "aov"},
+            ],
+        },
+        {
+            "id": "growth",
+            "nodes": [{"id": "signups"}],
+        },
+        {
+            # Trees with no id are skipped
+            "label": "Orphan",
+            "nodes": [{"id": "noise"}],
+        },
+    ]
+}
+
+
+class _FakeClient:
+    def __init__(self, bundle):
+        self._bundle = bundle
+        self.investigate_calls: list[dict[str, Any]] = []
+        self.list_calls: int = 0
+
+    def list_trees(self) -> dict[str, Any]:
+        self.list_calls += 1
+        return TREE_DATA
+
+    def investigate_tree(self, tree_id, c_from, c_to, p_from, p_to, **kwargs):
+        self.investigate_calls.append(
+            {
+                "tree_id": tree_id,
+                "current_from": c_from,
+                "current_to": c_to,
+                "comparison_from": p_from,
+                "comparison_to": p_to,
+                **kwargs,
+            }
+        )
+        return dict(self._bundle)
+
+
+# ---------------------------------------------------------------------------
+# collect_tree_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_collect_tree_metadata_indexes_trees_and_metrics():
+    tree_ids, metrics_by_tree = collect_tree_metadata(TREE_DATA)
+    assert tree_ids == {"revenue", "growth"}
+    assert metrics_by_tree["revenue"] == {"net_revenue", "orders", "aov"}
+    assert metrics_by_tree["growth"] == {"signups"}
+
+
+def test_collect_tree_metadata_handles_empty_payload():
+    assert collect_tree_metadata({}) == (set(), {})
+    assert collect_tree_metadata({"trees": []}) == (set(), {})
+
+
+# ---------------------------------------------------------------------------
+# sanitize_recommended_next_steps
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_rewrites_metric_compare_into_rca_analyze():
+    bundle = {
+        "tree_id": "revenue",
+        "agent": {
+            "recommended_next_steps": [
+                {
+                    "command": "qluent trees compare revenue orders --period 'last 7 days'",
+                    "why": "Compare a metric.",
+                }
+            ]
+        },
+    }
+    sanitize_recommended_next_steps(
+        bundle,
+        available_tree_ids={"revenue"},
+        metrics_by_tree={"revenue": {"orders"}},
+    )
+    step = bundle["agent"]["recommended_next_steps"][0]
+    assert step["command"].startswith(
+        "qluent rca analyze revenue --metric orders"
+    )
+    assert "Converted from compare" in step["why"]
+
+
+def test_sanitize_strips_unknown_compare_targets():
+    bundle = {
+        "tree_id": "revenue",
+        "agent": {
+            "recommended_next_steps": [
+                {"command": "qluent trees compare revenue ghost"}
+            ]
+        },
+    }
+    sanitize_recommended_next_steps(
+        bundle,
+        available_tree_ids={"revenue"},
+        metrics_by_tree={"revenue": set()},
+    )
+    step = bundle["agent"]["recommended_next_steps"][0]
+    assert "command" not in step
+    assert "must be available tree ids" in step["why"]
+
+
+def test_sanitize_drops_malformed_command():
+    bundle = {
+        "agent": {
+            "recommended_next_steps": [{"command": "qluent trees compare 'unterminated"}]
+        },
+    }
+    sanitize_recommended_next_steps(
+        bundle, available_tree_ids={"revenue"}, metrics_by_tree={"revenue": set()}
+    )
+    step = bundle["agent"]["recommended_next_steps"][0]
+    assert "command" not in step
+
+
+def test_sanitize_no_op_when_agent_section_missing():
+    bundle = {"tree_id": "revenue"}
+    sanitize_recommended_next_steps(
+        bundle, available_tree_ids={"revenue"}, metrics_by_tree={"revenue": set()}
+    )
+    assert bundle == {"tree_id": "revenue"}
+
+
+# ---------------------------------------------------------------------------
+# run_investigation
+# ---------------------------------------------------------------------------
+
+
+def test_run_investigation_passes_kwargs_through_and_sanitizes():
+    bundle_template = {
+        "tree_id": "revenue",
+        "agent": {
+            "recommended_next_steps": [
+                {
+                    "command": "qluent trees compare revenue orders",
+                    "why": "metric compare suggested",
+                }
+            ]
+        },
+    }
+    client = _FakeClient(bundle_template)
+    bundle = run_investigation(
+        client,
+        tree_id="revenue",
+        current_from="2026-04-01",
+        current_to="2026-04-07",
+        comparison_from="2026-03-25",
+        comparison_to="2026-03-31",
+        max_depth=2,
+        max_branching=3,
+    )
+    assert client.list_calls == 1
+    assert client.investigate_calls[0]["max_depth"] == 2
+    assert client.investigate_calls[0]["max_branching"] == 3
+    step = bundle["agent"]["recommended_next_steps"][0]
+    assert step["command"].startswith("qluent rca analyze revenue --metric orders")
+
+
+def test_run_investigation_skips_list_trees_when_trees_data_provided():
+    client = _FakeClient({"tree_id": "revenue"})
+    run_investigation(
+        client,
+        tree_id="revenue",
+        current_from="2026-04-01",
+        current_to="2026-04-07",
+        comparison_from="2026-03-25",
+        comparison_to="2026-03-31",
+        trees_data=TREE_DATA,
+    )
+    assert client.list_calls == 0
+    assert len(client.investigate_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# RunReporter
+# ---------------------------------------------------------------------------
+
+
+def test_run_reporter_emits_jsonl_when_streaming(capsys):
+    reporter = RunReporter(
+        command="investigate",
+        stream=True,
+        tree_id="revenue",
+        period_label="last 7 days",
+    )
+    reporter.start()
+    reporter.progress("awaiting_api", elapsed=1.5)
+    reporter.complete({"tree_id": "revenue"})
+    out_lines = capsys.readouterr().out.strip().splitlines()
+    assert len(out_lines) == 3
+    import json
+    started, progress, completed = (json.loads(line) for line in out_lines)
+    assert started["type"] == "run.started"
+    assert started["command"] == "investigate"
+    assert progress["type"] == "run.progress"
+    assert progress["stage"] == "awaiting_api"
+    assert completed["type"] == "run.completed"
+    assert completed["result"] == {"tree_id": "revenue"}
+
+
+def test_run_reporter_uses_stderr_when_not_streaming(capsys):
+    reporter = RunReporter(
+        command="investigate",
+        stream=False,
+        tree_id="revenue",
+        period_label="last 7 days",
+    )
+    reporter.start()
+    reporter.progress("awaiting_api", elapsed=2.0)
+    captured = capsys.readouterr()
+    # JSONL only goes to stdout when streaming; non-streaming uses stderr
+    assert captured.out == ""
+    assert "[qluent] investigate revenue" in captured.err
+    assert "awaiting response" in captured.err


### PR DESCRIPTION
## Summary

Closes #60.

A `qluent trees investigate` run bounced through 300+ lines of private helpers in `trees.py` — `_RunReporter`, `_collect_tree_metadata`, `_sanitize_recommended_next_steps`, plus their unindexed helpers. `mcp_server.py` imported two of those private names directly, so refactoring `trees.py` silently risked breaking the MCP server.

That coupling was a **real seam** — CLI + MCP — wearing the disguise of a private implementation detail.

This change names the seam:

- New `qluent_cli/runs.py` owns the run lifecycle:
  - `RunReporter` (was `_RunReporter`)
  - `collect_tree_metadata` (was `_collect_tree_metadata`)
  - `sanitize_recommended_next_steps` (was `_sanitize_recommended_next_steps`)
  - `run_investigation` — new top-level orchestrator: client call + sanitization, callable from any adapter
- The run state-machine vocabulary (start → progress → server-call → sanitize → complete) is documented in the module docstring.
- `trees.py` becomes an adapter that drives `run_investigation` for both `investigate` and `deep-dive` commands. The duplicated private helpers and their internal tokenizing helpers are deleted.
- `mcp_server.py` no longer reaches into `qluent_cli.trees.*`. Both `_investigate` and `_deep_dive` MCP handlers now go through `run_investigation`, eliminating the duplicated `_sanitize_bundle` helper and its private-import dependency.

## Test plan

- [x] `uv run pytest` — 161 passing (151 existing + 10 new in `tests/test_runs.py`)
- [x] `tests/test_runs.py` exercises run behavior directly without `CliRunner`: lifecycle reporting (JSONL vs stderr), all sanitization rules, and `run_investigation` kwarg pass-through plus its `trees_data` short-circuit.
- [x] One existing MCP test was updated to find the `investigate_tree` call by name rather than by index, since `run_investigation` orders `list_trees` before `investigate_tree` (matching the CLI's existing order).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wra47NtSXXSywB3Btp6ACC)_