### PR TITLE
chore: bump version to 0.1.11

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qluent/cli",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Install the Qluent CLI",
   "license": "UNLICENSED",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qluent-cli"
-version = "0.1.10"
+version = "0.1.11"
 description = "CLI for Qluent metric tree analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/qluent_cli/__init__.py
+++ b/src/qluent_cli/__init__.py
@@ -1,3 +1,3 @@
 """Qluent CLI — metric tree analysis from the command line."""
 
-__version__ = "0.1.10"
+__version__ = "0.1.11"

--- a/uv.lock
+++ b/uv.lock
@@ -672,7 +672,7 @@ wheels = [
 
 [[package]]
 name = "qluent-cli"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bump qluent-cli to 0.1.11 across pyproject.toml, __init__.py, npm/package.json, uv.lock
- Includes #71 since 0.1.10: login detects stale Claude Code plugin and prompts to update (closes #70).

## Test plan
- [ ] CI builds binaries on macOS / Linux / Windows after tag push
- [ ] After merge: tag `v0.1.11`, wait for GitHub Release assets, then `npm publish --access restricted` from `npm/`
- [ ] Smoke test `npm install -g @qluent/cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)