### PR TITLE
login: sync the qluent Claude Code plugin on every successful login

### DIFF
--- a/src/qluent_cli/plugin.py
+++ b/src/qluent_cli/plugin.py
@@ -1,9 +1,11 @@
-"""Claude Code plugin install bootstrap.
+"""Claude Code plugin install + sync.
 
 Wraps `claude plugin marketplace add` / `install` so `qluent login` can offer a
-one-time install of the qluent Claude Code plugin. Plugin lifecycle (updates,
-version tracking) is owned by Claude Code's `/plugin marketplace update` flow;
-this module deliberately does not check or manage plugin versions.
+one-time install of the qluent Claude Code plugin, and `claude plugin
+marketplace update` / `claude plugin update` so each subsequent login pulls the
+latest published plugin version. Plugin lifecycle is owned by Claude Code's
+marketplace flow — this module never inspects, caches, or compares plugin
+versions; it just shells out to Claude Code's idempotent commands.
 """
 
 from __future__ import annotations
@@ -95,6 +97,20 @@ def install_claude_plugin() -> bool:
     ))
 
 
+def sync_claude_plugin() -> bool:
+    """Refresh marketplace metadata and pull the latest plugin version.
+
+    Idempotent — no-ops cleanly when nothing has changed upstream. Run from the
+    login path on every successful login so users don't have to remember to
+    invoke `/plugin marketplace update` manually (third-party marketplaces
+    have auto-update off by default in Claude Code).
+    """
+    return _run_steps((
+        ["claude", "plugin", "marketplace", "update", MARKETPLACE_NAME],
+        ["claude", "plugin", "update", PLUGIN_ID],
+    ))
+
+
 def _manual_hint() -> str:
     return (
         "Install Claude Code (https://claude.ai/code), then run:\n"
@@ -111,16 +127,17 @@ def _refresh_tip() -> str:
 
 
 def offer_claude_plugin_install(install_plugin: bool | None) -> None:
-    """Install the qluent Claude Code plugin if it isn't already, or skip.
+    """Install or sync the qluent Claude Code plugin.
 
     install_plugin:
-      - True  : install without prompting
+      - True  : install/sync without prompting
       - False : skip silently
-      - None  : prompt (default Yes)
+      - None  : prompt for install if missing; sync silently if already present
 
-    When the plugin is already installed, prints a static refresh tip pointing
-    at Claude Code's own `/plugin marketplace update` flow. We do not compare
-    versions or trigger updates ourselves.
+    When the plugin is already installed, runs `sync_claude_plugin()` to pull
+    any newer published version. On sync failure, falls back to a static tip
+    pointing at Claude Code's own `/plugin marketplace update` flow so the
+    user has a recourse without blocking login.
     """
     if install_plugin is False:
         return
@@ -133,7 +150,10 @@ def offer_claude_plugin_install(install_plugin: bool | None) -> None:
         return
 
     if is_claude_plugin_installed():
