### PR TITLE
login: detect stale Claude Code plugin and prompt to update (closes #70)

### DIFF
--- a/src/qluent_cli/plugin.py
+++ b/src/qluent_cli/plugin.py
@@ -28,25 +28,36 @@ def claude_cli_available() -> bool:
 
 
 _STEP_TIMEOUT_SECONDS = 180
+_LIST_TIMEOUT_SECONDS = 10
 
 
-def _run(cmd: list[str]) -> tuple[bool, str]:
+def _exec(cmd: list[str], *, timeout: int = _STEP_TIMEOUT_SECONDS) -> tuple[int, str, str]:
+    """Run cmd and return (returncode, stdout, stderr).
+
+    Returncode is -1 with the error in stderr when the call timed out or the
+    binary was missing.
+    """
     try:
         result = subprocess.run(
             cmd,
             capture_output=True,
             text=True,
             check=False,
-            timeout=_STEP_TIMEOUT_SECONDS,
+            timeout=timeout,
         )
     except subprocess.TimeoutExpired:
-        return False, f"timed out after {_STEP_TIMEOUT_SECONDS}s"
+        return -1, "", f"timed out after {timeout}s"
     except OSError as exc:
-        return False, str(exc)
-    if result.returncode != 0:
-        message = (result.stderr or result.stdout or "").strip()
-        return False, message or f"exit {result.returncode}"
-    return True, ""
+        return -1, "", str(exc)
+    return result.returncode, result.stdout, result.stderr
+
+
+def _run(cmd: list[str]) -> tuple[bool, str]:
+    rc, stdout, stderr = _exec(cmd)
+    if rc == 0:
+        return True, ""
+    message = (stderr or stdout or "").strip()
+    return False, message or f"exit {rc}"
 
 
 def _run_steps(steps: tuple[list[str], ...]) -> bool:
@@ -60,20 +71,11 @@ def _run_steps(steps: tuple[list[str], ...]) -> bool:
     return True
 
 
-def _capture(cmd: list[str]) -> str | None:
-    try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=_STEP_TIMEOUT_SECONDS,
-        )
-    except (subprocess.TimeoutExpired, OSError):
+def _capture(cmd: list[str], *, timeout: int = _LIST_TIMEOUT_SECONDS) -> str | None:
+    rc, stdout, _ = _exec(cmd, timeout=timeout)
+    if rc != 0:
         return None
-    if result.returncode != 0:
-        return None
-    return result.stdout or ""
+    return stdout or ""
 
 
 def get_installed_claude_plugin_version() -> str | None:

--- a/src/qluent_cli/plugin.py
+++ b/src/qluent_cli/plugin.py
@@ -7,6 +7,7 @@ having to run the slash commands manually.
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 
@@ -17,6 +18,9 @@ from qluent_cli.output import echo_status
 MARKETPLACE_SOURCE = "qluent/qluent-plugin-cc"
 MARKETPLACE_NAME = "qluent-metric-trees"
 PLUGIN_ID = f"qluent@{MARKETPLACE_NAME}"
+
+# Bumped alongside qluent-plugin-cc releases.
+RECOMMENDED_CLAUDE_PLUGIN_VERSION = "0.3.0"
 
 
 def claude_cli_available() -> bool:
@@ -56,6 +60,66 @@ def _run_steps(steps: tuple[list[str], ...]) -> bool:
     return True
 
 
