### PR TITLE
login: drop Claude Code plugin freshness check, defer to /plugin mark…

### DIFF
--- a/src/qluent_cli/main.py
+++ b/src/qluent_cli/main.py
@@ -517,27 +517,6 @@ def claude_init(target_path: str, force: bool) -> None:
     _agents_init_impl(as_kind="claude", target_path=target_path, force=force)
 
 
-@claude.command("update")
-def claude_update() -> None:
-    """Refresh the qluent Claude Code plugin to the latest version."""
-    from qluent_cli.plugin import (
-        PLUGIN_ID,
-        claude_cli_available,
-        update_claude_plugin,
-    )
-
-    if not claude_cli_available():
-        raise click.ClickException(
-            "Claude Code CLI not found on PATH. Install it from https://claude.ai/code "
-            "and try again."
-        )
-
-    if not update_claude_plugin():
-        raise click.ClickException("Plugin update failed. See messages above.")
-
-    echo_status(f"Claude Code plugin up to date: {PLUGIN_ID}")
-
-
 cli.add_command(claude)
 
 

--- a/src/qluent_cli/plugin.py
+++ b/src/qluent_cli/plugin.py
@@ -1,13 +1,13 @@
-"""Claude Code plugin auto-install helpers.
+"""Claude Code plugin install bootstrap.
 
-Wraps `claude plugin marketplace add` / `install` / `update` so qluent
-commands can wire up (or refresh) the Claude Code plugin without the user
-having to run the slash commands manually.
+Wraps `claude plugin marketplace add` / `install` so `qluent login` can offer a
+one-time install of the qluent Claude Code plugin. Plugin lifecycle (updates,
+version tracking) is owned by Claude Code's `/plugin marketplace update` flow;
+this module deliberately does not check or manage plugin versions.
 """
 
 from __future__ import annotations
 
-import re
 import shutil
 import subprocess
 
@@ -18,9 +18,6 @@ from qluent_cli.output import echo_status
 MARKETPLACE_SOURCE = "qluent/qluent-plugin-cc"
 MARKETPLACE_NAME = "qluent-metric-trees"
 PLUGIN_ID = f"qluent@{MARKETPLACE_NAME}"
-
-# Bumped alongside qluent-plugin-cc releases.
-RECOMMENDED_CLAUDE_PLUGIN_VERSION = "0.3.0"
 
 
 def claude_cli_available() -> bool:
@@ -78,48 +75,12 @@ def _capture(cmd: list[str], *, timeout: int = _LIST_TIMEOUT_SECONDS) -> str | N
     return stdout or ""
 
 
-def get_installed_claude_plugin_version() -> str | None:
-    """Return the installed qluent plugin version, or None if not installed.
-
-    Parses `claude plugin list`, looking for a `qluent@qluent-metric-trees`
-    block followed (within a few lines) by a `Version: X.Y.Z` entry.
-    """
+def is_claude_plugin_installed() -> bool:
+    """Return True if `claude plugin list` mentions the qluent plugin."""
     output = _capture(["claude", "plugin", "list"])
     if output is None:
-        return None
-    lines = output.splitlines()
-    for idx, line in enumerate(lines):
-        if PLUGIN_ID not in line:
-            continue
-        # Look at the next few lines for a Version: entry.
-        for follow in lines[idx : idx + 5]:
-            match = re.search(r"Version:\s*([0-9][0-9A-Za-z.\-+]*)", follow)
-            if match:
-                return match.group(1)
-    return None
-
-
-def _parse_version(value: str) -> tuple[int, ...] | None:
-    """Parse a dotted numeric version into a tuple of ints.
-
-    Returns None if the value doesn't start with a numeric component.
-    Trailing pre-release/build tags (e.g. "1.2.3-rc1") are ignored.
-    """
-    head = re.split(r"[-+]", value, maxsplit=1)[0]
-    parts = head.split(".")
-    try:
-        return tuple(int(p) for p in parts if p)
-    except ValueError:
-        return None
-
-
-def _is_older(installed: str, recommended: str) -> bool:
-    """Return True when `installed` is strictly older than `recommended`."""
-    a = _parse_version(installed)
-    b = _parse_version(recommended)
-    if a is None or b is None:
         return False
-    return a < b
+    return PLUGIN_ID in output
 
 
 def install_claude_plugin() -> bool:
@@ -134,18 +95,6 @@ def install_claude_plugin() -> bool:
     ))
 
 
-def update_claude_plugin() -> bool:
-    """Refresh the marketplace and pull the latest plugin version.
-
-    Runs `claude plugin marketplace update <name>` then `claude plugin update
-    <plugin>`. No-ops cleanly when nothing has changed upstream.
-    """
-    return _run_steps((
-        ["claude", "plugin", "marketplace", "update", MARKETPLACE_NAME],
-        ["claude", "plugin", "update", PLUGIN_ID],
-    ))
-
-
 def _manual_hint() -> str:
     return (
         "Install Claude Code (https://claude.ai/code), then run:\n"
@@ -154,29 +103,24 @@ def _manual_hint() -> str:
     )
 
 
-def _prompt_and_update(installed: str, recommended: str, assume_yes: bool) -> None:
-    echo_status("")
-    echo_status("Claude Code plugin update available")
-    echo_status(f"  Installed:    {PLUGIN_ID} {installed}")
-    echo_status(f"  Recommended:  {PLUGIN_ID} {recommended}")
-
-    if not assume_yes and not click.confirm("Update now?", default=True):
-        echo_status("Skipped. Run `qluent claude update` to update later.")
-        return
-
-    if update_claude_plugin():
-        echo_status(f"Claude Code plugin updated to {recommended}: {PLUGIN_ID}")
-    else:
-        echo_status("Plugin update failed. Run `qluent claude update` to retry.")
+def _refresh_tip() -> str:
+    return (
+        f"Tip: in Claude Code, run /plugin marketplace update {MARKETPLACE_NAME} "
+        "to refresh the qluent plugin."
+    )
 
 
 def offer_claude_plugin_install(install_plugin: bool | None) -> None:
-    """Install, update, or skip the qluent Claude Code plugin.
+    """Install the qluent Claude Code plugin if it isn't already, or skip.
 
     install_plugin:
-      - True  : install/update without prompting
+      - True  : install without prompting
       - False : skip silently
       - None  : prompt (default Yes)
+
+    When the plugin is already installed, prints a static refresh tip pointing
+    at Claude Code's own `/plugin marketplace update` flow. We do not compare
+    versions or trigger updates ourselves.
     """
     if install_plugin is False:
         return