-        echo_status(_refresh_tip())
+        if sync_claude_plugin():
+            echo_status(f"Claude Code plugin synced: {PLUGIN_ID}")
+        else:
+            echo_status(_refresh_tip())
         return
 
     if install_plugin is None and not click.confirm(

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -73,29 +73,49 @@ def test_offer_install_prints_hint_when_claude_missing(monkeypatch, capsys):
     assert "claude plugin marketplace add" in err
 
 
-def test_offer_install_prints_refresh_tip_when_already_installed(monkeypatch, capsys):
-    called = []
+def test_offer_install_runs_sync_when_already_installed(monkeypatch, capsys):
+    """When the plugin is already installed, login runs sync — no install, no prompt."""
+    install_calls = []
+    sync_calls = []
     monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
     monkeypatch.setattr(plugin_module, "is_claude_plugin_installed", lambda: True)
     monkeypatch.setattr(
         plugin_module,
         "install_claude_plugin",
-        lambda: called.append("install") or True,
+        lambda: install_calls.append("install") or True,
+    )
+    monkeypatch.setattr(
+        plugin_module,
+        "sync_claude_plugin",
+        lambda: sync_calls.append("sync") or True,
     )
 
     plugin_module.offer_claude_plugin_install(None)
 
     err = capsys.readouterr().err
-    assert called == []
+    assert install_calls == []
+    assert sync_calls == ["sync"]
+    assert f"Claude Code plugin synced: {plugin_module.PLUGIN_ID}" in err
+
+
+def test_offer_install_falls_back_to_tip_when_sync_fails(monkeypatch, capsys):
+    """If sync fails, login still completes and prints the static refresh tip."""
+    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
+    monkeypatch.setattr(plugin_module, "is_claude_plugin_installed", lambda: True)
+    monkeypatch.setattr(plugin_module, "sync_claude_plugin", lambda: False)
+
+    plugin_module.offer_claude_plugin_install(None)
+
+    err = capsys.readouterr().err
     assert f"/plugin marketplace update {plugin_module.MARKETPLACE_NAME}" in err
-    # No version comparison output should leak through.
-    assert "up to date" not in err
+    assert "synced" not in err
 
 
 def test_offer_install_does_not_print_freshness_verdict(monkeypatch, capsys):
     """Regression: the old `Claude Code plugin up to date: …` line is gone."""
     monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
     monkeypatch.setattr(plugin_module, "is_claude_plugin_installed", lambda: True)
+    monkeypatch.setattr(plugin_module, "sync_claude_plugin", lambda: True)
 
     plugin_module.offer_claude_plugin_install(None)
 
@@ -240,18 +260,73 @@ def test_login_prompt_declined(monkeypatch, isolated_config, fake_browser_login,
     assert called == []
 
 
-def test_login_emits_refresh_tip_when_plugin_already_installed(
+def test_login_syncs_plugin_when_already_installed(
     monkeypatch, isolated_config, fake_browser_login, tmp_path
 ):
+    """End-to-end: every `qluent login` triggers a plugin sync if installed."""
     monkeypatch.chdir(tmp_path)
+    sync_calls = []
     monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
     monkeypatch.setattr(plugin_module, "is_claude_plugin_installed", lambda: True)
+    monkeypatch.setattr(
+        plugin_module,
+        "sync_claude_plugin",
+        lambda: sync_calls.append("sync") or True,
+    )
 
     result = CliRunner().invoke(cli, ["login"])
 
     assert result.exit_code == 0
-    assert f"/plugin marketplace update {plugin_module.MARKETPLACE_NAME}" in result.output
-    assert "Claude Code plugin up to date" not in result.output
+    assert sync_calls == ["sync"]
+    assert f"Claude Code plugin synced: {plugin_module.PLUGIN_ID}" in result.output
+
+
+def test_login_no_install_plugin_skips_sync(
+    monkeypatch, isolated_config, fake_browser_login, tmp_path
+):
+    """`--no-install-plugin` is the escape hatch — also skips sync."""
+    monkeypatch.chdir(tmp_path)
+    sync_calls = []
+    monkeypatch.setattr(plugin_module, "claude_cli_available", lambda: True)
+    monkeypatch.setattr(plugin_module, "is_claude_plugin_installed", lambda: True)
+    monkeypatch.setattr(
+        plugin_module,
+        "sync_claude_plugin",
+        lambda: sync_calls.append("sync") or True,
+    )
+
+    result = CliRunner().invoke(cli, ["login", "--no-install-plugin"])
+
+    assert result.exit_code == 0
+    assert sync_calls == []
+
+
+def test_sync_claude_plugin_runs_both_steps(monkeypatch):
+    commands = []
+
+    def fake_run(cmd, **_kwargs):
+        commands.append(cmd)
+        return _completed()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert plugin_module.sync_claude_plugin() is True
+    assert commands == [
+        ["claude", "plugin", "marketplace", "update", plugin_module.MARKETPLACE_NAME],
+        ["claude", "plugin", "update", plugin_module.PLUGIN_ID],
+    ]
+
+
+def test_sync_claude_plugin_returns_false_on_step_failure(monkeypatch, capsys):
+    def fake_run(cmd, **_kwargs):
+        return _completed(returncode=1, stderr="network down")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert plugin_module.sync_claude_plugin() is False
+    err = capsys.readouterr().err
+    assert "Failed: plugin marketplace update" in err
+    assert "network down" in err
 
 
 def test_claude_update_subcommand_is_removed():


### PR DESCRIPTION
Closes the delivery loop opened by 0.1.12 (which removed the broken freshness
check). Claude Code does not automatically poll marketplaces, and third-party
marketplaces have auto-update off by default — so plugin version bumps in
qluent/qluent-plugin-cc weren't reaching end users until they happened to run
`/plugin marketplace update qluent-metric-trees` themselves.

After login, when Claude Code is on PATH and the plugin is installed, run

  claude plugin marketplace update qluent-metric-trees
  claude plugin update qluent@qluent-metric-trees

Both commands are idempotent and no-op when nothing has changed upstream. The
CLI does not inspect, cache, or compare versions — it just shells out to
Claude Code's own commands. On sync failure, login still succeeds and the
static `/plugin marketplace update` tip is printed as a recourse so users
aren't left without a way forward.

The existing `--no-install-plugin` flag continues to opt out of all plugin
interaction, including sync (useful for CI / scripted login).