+def _capture(cmd: list[str]) -> str | None:
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_STEP_TIMEOUT_SECONDS,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout or ""
+
+
+def get_installed_claude_plugin_version() -> str | None:
+    """Return the installed qluent plugin version, or None if not installed.
+
+    Parses `claude plugin list`, looking for a `qluent@qluent-metric-trees`
+    block followed (within a few lines) by a `Version: X.Y.Z` entry.
+    """
+    output = _capture(["claude", "plugin", "list"])
+    if output is None:
+        return None
+    lines = output.splitlines()
+    for idx, line in enumerate(lines):
+        if PLUGIN_ID not in line:
+            continue
+        # Look at the next few lines for a Version: entry.
+        for follow in lines[idx : idx + 5]:
+            match = re.search(r"Version:\s*([0-9][0-9A-Za-z.\-+]*)", follow)
+            if match:
+                return match.group(1)
+    return None
+
+
+def _parse_version(value: str) -> tuple[int, ...] | None:
+    """Parse a dotted numeric version into a tuple of ints.
+
+    Returns None if the value doesn't start with a numeric component.
+    Trailing pre-release/build tags (e.g. "1.2.3-rc1") are ignored.
+    """
+    head = re.split(r"[-+]", value, maxsplit=1)[0]
+    parts = head.split(".")
+    try:
+        return tuple(int(p) for p in parts if p)
+    except ValueError:
+        return None
+
+
+def _is_older(installed: str, recommended: str) -> bool:
+    """Return True when `installed` is strictly older than `recommended`."""
+    a = _parse_version(installed)
+    b = _parse_version(recommended)
+    if a is None or b is None:
+        return False
+    return a < b
+
+
 def install_claude_plugin() -> bool:
     """Add the marketplace and install the plugin.
 
@@ -88,11 +152,27 @@ def _manual_hint() -> str:
     )
 
 
+def _prompt_and_update(installed: str, recommended: str, assume_yes: bool) -> None:
+    echo_status("")
+    echo_status("Claude Code plugin update available")
+    echo_status(f"  Installed:    {PLUGIN_ID} {installed}")
+    echo_status(f"  Recommended:  {PLUGIN_ID} {recommended}")
+
+    if not assume_yes and not click.confirm("Update now?", default=True):
+        echo_status("Skipped. Run `qluent claude update` to update later.")
+        return
+
+    if update_claude_plugin():
+        echo_status(f"Claude Code plugin updated to {recommended}: {PLUGIN_ID}")
+    else:
+        echo_status("Plugin update failed. Run `qluent claude update` to retry.")
+
+
 def offer_claude_plugin_install(install_plugin: bool | None) -> None:
-    """Install (or skip) the qluent Claude Code plugin.
+    """Install, update, or skip the qluent Claude Code plugin.
 
     install_plugin:
-      - True  : install without prompting
+      - True  : install/update without prompting
       - False : skip silently
       - None  : prompt (default Yes)
     """
@@ -106,11 +186,23 @@ def offer_claude_plugin_install(install_plugin: bool | None) -> None:
             echo_status("Claude Code CLI not detected. " + _manual_hint())
         return
 