@@ -188,23 +132,13 @@ def offer_claude_plugin_install(install_plugin: bool | None) -> None:
             echo_status("Claude Code CLI not detected. " + _manual_hint())
         return
 
-    installed = get_installed_claude_plugin_version()
-
-    if installed is None:
-        if install_plugin is None and not click.confirm(
-            "Install the qluent plugin in Claude Code?", default=True
-        ):
-            return
-        if install_claude_plugin():
-            echo_status(f"Claude Code plugin ready: {PLUGIN_ID}")
+    if is_claude_plugin_installed():
+        echo_status(_refresh_tip())
         return
 
-    if _is_older(installed, RECOMMENDED_CLAUDE_PLUGIN_VERSION):
-        _prompt_and_update(
-            installed,
-            RECOMMENDED_CLAUDE_PLUGIN_VERSION,
-            assume_yes=install_plugin is True,
-        )
+    if install_plugin is None and not click.confirm(
+        "Install the qluent plugin in Claude Code?", default=True
+    ):
         return
-
-    echo_status(f"Claude Code plugin up to date: {PLUGIN_ID} {installed}")
+    if install_claude_plugin():
+        echo_status(f"Claude Code plugin ready: {PLUGIN_ID}")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import subprocess
 from types import SimpleNamespace
 
-import click
 import pytest
 from click.testing import CliRunner
 
@@ -31,6 +30,10 @@ def _completed(returncode: int = 0, stderr: str = "") -> subprocess.CompletedPro
     )
 
 
+def _completed_with_stdout(stdout: str) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
 def test_offer_install_skips_when_flag_false(monkeypatch):
     called = SimpleNamespace(value=False)
     monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
@@ -45,12 +48,10 @@ def test_offer_install_skips_when_flag_false(monkeypatch):
     assert called.value is False
 
 
-def test_offer_install_runs_when_flag_true(monkeypatch):
+def test_offer_install_runs_when_flag_true_and_plugin_missing(monkeypatch):
     calls = []
     monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
-    monkeypatch.setattr(
-        plugin_module, "get_installed_claude_plugin_version", lambda: None
-    )
+    monkeypatch.setattr(plugin_module, "is_claude_plugin_installed", lambda: False)
     monkeypatch.setattr(
         plugin_module,
         "install_claude_plugin",
@@ -70,6 +71,36 @@ def test_offer_install_prints_hint_when_claude_missing(monkeypatch, capsys):
     err = capsys.readouterr().err
     assert "Claude Code CLI not detected" in err
     assert "claude plugin marketplace add" in err
+
+
+def test_offer_install_prints_refresh_tip_when_already_installed(monkeypatch, capsys):
+    called = []
+    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
+    monkeypatch.setattr(plugin_module, "is_claude_plugin_installed", lambda: True)
+    monkeypatch.setattr(
+        plugin_module,
+        "install_claude_plugin",
+        lambda: called.append("install") or True,
+    )
+
+    plugin_module.offer_claude_plugin_install(None)
+
+    err = capsys.readouterr().err
+    assert called == []
+    assert f"/plugin marketplace update {plugin_module.MARKETPLACE_NAME}" in err
+    # No version comparison output should leak through.
+    assert "up to date" not in err
+
+
+def test_offer_install_does_not_print_freshness_verdict(monkeypatch, capsys):
+    """Regression: the old `Claude Code plugin up to date: …` line is gone."""
+    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
+    monkeypatch.setattr(plugin_module, "is_claude_plugin_installed", lambda: True)
+
+    plugin_module.offer_claude_plugin_install(None)
+
+    err = capsys.readouterr().err
+    assert "Claude Code plugin up to date" not in err
 
 
 def test_install_claude_plugin_runs_both_steps(monkeypatch):
@@ -111,15 +142,52 @@ def test_install_claude_plugin_returns_false_on_timeout(monkeypatch, capsys):
     assert "timed out" in err
 
 
+def test_is_claude_plugin_installed_true_when_listed(monkeypatch):
+    output = (
+        "Installed plugins:\n"
+        "\n"
+        f"{plugin_module.PLUGIN_ID}\n"
+        "Version: 0.3.0\n"
+    )
+    monkeypatch.setattr(
+        subprocess, "run", lambda cmd, **_: _completed_with_stdout(output)
+    )
+
+    assert plugin_module.is_claude_plugin_installed() is True
+
+
+def test_is_claude_plugin_installed_false_when_absent(monkeypatch):
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **_: _completed_with_stdout("No plugins installed.\n"),
+    )
+
+    assert plugin_module.is_claude_plugin_installed() is False
+
+
+def test_is_claude_plugin_installed_false_on_command_error(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", lambda cmd, **_: _completed(returncode=2))
+
+    assert plugin_module.is_claude_plugin_installed() is False
+
+
+def test_is_claude_plugin_installed_false_on_oserror(monkeypatch):
+    def fake_run(cmd, **_):
+        raise OSError("claude binary missing")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert plugin_module.is_claude_plugin_installed() is False
+
+
 def test_login_install_plugin_flag_invokes_install(
     monkeypatch, isolated_config, fake_browser_login, tmp_path
 ):
     monkeypatch.chdir(tmp_path)
     called = []
     monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
-    monkeypatch.setattr(
-        plugin_module, "get_installed_claude_plugin_version", lambda: None
-    )
+    monkeypatch.setattr(plugin_module, "is_claude_plugin_installed", lambda: False)
     monkeypatch.setattr(
         plugin_module,
         "install_claude_plugin",
@@ -139,9 +207,7 @@ def test_login_no_install_plugin_skips(
     monkeypatch.chdir(tmp_path)
     called = []
     monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
-    monkeypatch.setattr(
-        plugin_module, "get_installed_claude_plugin_version", lambda: None
-    )
+    monkeypatch.setattr(plugin_module, "is_claude_plugin_installed", lambda: False)
     monkeypatch.setattr(
         plugin_module,
         "install_claude_plugin",
@@ -159,9 +225,7 @@ def test_login_prompt_declined(monkeypatch, isolated_config, fake_browser_login,
     (tmp_path / "AGENTS.md").write_text("existing content")
     called = []
     monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
-    monkeypatch.setattr(
-        plugin_module, "get_installed_claude_plugin_version", lambda: None
-    )
+    monkeypatch.setattr(plugin_module, "is_claude_plugin_installed", lambda: False)
     monkeypatch.setattr(
         plugin_module,
         "install_claude_plugin",
@@ -176,236 +240,22 @@ def test_login_prompt_declined(monkeypatch, isolated_config, fake_browser_login,
     assert called == []
 
 
-def test_update_claude_plugin_runs_both_steps(monkeypatch):
-    commands = []
-
-    def fake_run(cmd, **_kwargs):
-        commands.append(cmd)
-        return _completed()
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-
-    assert plugin_module.update_claude_plugin() is True
-    assert commands == [
-        ["claude", "plugin", "marketplace", "update", plugin_module.MARKETPLACE_NAME],
-        ["claude", "plugin", "update", plugin_module.PLUGIN_ID],
-    ]
-
-
-def test_update_claude_plugin_returns_false_on_step_failure(monkeypatch, capsys):
-    def fake_run(cmd, **_kwargs):
-        return _completed(returncode=1, stderr="network down")
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-
-    assert plugin_module.update_claude_plugin() is False
-    err = capsys.readouterr().err
-    assert "Failed: plugin marketplace update" in err
-    assert "network down" in err
-
-
-def test_claude_update_command_succeeds(monkeypatch):
+def test_login_emits_refresh_tip_when_plugin_already_installed(
+    monkeypatch, isolated_config, fake_browser_login, tmp_path
+):
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
-    monkeypatch.setattr(plugin_module, "update_claude_plugin", lambda: True)
+    monkeypatch.setattr(plugin_module, "is_claude_plugin_installed", lambda: True)
 
-    result = CliRunner().invoke(cli, ["claude", "update"])
+    result = CliRunner().invoke(cli, ["login"])
 
     assert result.exit_code == 0
-    assert plugin_module.PLUGIN_ID in result.output
-    assert "up to date" in result.output
+    assert f"/plugin marketplace update {plugin_module.MARKETPLACE_NAME}" in result.output
+    assert "Claude Code plugin up to date" not in result.output
 
 
-def test_claude_update_command_fails_when_claude_missing(monkeypatch):
-    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: False)
-
+def test_claude_update_subcommand_is_removed():
+    """The freshness-check workaround command should no longer exist."""
     result = CliRunner().invoke(cli, ["claude", "update"])
 
     assert result.exit_code != 0
-    assert "Claude Code CLI not found" in result.output
-
-
-def test_claude_update_command_fails_on_step_error(monkeypatch):
-    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
-    monkeypatch.setattr(plugin_module, "update_claude_plugin", lambda: False)
-
-    result = CliRunner().invoke(cli, ["claude", "update"])
-
-    assert result.exit_code != 0
-    assert "Plugin update failed" in result.output
-
-
-# ---------------------------------------------------------------------------
-# Version detection + stale-plugin prompt
-# ---------------------------------------------------------------------------
-
-
-def _completed_with_stdout(stdout: str) -> subprocess.CompletedProcess:
-    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
-
-
-def test_get_installed_version_parses_plugin_list(monkeypatch):
-    output = (
-        "Installed plugins:\n"
-        "\n"
-        f"{plugin_module.PLUGIN_ID}\n"
-        "Version: 0.2.0\n"
-        "\n"
-        "other@thing\n"
-        "Version: 9.9.9\n"
-    )
-    monkeypatch.setattr(
-        subprocess, "run", lambda cmd, **_: _completed_with_stdout(output)
-    )
-
-    assert plugin_module.get_installed_claude_plugin_version() == "0.2.0"
-
-
-def test_get_installed_version_returns_none_when_plugin_absent(monkeypatch):
-    monkeypatch.setattr(
-        subprocess,
-        "run",
-        lambda cmd, **_: _completed_with_stdout("No plugins installed.\n"),
-    )
-
-    assert plugin_module.get_installed_claude_plugin_version() is None
-
-
-def test_get_installed_version_returns_none_on_command_error(monkeypatch):
-    monkeypatch.setattr(subprocess, "run", lambda cmd, **_: _completed(returncode=2))
-
-    assert plugin_module.get_installed_claude_plugin_version() is None
-
-
-def test_get_installed_version_returns_none_on_oserror(monkeypatch):
-    def fake_run(cmd, **_):
-        raise OSError("claude binary missing")
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-
-    assert plugin_module.get_installed_claude_plugin_version() is None
-
-
-def test_is_older_compares_dotted_versions():
-    assert plugin_module._is_older("0.2.0", "0.3.0") is True
-    assert plugin_module._is_older("0.3.0", "0.3.0") is False
-    assert plugin_module._is_older("0.4.0", "0.3.0") is False
-    assert plugin_module._is_older("0.2", "0.2.1") is True
-    assert plugin_module._is_older("0.2.0-rc1", "0.3.0") is True
-
-
-def test_is_older_handles_unparseable_versions():
-    assert plugin_module._is_older("garbage", "0.3.0") is False
-
-
-def test_offer_install_skips_install_when_plugin_already_current(monkeypatch, capsys):
-    called = []
-    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
-    monkeypatch.setattr(
-        plugin_module,
-        "get_installed_claude_plugin_version",
-        lambda: plugin_module.RECOMMENDED_CLAUDE_PLUGIN_VERSION,
-    )
-    monkeypatch.setattr(
-        plugin_module,
-        "install_claude_plugin",
-        lambda: called.append("install") or True,
-    )
-    monkeypatch.setattr(
-        plugin_module,
-        "update_claude_plugin",
-        lambda: called.append("update") or True,
-    )
-
-    plugin_module.offer_claude_plugin_install(None)
-
-    err = capsys.readouterr().err
-    assert called == []
-    assert "up to date" in err
-    assert plugin_module.RECOMMENDED_CLAUDE_PLUGIN_VERSION in err
-
-
-def test_offer_install_prompts_to_update_when_stale_and_runs(monkeypatch, capsys):
-    called = []
-    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
-    monkeypatch.setattr(
-        plugin_module, "get_installed_claude_plugin_version", lambda: "0.2.0"
-    )
-    monkeypatch.setattr(
-        plugin_module, "RECOMMENDED_CLAUDE_PLUGIN_VERSION", "0.3.0"
-    )
-    monkeypatch.setattr(
-        plugin_module, "update_claude_plugin", lambda: called.append("update") or True
-    )
-    monkeypatch.setattr(click, "confirm", lambda *a, **k: True)
-
-    plugin_module.offer_claude_plugin_install(None)
-
-    err = capsys.readouterr().err
-    assert called == ["update"]
-    assert "update available" in err
-    assert "0.2.0" in err
-    assert "0.3.0" in err
-    assert "updated to 0.3.0" in err
-
-
-def test_offer_install_declined_update_prints_manual_command(monkeypatch, capsys):
-    called = []
-    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
-    monkeypatch.setattr(
-        plugin_module, "get_installed_claude_plugin_version", lambda: "0.2.0"
-    )
-    monkeypatch.setattr(
-        plugin_module, "RECOMMENDED_CLAUDE_PLUGIN_VERSION", "0.3.0"
-    )
-    monkeypatch.setattr(
-        plugin_module, "update_claude_plugin", lambda: called.append("update") or True
-    )
-    monkeypatch.setattr(click, "confirm", lambda *a, **k: False)
-
-    plugin_module.offer_claude_plugin_install(None)
-
-    err = capsys.readouterr().err
-    assert called == []
-    assert "qluent claude update" in err
-
-
-def test_offer_install_stale_with_install_flag_true_skips_prompt(monkeypatch, capsys):
-    called = []
-    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
-    monkeypatch.setattr(
-        plugin_module, "get_installed_claude_plugin_version", lambda: "0.2.0"
-    )
-    monkeypatch.setattr(
-        plugin_module, "RECOMMENDED_CLAUDE_PLUGIN_VERSION", "0.3.0"
-    )
-    monkeypatch.setattr(
-        plugin_module, "update_claude_plugin", lambda: called.append("update") or True
-    )
-
-    def fail_confirm(*_a, **_k):
-        raise AssertionError("click.confirm should not be called when assume_yes is True")
-
-    monkeypatch.setattr(click, "confirm", fail_confirm)
-
-    plugin_module.offer_claude_plugin_install(True)
-
-    assert called == ["update"]
-    assert "updated to 0.3.0" in capsys.readouterr().err
-
-
-def test_offer_install_stale_update_failure_reports_retry(monkeypatch, capsys):
-    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
-    monkeypatch.setattr(
-        plugin_module, "get_installed_claude_plugin_version", lambda: "0.2.0"
-    )
-    monkeypatch.setattr(
-        plugin_module, "RECOMMENDED_CLAUDE_PLUGIN_VERSION", "0.3.0"
-    )
-    monkeypatch.setattr(plugin_module, "update_claude_plugin", lambda: False)
-    monkeypatch.setattr(click, "confirm", lambda *a, **k: True)
-
-    plugin_module.offer_claude_plugin_install(None)
-
-    err = capsys.readouterr().err
-    assert "Plugin update failed" in err
-    assert "qluent claude update" in err


### PR DESCRIPTION
…etplace update

The qluent CLI was inspecting `claude plugin list` and comparing against a hardcoded RECOMMENDED_CLAUDE_PLUGIN_VERSION constant, then printing "Claude Code plugin up to date: …" or prompting to update. This created a parallel update path that drifted whenever the plugin repo released without a matching CLI bump (last seen: stuck on 0.3.0 while plugin main was 0.3.1).

Plugin lifecycle is owned by Claude Code's `/plugin marketplace update` flow. Remove the version-comparison machinery and the `qluent claude update` subcommand that was added to work around the previous staleness; replace the verdict line with a static one-line tip pointing at the canonical refresh command when the plugin is already installed.

The first-run install bootstrap (claude plugin marketplace add + install) is preserved so qluent login still offers a friendly first-time setup.