-    if install_plugin is None:
-        if not click.confirm(
+    installed = get_installed_claude_plugin_version()
+
+    if installed is None:
+        if install_plugin is None and not click.confirm(
             "Install the qluent plugin in Claude Code?", default=True
         ):
             return
+        if install_claude_plugin():
+            echo_status(f"Claude Code plugin ready: {PLUGIN_ID}")
+        return
 
-    if install_claude_plugin():
-        echo_status(f"Claude Code plugin ready: {PLUGIN_ID}")
+    if _is_older(installed, RECOMMENDED_CLAUDE_PLUGIN_VERSION):
+        _prompt_and_update(
+            installed,
+            RECOMMENDED_CLAUDE_PLUGIN_VERSION,
+            assume_yes=install_plugin is True,
+        )
+        return
+
+    echo_status(f"Claude Code plugin up to date: {PLUGIN_ID} {installed}")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import subprocess
 from types import SimpleNamespace
 
+import click
 import pytest
 from click.testing import CliRunner
 
@@ -47,6 +48,9 @@ def test_offer_install_skips_when_flag_false(monkeypatch):
 def test_offer_install_runs_when_flag_true(monkeypatch):
     calls = []
     monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
+    monkeypatch.setattr(
+        plugin_module, "get_installed_claude_plugin_version", lambda: None
+    )
     monkeypatch.setattr(
         plugin_module,
         "install_claude_plugin",
@@ -114,6 +118,9 @@ def test_login_install_plugin_flag_invokes_install(
     called = []
     monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
     monkeypatch.setattr(
+        plugin_module, "get_installed_claude_plugin_version", lambda: None
+    )
+    monkeypatch.setattr(
         plugin_module,
         "install_claude_plugin",
         lambda: called.append("ran") or True,
@@ -133,6 +140,9 @@ def test_login_no_install_plugin_skips(
     called = []
     monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
     monkeypatch.setattr(
+        plugin_module, "get_installed_claude_plugin_version", lambda: None
+    )
+    monkeypatch.setattr(
         plugin_module,
         "install_claude_plugin",
         lambda: called.append("ran") or True,
@@ -149,6 +159,9 @@ def test_login_prompt_declined(monkeypatch, isolated_config, fake_browser_login,
     (tmp_path / "AGENTS.md").write_text("existing content")
     called = []
     monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
+    monkeypatch.setattr(
+        plugin_module, "get_installed_claude_plugin_version", lambda: None
+    )
     monkeypatch.setattr(
         plugin_module,
         "install_claude_plugin",
@@ -219,3 +232,181 @@ def test_claude_update_command_fails_on_step_error(monkeypatch):
 
     assert result.exit_code != 0
     assert "Plugin update failed" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Version detection + stale-plugin prompt
+# ---------------------------------------------------------------------------
+
+
+def _completed_with_stdout(stdout: str) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def test_get_installed_version_parses_plugin_list(monkeypatch):
+    output = (
+        "Installed plugins:\n"
+        "\n"
+        f"{plugin_module.PLUGIN_ID}\n"
+        "Version: 0.2.0\n"
+        "\n"
+        "other@thing\n"
+        "Version: 9.9.9\n"
+    )
+    monkeypatch.setattr(
+        subprocess, "run", lambda cmd, **_: _completed_with_stdout(output)
+    )
+
+    assert plugin_module.get_installed_claude_plugin_version() == "0.2.0"
+
+
+def test_get_installed_version_returns_none_when_plugin_absent(monkeypatch):
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **_: _completed_with_stdout("No plugins installed.\n"),
+    )
+
+    assert plugin_module.get_installed_claude_plugin_version() is None
+
+
+def test_get_installed_version_returns_none_on_command_error(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", lambda cmd, **_: _completed(returncode=2))
+
+    assert plugin_module.get_installed_claude_plugin_version() is None
+
+
+def test_get_installed_version_returns_none_on_oserror(monkeypatch):
+    def fake_run(cmd, **_):
+        raise OSError("claude binary missing")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert plugin_module.get_installed_claude_plugin_version() is None
+
+
+def test_is_older_compares_dotted_versions():
+    assert plugin_module._is_older("0.2.0", "0.3.0") is True
+    assert plugin_module._is_older("0.3.0", "0.3.0") is False
+    assert plugin_module._is_older("0.4.0", "0.3.0") is False
+    assert plugin_module._is_older("0.2", "0.2.1") is True
+    # Pre-release suffix is stripped before comparison.
+    assert plugin_module._is_older("0.2.0-rc1", "0.3.0") is True
+
+
+def test_is_older_handles_unparseable_versions():
+    assert plugin_module._is_older("garbage", "0.3.0") is False
+
+
+def test_offer_install_skips_install_when_plugin_already_current(monkeypatch, capsys):
+    called = []
+    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
+    monkeypatch.setattr(
+        plugin_module,
+        "get_installed_claude_plugin_version",
+        lambda: plugin_module.RECOMMENDED_CLAUDE_PLUGIN_VERSION,
+    )
+    monkeypatch.setattr(
+        plugin_module,
+        "install_claude_plugin",
+        lambda: called.append("install") or True,
+    )
+    monkeypatch.setattr(
+        plugin_module,
+        "update_claude_plugin",
+        lambda: called.append("update") or True,
+    )
+
+    plugin_module.offer_claude_plugin_install(None)
+
+    err = capsys.readouterr().err
+    assert called == []
+    assert "up to date" in err
+    assert plugin_module.RECOMMENDED_CLAUDE_PLUGIN_VERSION in err
+
+
+def test_offer_install_prompts_to_update_when_stale_and_runs(monkeypatch, capsys):
+    called = []
+    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
+    monkeypatch.setattr(
+        plugin_module, "get_installed_claude_plugin_version", lambda: "0.2.0"
+    )
+    monkeypatch.setattr(
+        plugin_module, "RECOMMENDED_CLAUDE_PLUGIN_VERSION", "0.3.0"
+    )
+    monkeypatch.setattr(
+        plugin_module, "update_claude_plugin", lambda: called.append("update") or True
+    )
+    monkeypatch.setattr(click, "confirm", lambda *a, **k: True)
+
+    plugin_module.offer_claude_plugin_install(None)
+
+    err = capsys.readouterr().err
+    assert called == ["update"]
+    assert "update available" in err
+    assert "0.2.0" in err
+    assert "0.3.0" in err
+    assert "updated to 0.3.0" in err
+
+
+def test_offer_install_declined_update_prints_manual_command(monkeypatch, capsys):
+    called = []
+    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
+    monkeypatch.setattr(
+        plugin_module, "get_installed_claude_plugin_version", lambda: "0.2.0"
+    )
+    monkeypatch.setattr(
+        plugin_module, "RECOMMENDED_CLAUDE_PLUGIN_VERSION", "0.3.0"
+    )
+    monkeypatch.setattr(
+        plugin_module, "update_claude_plugin", lambda: called.append("update") or True
+    )
+    monkeypatch.setattr(click, "confirm", lambda *a, **k: False)
+
+    plugin_module.offer_claude_plugin_install(None)
+
+    err = capsys.readouterr().err
+    assert called == []
+    assert "qluent claude update" in err
+
+
+def test_offer_install_stale_with_install_flag_true_skips_prompt(monkeypatch, capsys):
+    called = []
+    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
+    monkeypatch.setattr(
+        plugin_module, "get_installed_claude_plugin_version", lambda: "0.2.0"
+    )
+    monkeypatch.setattr(
+        plugin_module, "RECOMMENDED_CLAUDE_PLUGIN_VERSION", "0.3.0"
+    )
+    monkeypatch.setattr(
+        plugin_module, "update_claude_plugin", lambda: called.append("update") or True
+    )
+
+    def fail_confirm(*_a, **_k):
+        raise AssertionError("click.confirm should not be called when assume_yes is True")
+
+    monkeypatch.setattr(click, "confirm", fail_confirm)
+
+    plugin_module.offer_claude_plugin_install(True)
+
+    assert called == ["update"]
+    assert "updated to 0.3.0" in capsys.readouterr().err
+
+
+def test_offer_install_stale_update_failure_reports_retry(monkeypatch, capsys):
+    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
+    monkeypatch.setattr(
+        plugin_module, "get_installed_claude_plugin_version", lambda: "0.2.0"
+    )
+    monkeypatch.setattr(
+        plugin_module, "RECOMMENDED_CLAUDE_PLUGIN_VERSION", "0.3.0"
+    )
+    monkeypatch.setattr(plugin_module, "update_claude_plugin", lambda: False)
+    monkeypatch.setattr(click, "confirm", lambda *a, **k: True)
+
+    plugin_module.offer_claude_plugin_install(None)
+
+    err = capsys.readouterr().err
+    assert "Plugin update failed" in err
+    assert "qluent claude update" in err

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -290,7 +290,6 @@ def test_is_older_compares_dotted_versions():
     assert plugin_module._is_older("0.3.0", "0.3.0") is False
     assert plugin_module._is_older("0.4.0", "0.3.0") is False
     assert plugin_module._is_older("0.2", "0.2.1") is True
-    # Pre-release suffix is stripped before comparison.
     assert plugin_module._is_older("0.2.0-rc1", "0.3.0") is True
 
 


### PR DESCRIPTION
## Summary

`qluent login` previously called the idempotent `claude plugin install`, which left users stuck on a stale plugin version even after the CLI reported the plugin as "ready" (see #70).

This change parses `claude plugin list` for the installed `qluent@qluent-metric-trees` version, compares it against a new `RECOMMENDED_CLAUDE_PLUGIN_VERSION` constant (currently `0.3.0`), and adapts the login/setup flow:

- **Missing**  → install (existing behavior).
- **Stale**    → print installed/recommended versions and prompt to update; on accept run `claude plugin marketplace update` + `claude plugin update`; on decline point at `qluent claude update`.
- **Current**  → print a clear "up to date" message.
- `--install-plugin` skips the prompt and updates straight away when stale.
- `--no-install-plugin` is unchanged (silent skip).

## Implementation notes

- New helpers in `src/qluent_cli/plugin.py`:
  - `RECOMMENDED_CLAUDE_PLUGIN_VERSION` — bumped alongside qluent-plugin-cc releases.
  - `get_installed_claude_plugin_version()` — captures `claude plugin list` and pulls out `Version: X.Y.Z` near the plugin id; returns `None` on missing plugin / OSError / non-zero exit.
  - `_parse_version` + `_is_older` — dependency-free dotted-numeric semver comparator that strips pre-release/build suffixes.
- `update_claude_plugin()` is reused for the in-prompt update path, keeping `qluent claude update` as the manual command.

## Test plan

- [x] `uv run pytest` — 180 passed (25 in `tests/test_plugin.py`).
- New tests cover: parsing `claude plugin list`, plugin absent, command error, OSError, version comparison, current-plugin path, stale prompt accepted, stale prompt declined, `--install-plugin` skipping the prompt when stale, and update-failure messaging.

https://claude.ai/code/session_01HrdzFMAQHxtWsLrJjH8DxY

---
_Generated by [Claude Code](https://claude.ai/code/session_01HrdzFMAQHxtWsLrJjH8DxY)_