### PR TITLE
arch: deepen six shallow modules (rendering, period, contracts, configs, runs, command runner)

### DIFF
--- a/src/qluent_cli/client.py
+++ b/src/qluent_cli/client.py
@@ -15,6 +15,7 @@ import httpx
 
 from qluent_cli.config import QluentConfig
 from qluent_cli.output import echo_status
+from qluent_cli.rca_contracts import RCAOutput, enrich_rca_output
 
 
 _INVESTIGATE_TIMEOUT = 300.0
@@ -318,7 +319,39 @@ class QluentClient:
         max_branching: int = 2,
         max_segments: int = 5,
         min_contribution_share: float = 0.1,
+    ) -> RCAOutput:
+        """Run RCA and return the enriched agent contract.
+
+        The enriched contract — `schema_version`, `provenance`, materiality
+        fields, normalized deltas — is part of the client's interface, not a
+        post-processing step callers must remember.
+        """
+        raw = self._root_cause_raw(
+            tree_id, current_from, current_to, comparison_from, comparison_to,
+            segment_by=segment_by, filters=filters, metric=metric,
+            max_depth=max_depth, max_branching=max_branching,
+            max_segments=max_segments, min_contribution_share=min_contribution_share,
+        )
+        return enrich_rca_output(raw, self._config)
+
+    def _root_cause_raw(
+        self,
+        tree_id: str,
+        current_from: str,
+        current_to: str,
+        comparison_from: str,
+        comparison_to: str,
+        *,
+        segment_by: list[str] | None = None,
+        filters: dict[str, list[str]] | None = None,
+        metric: str | None = None,
+        max_depth: int = 3,
+        max_branching: int = 2,
+        max_segments: int = 5,
+        min_contribution_share: float = 0.1,
     ) -> dict[str, Any]:
+        """Wire-level RCA call. Internal seam for tests; production callers
+        go through `root_cause_tree`."""
         resp = self._client.post(
             f"{self._base}/metric-trees/{tree_id}/root-cause/",
             json=self._rca_body(

--- a/src/qluent_cli/client.py
+++ b/src/qluent_cli/client.py
@@ -13,7 +13,14 @@ from typing import Any
 
 import httpx
 
+from qluent_cli.client_configs import (
+    ElasticityParams,
+    InvestigationParams,
+    RcaParams,
+    rca_params_to_kwargs,
+)
 from qluent_cli.config import QluentConfig
+from qluent_cli.dates import DateWindows
 from qluent_cli.output import echo_status
 from qluent_cli.rca_contracts import RCAOutput, enrich_rca_output
 
@@ -144,6 +151,94 @@ def _build_transport() -> httpx.BaseTransport:
     return _RetryTransport(httpx.HTTPTransport())
 
 
+def _windows_to_iso(
+    windows: DateWindows | None,
+    current_from: str | None,
+    current_to: str | None,
+    comparison_from: str | None,
+    comparison_to: str | None,
+) -> tuple[str, str, str, str]:
+    """Accept either a `DateWindows` or four positional ISO strings."""
+    if windows is not None:
+        return windows.iso_tuple()
+    if not all([current_from, current_to, comparison_from, comparison_to]):
+        raise TypeError(
+            "Pass either `windows=DateWindows(...)` or all four of "
+            "current_from/current_to/comparison_from/comparison_to."
+        )
+    return current_from, current_to, comparison_from, comparison_to  # type: ignore[return-value]
+
+
+def _merge_rca_params(
+    params: RcaParams | None,
+    *,
+    segment_by: list[str] | None,
+    filters: dict[str, list[str]] | None,
+    metric: str | None,
+    max_depth: int | None,
+    max_branching: int | None,
+    max_segments: int | None,
+    min_contribution_share: float | None,
+) -> RcaParams:
+    """Take an explicit `RcaParams`, falling back to per-kwarg overrides
+    when none was provided. Kwargs are kept for adapters that build
+    their params iteratively (CLI Click options); the dataclass is the
+    canonical shape."""
+    if params is None:
+        params = RcaParams()
+    return RcaParams(
+        metric=metric if metric is not None else params.metric,
+        segment_by=tuple(segment_by) if segment_by is not None else params.segment_by,
+        filters=dict(filters) if filters is not None else params.filters,
+        max_depth=max_depth if max_depth is not None else params.max_depth,
+        max_branching=max_branching if max_branching is not None else params.max_branching,
+        max_segments=max_segments if max_segments is not None else params.max_segments,
+        min_contribution_share=(
+            min_contribution_share
+            if min_contribution_share is not None
+            else params.min_contribution_share
+        ),
+    )
+
+
+def _merge_investigation_params(
+    params: InvestigationParams | None,
+    *,
+    trend_periods: int | None,
+    trend_grain: str | None,
+    trend_as_of: str | None,
+    segment_by: list[str] | None,
+    filters: dict[str, list[str]] | None,
+    metric: str | None,
+    compare_trees: list[str] | None,
+    max_depth: int | None,
+    max_branching: int | None,
+    max_segments: int | None,
+    min_contribution_share: float | None,
+) -> InvestigationParams:
+    if params is None:
+        params = InvestigationParams()
+    return InvestigationParams(
+        metric=metric if metric is not None else params.metric,
+        segment_by=tuple(segment_by) if segment_by is not None else params.segment_by,
+        filters=dict(filters) if filters is not None else params.filters,
+        max_depth=max_depth if max_depth is not None else params.max_depth,
+        max_branching=max_branching if max_branching is not None else params.max_branching,
+        max_segments=max_segments if max_segments is not None else params.max_segments,
+        min_contribution_share=(
+            min_contribution_share
+            if min_contribution_share is not None
+            else params.min_contribution_share
+        ),
+        trend_periods=trend_periods if trend_periods is not None else params.trend_periods,
+        trend_grain=trend_grain if trend_grain is not None else params.trend_grain,
+        trend_as_of=trend_as_of if trend_as_of is not None else params.trend_as_of,
+        compare_trees=(
+            tuple(compare_trees) if compare_trees is not None else params.compare_trees
+        ),
+    )
+
+
 class QluentClient:
     """Thin wrapper around the Qluent external API."""
 
@@ -230,14 +325,19 @@ class QluentClient:
     def evaluate_tree(
         self,
         tree_id: str,
-        current_from: str,
-        current_to: str,
-        comparison_from: str,
-        comparison_to: str,
+        current_from: str | None = None,
+        current_to: str | None = None,
+        comparison_from: str | None = None,
+        comparison_to: str | None = None,
+        *,
+        windows: DateWindows | None = None,
     ) -> dict[str, Any]:
+        c_from, c_to, p_from, p_to = _windows_to_iso(
+            windows, current_from, current_to, comparison_from, comparison_to
+        )
         resp = self._client.post(
             f"{self._base}/metric-trees/{tree_id}/evaluate/",
-            json=self._window_body(current_from, current_to, comparison_from, comparison_to),
+            json=self._window_body(c_from, c_to, p_from, p_to),
         )
         resp.raise_for_status()
         return resp.json()
@@ -245,22 +345,24 @@ class QluentClient:
     def investigate_tree(
         self,
         tree_id: str,
-        current_from: str,
-        current_to: str,
-        comparison_from: str,
-        comparison_to: str,
+        current_from: str | None = None,
+        current_to: str | None = None,
+        comparison_from: str | None = None,
+        comparison_to: str | None = None,
         *,
-        trend_periods: int = 4,
-        trend_grain: str = "week",
+        windows: DateWindows | None = None,
+        params: InvestigationParams | None = None,
+        trend_periods: int | None = None,
+        trend_grain: str | None = None,
         trend_as_of: str | None = None,
         segment_by: list[str] | None = None,
         filters: dict[str, list[str]] | None = None,
         metric: str | None = None,
         compare_trees: list[str] | None = None,
-        max_depth: int = 3,
-        max_branching: int = 2,
-        max_segments: int = 5,
-        min_contribution_share: float = 0.1,
+        max_depth: int | None = None,
+        max_branching: int | None = None,
+        max_segments: int | None = None,
+        min_contribution_share: float | None = None,
         progress_callback: ProgressCallback | None = None,
     ) -> dict[str, Any]:
         """Run a full server-side investigation bundle.
@@ -270,17 +372,29 @@ class QluentClient:
         `_PROGRESS_INTERVAL_SECONDS` until the POST returns. The thread is
         torn down before the response is returned, regardless of outcome.
         """
-        body = self._rca_body(
-            current_from, current_to, comparison_from, comparison_to,
-            segment_by=segment_by, filters=filters, metric=metric,
-            max_depth=max_depth, max_branching=max_branching,
-            max_segments=max_segments, min_contribution_share=min_contribution_share,
+        c_from, c_to, p_from, p_to = _windows_to_iso(
+            windows, current_from, current_to, comparison_from, comparison_to
         )
+        merged = _merge_investigation_params(
+            params,
+            trend_periods=trend_periods,
+            trend_grain=trend_grain,
+            trend_as_of=trend_as_of,
+            segment_by=segment_by,
+            filters=filters,
+            metric=metric,
+            compare_trees=compare_trees,
+            max_depth=max_depth,
+            max_branching=max_branching,
+            max_segments=max_segments,
+            min_contribution_share=min_contribution_share,
+        )
+        body = self._rca_body(c_from, c_to, p_from, p_to, **rca_params_to_kwargs(merged.as_rca()))
         body.update({
-            "trend_periods": trend_periods,
-            "trend_grain": trend_grain,
-            "trend_as_of": trend_as_of,
-            "compare_trees": compare_trees or [],
+            "trend_periods": merged.trend_periods,
+            "trend_grain": merged.trend_grain,
+            "trend_as_of": merged.trend_as_of,
+            "compare_trees": list(merged.compare_trees),
         })
         url = f"{self._base}/metric-trees/{tree_id}/investigate/"
 
@@ -307,18 +421,20 @@ class QluentClient:
     def root_cause_tree(
         self,
         tree_id: str,
-        current_from: str,
-        current_to: str,
-        comparison_from: str,
-        comparison_to: str,
+        current_from: str | None = None,
+        current_to: str | None = None,
+        comparison_from: str | None = None,
+        comparison_to: str | None = None,
         *,
+        windows: DateWindows | None = None,
+        params: RcaParams | None = None,
         segment_by: list[str] | None = None,
         filters: dict[str, list[str]] | None = None,
         metric: str | None = None,
-        max_depth: int = 3,
-        max_branching: int = 2,
-        max_segments: int = 5,
-        min_contribution_share: float = 0.1,
+        max_depth: int | None = None,
+        max_branching: int | None = None,
+        max_segments: int | None = None,
+        min_contribution_share: float | None = None,
     ) -> RCAOutput:
         """Run RCA and return the enriched agent contract.
 
@@ -326,11 +442,21 @@ class QluentClient:
         fields, normalized deltas — is part of the client's interface, not a
         post-processing step callers must remember.
         """
+        c_from, c_to, p_from, p_to = _windows_to_iso(
+            windows, current_from, current_to, comparison_from, comparison_to
+        )
+        merged = _merge_rca_params(
+            params,
+            segment_by=segment_by,
+            filters=filters,
+            metric=metric,
+            max_depth=max_depth,
+            max_branching=max_branching,
+            max_segments=max_segments,
+            min_contribution_share=min_contribution_share,
+        )
         raw = self._root_cause_raw(
-            tree_id, current_from, current_to, comparison_from, comparison_to,
-            segment_by=segment_by, filters=filters, metric=metric,
-            max_depth=max_depth, max_branching=max_branching,
-            max_segments=max_segments, min_contribution_share=min_contribution_share,
+            tree_id, c_from, c_to, p_from, p_to, **rca_params_to_kwargs(merged),
         )
         return enrich_rca_output(raw, self._config)
 
@@ -367,24 +493,35 @@ class QluentClient:
     def elasticity_tree(
         self,
         tree_id: str,
-        current_from: str,
-        current_to: str,
-        comparison_from: str,
-        comparison_to: str,
+        current_from: str | None = None,
+        current_to: str | None = None,
+        comparison_from: str | None = None,
+        comparison_to: str | None = None,
         *,
-        outcome: str,
-        lever: str,
+        windows: DateWindows | None = None,
+        params: ElasticityParams | None = None,
+        outcome: str | None = None,
+        lever: str | None = None,
         dimension: str | None = None,
         filters: dict[str, list[str]] | None = None,
     ) -> dict[str, Any]:
-        body = self._window_body(current_from, current_to, comparison_from, comparison_to)
+        c_from, c_to, p_from, p_to = _windows_to_iso(
+            windows, current_from, current_to, comparison_from, comparison_to
+        )
+        merged_outcome = params.outcome if params else outcome
+        merged_lever = params.lever if params else lever
+        merged_dimension = params.dimension if params and dimension is None else dimension
+        merged_filters = (
+            dict(params.filters) if params and filters is None else (filters or {})
+        )
+        body = self._window_body(c_from, c_to, p_from, p_to)
         body.update({
-            "outcome": outcome,
-            "lever": lever,
-            "dimension": dimension,
-            "filters": filters or {},
+            "outcome": merged_outcome,
+            "lever": merged_lever,
+            "dimension": merged_dimension,
+            "filters": merged_filters,
         })
-        if dimension is None:
+        if merged_dimension is None:
             body.pop("dimension")
         resp = self._client.post(
             f"{self._base}/metric-trees/{tree_id}/elasticity/",

--- a/src/qluent_cli/client_configs.py
+++ b/src/qluent_cli/client_configs.py
@@ -1,0 +1,78 @@
+"""Domain-shaped configs for client requests.
+
+The client used to take long kwargs lists and defaults lived in three
+places (Click options, MCP schemas, client method signatures).  These
+dataclasses make the defaults canonical and the call sites legible.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RcaParams:
+    """Parameters shared by `root_cause_tree` and `investigate_tree`."""
+
+    metric: str | None = None
+    segment_by: tuple[str, ...] = ()
+    filters: dict[str, list[str]] = field(default_factory=dict)
+    max_depth: int = 3
+    max_branching: int = 2
+    max_segments: int = 5
+    min_contribution_share: float = 0.1
+
+
+@dataclass(frozen=True)
+class InvestigationParams:
+    """Investigation-specific options layered on top of RCA params.
+
+    Investigation = RCA + multi-period trend + cross-tree comparison.
+    """
+
+    metric: str | None = None
+    segment_by: tuple[str, ...] = ()
+    filters: dict[str, list[str]] = field(default_factory=dict)
+    max_depth: int = 3
+    max_branching: int = 2
+    max_segments: int = 5
+    min_contribution_share: float = 0.1
+    trend_periods: int = 4
+    trend_grain: str = "week"
+    trend_as_of: str | None = None
+    compare_trees: tuple[str, ...] = ()
+
+    def as_rca(self) -> RcaParams:
+        return RcaParams(
+            metric=self.metric,
+            segment_by=self.segment_by,
+            filters=self.filters,
+            max_depth=self.max_depth,
+            max_branching=self.max_branching,
+            max_segments=self.max_segments,
+            min_contribution_share=self.min_contribution_share,
+        )
+
+
+@dataclass(frozen=True)
+class ElasticityParams:
+    """Parameters for the elasticity endpoint."""
+
+    outcome: str
+    lever: str
+    dimension: str | None = None
+    filters: dict[str, list[str]] = field(default_factory=dict)
+
+
+def rca_params_to_kwargs(params: RcaParams) -> dict[str, Any]:
+    """Adapt an `RcaParams` into the kwargs the wire-level helpers accept."""
+    return {
+        "metric": params.metric,
+        "segment_by": list(params.segment_by),
+        "filters": dict(params.filters),
+        "max_depth": params.max_depth,
+        "max_branching": params.max_branching,
+        "max_segments": params.max_segments,
+        "min_contribution_share": params.min_contribution_share,
+    }

--- a/src/qluent_cli/command_runner.py
+++ b/src/qluent_cli/command_runner.py
@@ -1,0 +1,65 @@
+"""Command-runner decorator — capstone of the architecture refactor.
+
+After the prior deepenings (rendering, window resolver, client configs,
+RunManager), every Click command has the same skeleton:
+
+    config = load_config()
+    client = QluentClient(config)
+    try:
+        ... business logic ...
+    except PeriodResolutionError as exc:
+        raise click.ClickException(str(exc)) from exc
+    render(result, as_json=as_json)
+
+`@qluent_command` collapses that.  The wrapped function takes
+`(client, config, *args, **kwargs)` and returns a `Result | None`.
+"""
+
+from __future__ import annotations
+
+import functools
+import sys
+from typing import Any, Callable
+
+import click
+
+from qluent_cli.client import QluentClient
+from qluent_cli.config import load_config
+from qluent_cli.rendering import Result, render
+from qluent_cli.window_resolver import PeriodResolutionError
+
+
+def qluent_command(func: Callable[..., Result | None]) -> Callable[..., Any]:
+    """Wrap a Click command body so it receives `client`, `config`, and
+    only has to return a `Result` (or `None`) for the renderer to emit.
+
+    The decorator:
+      * loads the config and constructs a client
+      * forwards Click options/arguments unchanged
+      * maps `PeriodResolutionError` to `click.ClickException`
+      * renders any returned `Result` with the right `as_json` flag
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> None:
+        # Resolve load_config / QluentClient via the wrapped function's
+        # module first, so existing monkey-patches like
+        # `monkeypatch.setattr("qluent_cli.trees.load_config", ...)`
+        # continue to work.
+        host = sys.modules.get(func.__module__)
+        local_load_config = getattr(host, "load_config", load_config)
+        local_client_cls = getattr(host, "QluentClient", QluentClient)
+
+        config = local_load_config()
+        client = local_client_cls(config)
+        try:
+            result = func(client, config, *args, **kwargs)
+        except PeriodResolutionError as exc:
+            raise click.ClickException(str(exc)) from exc
+
+        if result is None:
+            return
+        as_json = bool(kwargs.get("as_json", False))
+        render(result, as_json=as_json)
+
+    return wrapper

--- a/src/qluent_cli/dates.py
+++ b/src/qluent_cli/dates.py
@@ -43,6 +43,15 @@ class DateWindows:
     current: DateWindow
     comparison: DateWindow
 
+    def iso_tuple(self) -> tuple[str, str, str, str]:
+        """Return `(current_from, current_to, comparison_from, comparison_to)`."""
+        return (
+            self.current.iso_from,
+            self.current.iso_to,
+            self.comparison.iso_from,
+            self.comparison.iso_to,
+        )
+
 
 def resolve_windows(
     period: str | None,

--- a/src/qluent_cli/elasticity.py
+++ b/src/qluent_cli/elasticity.py
@@ -8,12 +8,13 @@ import click
 
 from qluent_cli.client import QluentClient
 from qluent_cli.client_configs import ElasticityParams
+from qluent_cli.command_runner import qluent_command
 from qluent_cli.config import QluentConfig, load_config
 from qluent_cli.dates import DateWindow, DateWindows
 from qluent_cli.formatters import format_elasticity
-from qluent_cli.rendering import render, simple_result
+from qluent_cli.rendering import Result, simple_result
 from qluent_cli.utils import parse_filters
-from qluent_cli.window_resolver import PeriodResolutionError, resolve_period
+from qluent_cli.window_resolver import resolve_period
 
 
 def analyze_elasticity(
@@ -87,7 +88,10 @@ def analyze_elasticity(
 @click.option("--compare", "compare_range", default=None, help="Comparison window as YYYY-MM-DD:YYYY-MM-DD")
 @click.option("--filter", "filters", multiple=True, help="Filter as dimension=value (repeatable)")
 @click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
+@qluent_command
 def elasticity(
+    client,
+    config,
     tree_id: str,
     outcome: str,
     lever: str,
@@ -96,20 +100,16 @@ def elasticity(
     current_range: str | None,
     compare_range: str | None,
     filters: tuple[str, ...],
+    *,
     as_json: bool,
-) -> None:
+) -> Result:
     """Analyze observed elasticity between a lever and an outcome metric."""
-    try:
-        rp = resolve_period(
-            period=period,
-            current_range=current_range,
-            compare_range=compare_range,
-        )
-    except PeriodResolutionError as exc:
-        raise click.ClickException(str(exc)) from exc
+    rp = resolve_period(
+        period=period,
+        current_range=current_range,
+        compare_range=compare_range,
+    )
     c_from, c_to, p_from, p_to = rp.windows.iso_tuple()
-    config = load_config()
-    client = QluentClient(config)
     data = analyze_elasticity(
         client,
         config,
@@ -123,5 +123,4 @@ def elasticity(
         comparison_to=p_to,
         filters=parse_filters(filters),
     )
-
-    render(simple_result(data, formatter=format_elasticity), as_json=as_json)
+    return simple_result(data, formatter=format_elasticity)

--- a/src/qluent_cli/elasticity.py
+++ b/src/qluent_cli/elasticity.py
@@ -8,10 +8,10 @@ import click
 
 from qluent_cli.client import QluentClient
 from qluent_cli.config import QluentConfig, load_config
-from qluent_cli.dates import resolve_windows
 from qluent_cli.formatters import format_elasticity
 from qluent_cli.rendering import render, simple_result
 from qluent_cli.utils import parse_filters
+from qluent_cli.window_resolver import PeriodResolutionError, resolve_period
 
 
 def analyze_elasticity(
@@ -90,7 +90,15 @@ def elasticity(
     as_json: bool,
 ) -> None:
     """Analyze observed elasticity between a lever and an outcome metric."""
-    windows = resolve_windows(period, current_range, compare_range)
+    try:
+        rp = resolve_period(
+            period=period,
+            current_range=current_range,
+            compare_range=compare_range,
+        )
+    except PeriodResolutionError as exc:
+        raise click.ClickException(str(exc)) from exc
+    c_from, c_to, p_from, p_to = rp.windows.iso_tuple()
     config = load_config()
     client = QluentClient(config)
     data = analyze_elasticity(
@@ -100,10 +108,10 @@ def elasticity(
         outcome=outcome,
         lever=lever,
         dimension=dimension,
-        current_from=windows.current.iso_from,
-        current_to=windows.current.iso_to,
-        comparison_from=windows.comparison.iso_from,
-        comparison_to=windows.comparison.iso_to,
+        current_from=c_from,
+        current_to=c_to,
+        comparison_from=p_from,
+        comparison_to=p_to,
         filters=parse_filters(filters),
     )
 

--- a/src/qluent_cli/elasticity.py
+++ b/src/qluent_cli/elasticity.py
@@ -7,7 +7,9 @@ from typing import Any
 import click
 
 from qluent_cli.client import QluentClient
+from qluent_cli.client_configs import ElasticityParams
 from qluent_cli.config import QluentConfig, load_config
+from qluent_cli.dates import DateWindow, DateWindows
 from qluent_cli.formatters import format_elasticity
 from qluent_cli.rendering import render, simple_result
 from qluent_cli.utils import parse_filters
@@ -34,16 +36,23 @@ def analyze_elasticity(
     the `qluent_elasticity` MCP tool. Both adapters call into here so they
     cannot drift on contract shape, defaults, or provenance.
     """
+    from datetime import date as _date
+
+    windows = DateWindows(
+        current=DateWindow(_date.fromisoformat(current_from), _date.fromisoformat(current_to)),
+        comparison=DateWindow(
+            _date.fromisoformat(comparison_from), _date.fromisoformat(comparison_to)
+        ),
+    )
     data = client.elasticity_tree(
         tree_id,
-        current_from,
-        current_to,
-        comparison_from,
-        comparison_to,
-        outcome=outcome,
-        lever=lever,
-        dimension=dimension,
-        filters=filters or {},
+        windows=windows,
+        params=ElasticityParams(
+            outcome=outcome,
+            lever=lever,
+            dimension=dimension,
+            filters=filters or {},
+        ),
     )
     data.setdefault("contract_kind", "elasticity_analysis")
     data.setdefault("deterministic", True)

--- a/src/qluent_cli/elasticity.py
+++ b/src/qluent_cli/elasticity.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 import click
@@ -11,6 +10,7 @@ from qluent_cli.client import QluentClient
 from qluent_cli.config import QluentConfig, load_config
 from qluent_cli.dates import resolve_windows
 from qluent_cli.formatters import format_elasticity
+from qluent_cli.rendering import render, simple_result
 from qluent_cli.utils import parse_filters
 
 
@@ -107,7 +107,4 @@ def elasticity(
         filters=parse_filters(filters),
     )
 
-    if as_json:
-        click.echo(json.dumps(data, indent=2))
-    else:
-        click.echo(format_elasticity(data))
+    render(simple_result(data, formatter=format_elasticity), as_json=as_json)

--- a/src/qluent_cli/mcp_server.py
+++ b/src/qluent_cli/mcp_server.py
@@ -16,12 +16,12 @@ from typing import Any, Awaitable, Callable
 from qluent_cli import __version__
 from qluent_cli.client import QluentClient
 from qluent_cli.config import QluentConfig, load_config
-from qluent_cli.dates import resolve_windows
 from qluent_cli.elasticity import analyze_elasticity
 from qluent_cli.rca_contracts import enrich_rca_output
 from qluent_cli.runs import run_investigation
 from qluent_cli.suggestions import build_suggestions
 from qluent_cli.utils import parse_filters
+from qluent_cli.window_resolver import resolve_period
 
 
 SERVER_NAME = "qluent"
@@ -55,13 +55,11 @@ def _resolve_dates(
     current_range: str | None,
     compare_range: str | None,
 ) -> tuple[str, str, str, str]:
-    windows = resolve_windows(period, current_range, compare_range)
-    return (
-        windows.current.iso_from,
-        windows.current.iso_to,
-        windows.comparison.iso_from,
-        windows.comparison.iso_to,
-    )
+    return resolve_period(
+        period=period,
+        current_range=current_range,
+        compare_range=compare_range,
+    ).windows.iso_tuple()
 
 
 def _filter_schema() -> dict[str, Any]:

--- a/src/qluent_cli/mcp_server.py
+++ b/src/qluent_cli/mcp_server.py
@@ -15,6 +15,7 @@ from typing import Any, Awaitable, Callable
 
 from qluent_cli import __version__
 from qluent_cli.client import QluentClient
+from qluent_cli.client_configs import RcaParams
 from qluent_cli.config import QluentConfig, load_config
 from qluent_cli.elasticity import analyze_elasticity
 from qluent_cli.runs import run_investigation
@@ -368,19 +369,24 @@ async def _rca_analyze(client: QluentClient, config: QluentConfig, args: dict[st
     c_from, c_to, p_from, p_to = _resolve_dates(
         args.get("period"), args.get("current"), args.get("compare")
     )
+    defaults = RcaParams()
     return client.root_cause_tree(
         args["tree_id"],
         c_from,
         c_to,
         p_from,
         p_to,
-        segment_by=list(args.get("segment_by") or []),
-        filters=_filters_from_arg(args.get("filters")),
-        metric=args.get("metric"),
-        max_depth=int(args.get("max_depth", 3)),
-        max_branching=int(args.get("max_branches", 2)),
-        max_segments=int(args.get("max_segments", 5)),
-        min_contribution_share=float(args.get("min_contribution_share", 0.1)),
+        params=RcaParams(
+            metric=args.get("metric"),
+            segment_by=tuple(args.get("segment_by") or ()),
+            filters=_filters_from_arg(args.get("filters")),
+            max_depth=int(args.get("max_depth", defaults.max_depth)),
+            max_branching=int(args.get("max_branches", defaults.max_branching)),
+            max_segments=int(args.get("max_segments", defaults.max_segments)),
+            min_contribution_share=float(
+                args.get("min_contribution_share", defaults.min_contribution_share)
+            ),
+        ),
     )
 
 

--- a/src/qluent_cli/mcp_server.py
+++ b/src/qluent_cli/mcp_server.py
@@ -17,7 +17,6 @@ from qluent_cli import __version__
 from qluent_cli.client import QluentClient
 from qluent_cli.config import QluentConfig, load_config
 from qluent_cli.elasticity import analyze_elasticity
-from qluent_cli.rca_contracts import enrich_rca_output
 from qluent_cli.runs import run_investigation
 from qluent_cli.suggestions import build_suggestions
 from qluent_cli.utils import parse_filters
@@ -369,7 +368,7 @@ async def _rca_analyze(client: QluentClient, config: QluentConfig, args: dict[st
     c_from, c_to, p_from, p_to = _resolve_dates(
         args.get("period"), args.get("current"), args.get("compare")
     )
-    data = client.root_cause_tree(
+    return client.root_cause_tree(
         args["tree_id"],
         c_from,
         c_to,
@@ -383,7 +382,6 @@ async def _rca_analyze(client: QluentClient, config: QluentConfig, args: dict[st
         max_segments=int(args.get("max_segments", 5)),
         min_contribution_share=float(args.get("min_contribution_share", 0.1)),
     )
-    return enrich_rca_output(data, config)
 
 
 async def _elasticity(client: QluentClient, config: QluentConfig, args: dict[str, Any]) -> dict[str, Any]:

--- a/src/qluent_cli/rca.py
+++ b/src/qluent_cli/rca.py
@@ -6,11 +6,12 @@ import click
 
 from qluent_cli.client import QluentClient
 from qluent_cli.client_configs import RcaParams
+from qluent_cli.command_runner import qluent_command
 from qluent_cli.config import load_config
-from qluent_cli.rendering import render, simple_result
+from qluent_cli.rendering import Result, simple_result
 from qluent_cli.formatters import format_root_cause
 from qluent_cli.utils import parse_filters
-from qluent_cli.window_resolver import PeriodResolutionError, resolve_period
+from qluent_cli.window_resolver import resolve_period
 
 
 _DEFAULTS = RcaParams()
@@ -39,7 +40,10 @@ def rca() -> None:
     help="Minimum absolute direct contribution share required to follow a child branch",
 )
 @click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
+@qluent_command
 def analyze(
+    client,
+    config,
     tree_id: str,
     metric: str | None,
     period: str | None,
@@ -51,29 +55,23 @@ def analyze(
     max_branches: int,
     max_segments: int,
     min_contribution_share: float,
+    *,
     as_json: bool,
-) -> None:
+) -> Result:
     """Run deterministic root-cause analysis for a metric tree."""
-    try:
-        rp = resolve_period(
-            period=period,
-            current_range=current_range,
-            compare_range=compare_range,
-        )
-    except PeriodResolutionError as exc:
-        raise click.ClickException(str(exc)) from exc
-    parsed_filters = parse_filters(filters)
+    rp = resolve_period(
+        period=period,
+        current_range=current_range,
+        compare_range=compare_range,
+    )
     params = RcaParams(
         metric=metric,
         segment_by=tuple(segment_by),
-        filters=parsed_filters,
+        filters=parse_filters(filters),
         max_depth=max_depth,
         max_branching=max_branches,
         max_segments=max_segments,
         min_contribution_share=min_contribution_share,
     )
-
-    config = load_config()
-    client = QluentClient(config)
     data = client.root_cause_tree(tree_id, windows=rp.windows, params=params)
-    render(simple_result(data, formatter=format_root_cause), as_json=as_json)
+    return simple_result(data, formatter=format_root_cause)

--- a/src/qluent_cli/rca.py
+++ b/src/qluent_cli/rca.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 import click
 
 from qluent_cli.client import QluentClient
+from qluent_cli.client_configs import RcaParams
 from qluent_cli.config import load_config
 from qluent_cli.rendering import render, simple_result
 from qluent_cli.formatters import format_root_cause
 from qluent_cli.utils import parse_filters
 from qluent_cli.window_resolver import PeriodResolutionError, resolve_period
+
+
+_DEFAULTS = RcaParams()
 
 
 @click.group()
@@ -25,12 +29,12 @@ def rca() -> None:
 @click.option("--compare", "compare_range", default=None, help="Comparison window as YYYY-MM-DD:YYYY-MM-DD")
 @click.option("--segment-by", "segment_by", multiple=True, help="Dimension to consider for segment RCA (repeatable)")
 @click.option("--filter", "filters", multiple=True, help="Filter as dimension=value (repeatable)")
-@click.option("--max-depth", default=3, type=click.IntRange(1, 6), help="Maximum tree depth to traverse")
-@click.option("--max-branches", default=2, type=click.IntRange(1, 10), help="Maximum child branches to follow per node")
-@click.option("--max-segments", default=5, type=click.IntRange(1, 20), help="Maximum segments to show per node")
+@click.option("--max-depth", default=_DEFAULTS.max_depth, type=click.IntRange(1, 6), help="Maximum tree depth to traverse")
+@click.option("--max-branches", default=_DEFAULTS.max_branching, type=click.IntRange(1, 10), help="Maximum child branches to follow per node")
+@click.option("--max-segments", default=_DEFAULTS.max_segments, type=click.IntRange(1, 20), help="Maximum segments to show per node")
 @click.option(
     "--min-contribution-share",
-    default=0.1,
+    default=_DEFAULTS.min_contribution_share,
     type=click.FloatRange(0.0, 1.0),
     help="Minimum absolute direct contribution share required to follow a child branch",
 )
@@ -58,23 +62,18 @@ def analyze(
         )
     except PeriodResolutionError as exc:
         raise click.ClickException(str(exc)) from exc
-    c_from, c_to, p_from, p_to = rp.windows.iso_tuple()
     parsed_filters = parse_filters(filters)
-
-    config = load_config()
-    client = QluentClient(config)
-    data = client.root_cause_tree(
-        tree_id,
-        c_from,
-        c_to,
-        p_from,
-        p_to,
-        segment_by=list(segment_by),
-        filters=parsed_filters,
+    params = RcaParams(
         metric=metric,
+        segment_by=tuple(segment_by),
+        filters=parsed_filters,
         max_depth=max_depth,
         max_branching=max_branches,
         max_segments=max_segments,
         min_contribution_share=min_contribution_share,
     )
+
+    config = load_config()
+    client = QluentClient(config)
+    data = client.root_cause_tree(tree_id, windows=rp.windows, params=params)
     render(simple_result(data, formatter=format_root_cause), as_json=as_json)

--- a/src/qluent_cli/rca.py
+++ b/src/qluent_cli/rca.py
@@ -6,11 +6,11 @@ import click
 
 from qluent_cli.client import QluentClient
 from qluent_cli.config import load_config
-from qluent_cli.dates import resolve_windows
 from qluent_cli.rca_contracts import enrich_rca_output
 from qluent_cli.rendering import render, simple_result
 from qluent_cli.formatters import format_root_cause
 from qluent_cli.utils import parse_filters
+from qluent_cli.window_resolver import PeriodResolutionError, resolve_period
 
 
 @click.group()
@@ -51,9 +51,15 @@ def analyze(
     as_json: bool,
 ) -> None:
     """Run deterministic root-cause analysis for a metric tree."""
-    windows = resolve_windows(period, current_range, compare_range)
-    c_from, c_to = windows.current.iso_from, windows.current.iso_to
-    p_from, p_to = windows.comparison.iso_from, windows.comparison.iso_to
+    try:
+        rp = resolve_period(
+            period=period,
+            current_range=current_range,
+            compare_range=compare_range,
+        )
+    except PeriodResolutionError as exc:
+        raise click.ClickException(str(exc)) from exc
+    c_from, c_to, p_from, p_to = rp.windows.iso_tuple()
     parsed_filters = parse_filters(filters)
 
     config = load_config()

--- a/src/qluent_cli/rca.py
+++ b/src/qluent_cli/rca.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-import json
-
 import click
 
 from qluent_cli.client import QluentClient
 from qluent_cli.config import load_config
 from qluent_cli.dates import resolve_windows
 from qluent_cli.rca_contracts import enrich_rca_output
+from qluent_cli.rendering import render, simple_result
 from qluent_cli.formatters import format_root_cause
 from qluent_cli.utils import parse_filters
 
@@ -74,8 +73,4 @@ def analyze(
         min_contribution_share=min_contribution_share,
     )
     data = enrich_rca_output(data, config)
-
-    if as_json:
-        click.echo(json.dumps(data, indent=2))
-    else:
-        click.echo(format_root_cause(data))
+    render(simple_result(data, formatter=format_root_cause), as_json=as_json)

--- a/src/qluent_cli/rca.py
+++ b/src/qluent_cli/rca.py
@@ -6,7 +6,6 @@ import click
 
 from qluent_cli.client import QluentClient
 from qluent_cli.config import load_config
-from qluent_cli.rca_contracts import enrich_rca_output
 from qluent_cli.rendering import render, simple_result
 from qluent_cli.formatters import format_root_cause
 from qluent_cli.utils import parse_filters
@@ -78,5 +77,4 @@ def analyze(
         max_segments=max_segments,
         min_contribution_share=min_contribution_share,
     )
-    data = enrich_rca_output(data, config)
     render(simple_result(data, formatter=format_root_cause), as_json=as_json)

--- a/src/qluent_cli/rendering.py
+++ b/src/qluent_cli/rendering.py
@@ -1,0 +1,75 @@
+"""Rendering seam for command output.
+
+Every command branches on `--json-output` to emit either a JSON dump or a
+human-formatted string.  Doing this inline at every site means cross-cutting
+concerns (indent style, redaction, stderr routing) are re-applied at each
+command.  This module owns the branch.
+
+Usage:
+
+    from qluent_cli.rendering import Result, render
+
+    result = Result(json_payload=data, human=lambda: format_evaluation(data))
+    render(result, as_json=ctx.obj["as_json"])
+
+Or, when the JSON payload is just the source data:
+
+    result = simple_result(data, formatter=format_evaluation)
+    render(result, as_json=...)
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import click
+
+
+HumanRenderer = str | Callable[[], str]
+
+
+@dataclass(frozen=True)
+class Result:
+    """A rendered command result.
+
+    `json_payload` is what we emit when `--json-output` is set.  `human`
+    is either a pre-formatted string or a zero-arg callable that produces
+    one (lazy: never invoked when JSON output is requested).
+    """
+
+    json_payload: Any
+    human: HumanRenderer
+
+
+def simple_result(data: Any, *, formatter: Callable[[Any], str]) -> Result:
+    """Convenience factory: same `data` for both branches."""
+    return Result(json_payload=data, human=lambda: formatter(data))
+
+
+def render(result: Result, *, as_json: bool | None = None) -> None:
+    """Emit the result on stdout.
+
+    `as_json` may be omitted; when omitted, the renderer reads it from the
+    Click context's `obj["as_json"]`, set by top-level `--json-output`.
+    """
+    if as_json is None:
+        as_json = _as_json_from_context()
+    if as_json:
+        click.echo(json.dumps(result.json_payload, indent=2))
+    else:
+        click.echo(_resolve_human(result.human))
+
+
+def _resolve_human(human: HumanRenderer) -> str:
+    return human() if callable(human) else human
+
+
+def _as_json_from_context() -> bool:
+    ctx = click.get_current_context(silent=True)
+    while ctx is not None:
+        if isinstance(ctx.obj, dict) and "as_json" in ctx.obj:
+            return bool(ctx.obj["as_json"])
+        ctx = ctx.parent
+    return False

--- a/src/qluent_cli/run_manager.py
+++ b/src/qluent_cli/run_manager.py
@@ -1,0 +1,155 @@
+"""RunManager — owns the investigation lifecycle.
+
+Today the investigate flow is split:
+
+    trees.py:investigate
+        -> builds RunReporter
+        -> calls run_investigation (sanitize)
+        -> calls _persist_run_safely
+        -> calls _emit_investigation
+
+    mcp_server.py:_investigate
+        -> calls run_investigation (sanitize)
+
+Both adapters re-implement the same dance.  The deepening: a `RunManager`
+that owns reporter + persistence + sanitization as one unit.  Adapters say
+"investigate this tree under these constraints" and get back a finished,
+persisted result.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+from qluent_cli import sessions
+from qluent_cli.client import QluentClient
+from qluent_cli.client_configs import InvestigationParams
+from qluent_cli.config import QluentConfig
+from qluent_cli.dates import DateWindows
+from qluent_cli.runs import (
+    RunReporter,
+    collect_tree_metadata,
+    sanitize_recommended_next_steps,
+)
+
+
+@dataclass
+class RunResult:
+    """The finished result of an investigation."""
+
+    bundle: dict[str, Any]
+    run_id: str | None
+    from_cache: bool = False
+
+
+class RunManager:
+    """Encapsulates the investigation lifecycle for one or many trees."""
+
+    INVESTIGATE_COMMAND = sessions.INVESTIGATE_COMMAND
+
+    def __init__(
+        self,
+        client: QluentClient,
+        config: QluentConfig,
+        *,
+        persist: bool = True,
+    ) -> None:
+        self._client = client
+        self._config = config
+        self._persist = persist
+
+    def investigate(
+        self,
+        tree_id: str,
+        *,
+        windows: DateWindows,
+        params: InvestigationParams,
+        reporter: RunReporter | None = None,
+        original_args: dict[str, Any] | None = None,
+    ) -> RunResult:
+        """Run a single tree investigation: client call -> sanitize -> persist."""
+        c_from, c_to, p_from, p_to = windows.iso_tuple()
+        trees_data = self._client.list_trees()
+        if reporter is not None:
+            reporter.progress("awaiting_api")
+
+        bundle = self._client.investigate_tree(
+            tree_id,
+            windows=windows,
+            params=params,
+            progress_callback=(
+                (lambda stage, elapsed: reporter.progress(stage, elapsed=elapsed))
+                if reporter is not None
+                else None
+            ),
+        )
+        if reporter is not None:
+            reporter.progress("formatting")
+
+        available_tree_ids, metrics_by_tree = collect_tree_metadata(trees_data)
+        sanitize_recommended_next_steps(
+            bundle,
+            available_tree_ids=available_tree_ids,
+            metrics_by_tree=metrics_by_tree,
+        )
+
+        record = self._maybe_persist(
+            tree_id=tree_id,
+            c_from=c_from,
+            c_to=c_to,
+            p_from=p_from,
+            p_to=p_to,
+            params=params,
+            bundle=bundle,
+            original_args=original_args or {},
+        )
+        return RunResult(
+            bundle=bundle,
+            run_id=record.run_id if record else sessions.generate_run_id(),
+            from_cache=False,
+        )
+
+    def _maybe_persist(
+        self,
+        *,
+        tree_id: str,
+        c_from: str,
+        c_to: str,
+        p_from: str,
+        p_to: str,
+        params: InvestigationParams,
+        bundle: dict[str, Any],
+        original_args: dict[str, Any],
+    ):
+        if not self._persist:
+            return None
+        try:
+            return sessions.record_run(
+                command=self.INVESTIGATE_COMMAND,
+                tree_id=tree_id,
+                period_start=c_from,
+                period_end=c_to,
+                comparison_start=p_from,
+                comparison_end=p_to,
+                profile=f"{self._config.user_email}@{self._config.api_url}",
+                client_safe=self._config.client_safe,
+                args={
+                    "trend_periods": params.trend_periods,
+                    "trend_grain": params.trend_grain,
+                    "trend_as_of": params.trend_as_of,
+                    "segment_by": list(params.segment_by),
+                    "filters": dict(params.filters),
+                    "compare_trees": list(params.compare_trees),
+                    "max_depth": params.max_depth,
+                    "max_branches": params.max_branching,
+                    "max_segments": params.max_segments,
+                    "min_contribution_share": params.min_contribution_share,
+                    **original_args,
+                },
+                payload=bundle,
+            )
+        except Exception as exc:
+            print(f"Warning: failed to persist run: {exc}", file=sys.stderr)
+            return None

--- a/src/qluent_cli/run_manager.py
+++ b/src/qluent_cli/run_manager.py
@@ -107,7 +107,7 @@ class RunManager:
         )
         return RunResult(
             bundle=bundle,
-            run_id=record.run_id if record else sessions.generate_run_id(),
+            run_id=record.run_id if record else None,
             from_cache=False,
         )
 

--- a/src/qluent_cli/trees.py
+++ b/src/qluent_cli/trees.py
@@ -30,8 +30,11 @@ from qluent_cli.formatters import (
     format_tree_list,
     format_tree_validation,
 )
-from qluent_cli.dates import resolve_windows
 from qluent_cli.utils import parse_filters
+from qluent_cli.window_resolver import (
+    PeriodResolutionError,
+    resolve_period,
+)
 
 
 @click.group()
@@ -43,38 +46,29 @@ def _profile_for(config: QluentConfig) -> str:
     return f"{config.user_email}@{config.api_url}"
 
 
-def _resume_or_last(
+def _resolve_period_or_raise(
     *,
     command: str,
-    resume: str | None,
-    use_last: bool,
-    tree_id: str | None,
-) -> sessions.RunRecord | None:
-    """Resolve --resume / --last to a stored run; raises if requested but missing."""
-    if resume and use_last:
-        raise click.ClickException("Use either --resume or --last, not both.")
-    if resume:
-        record = sessions.get_run(resume)
-        if record is None:
-            raise click.ClickException(f"No run found for run_id={resume}")
-        if record.command != command:
-            raise click.ClickException(
-                f"Run {resume} is a {record.command!r} run, not {command!r}."
-            )
-        if tree_id and record.tree_id and record.tree_id != tree_id:
-            raise click.ClickException(
-                f"Run {resume} is for tree {record.tree_id!r}, not {tree_id!r}."
-            )
-        return record
-    if use_last:
-        record = sessions.find_last_run(command=command, tree_id=tree_id)
-        if record is None:
-            target = f" for {tree_id}" if tree_id else ""
-            raise click.ClickException(
-                f"No prior {command!r} run{target} found. Run it once to populate the cache."
-            )
-        return record
-    return None
+    period: str | None = None,
+    current_range: str | None = None,
+    compare_range: str | None = None,
+    resume: str | None = None,
+    use_last: bool = False,
+    tree_id: str | None = None,
+):
+    """Click-flavoured wrapper around `window_resolver.resolve_period`."""
+    try:
+        return resolve_period(
+            period=period,
+            current_range=current_range,
+            compare_range=compare_range,
+            resume=resume,
+            use_last=use_last,
+            command=command,
+            tree_id=tree_id,
+        )
+    except PeriodResolutionError as exc:
+        raise click.ClickException(str(exc)) from exc
 
 
 def _persist_run_safely(**kwargs):
@@ -299,9 +293,13 @@ def evaluate(
     """Evaluate a metric tree over date windows."""
     if as_json and contract_output:
         raise click.ClickException("Use either --json-output or --contract-output, not both.")
-    windows = resolve_windows(period, current_range, compare_range)
-    c_from, c_to = windows.current.iso_from, windows.current.iso_to
-    p_from, p_to = windows.comparison.iso_from, windows.comparison.iso_to
+    rp = _resolve_period_or_raise(
+        command=sessions.INVESTIGATE_COMMAND,
+        period=period,
+        current_range=current_range,
+        compare_range=compare_range,
+    )
+    c_from, c_to, p_from, p_to = rp.windows.iso_tuple()
     config = load_config()
     client = QluentClient(config)
     data = client.evaluate_tree(tree_id, c_from, c_to, p_from, p_to)
@@ -340,9 +338,13 @@ def levers(
     as_json: bool,
 ) -> None:
     """Quantify top lever impacts from tree elasticities."""
-    windows = resolve_windows(period, current_range, compare_range)
-    c_from, c_to = windows.current.iso_from, windows.current.iso_to
-    p_from, p_to = windows.comparison.iso_from, windows.comparison.iso_to
+    rp = _resolve_period_or_raise(
+        command=sessions.INVESTIGATE_COMMAND,
+        period=period,
+        current_range=current_range,
+        compare_range=compare_range,
+    )
+    c_from, c_to, p_from, p_to = rp.windows.iso_tuple()
     client = QluentClient(load_config())
     evaluation = client.evaluate_tree(tree_id, c_from, c_to, p_from, p_to)
     data = _build_lever_analysis(evaluation, top_n=top, scenarios=scenarios)
@@ -383,9 +385,13 @@ def compare(
     as_json: bool,
 ) -> None:
     """Compare multiple metric trees side by side for the same period."""
-    windows = resolve_windows(period, current_range, compare_range)
-    c_from, c_to = windows.current.iso_from, windows.current.iso_to
-    p_from, p_to = windows.comparison.iso_from, windows.comparison.iso_to
+    rp = _resolve_period_or_raise(
+        command=sessions.INVESTIGATE_COMMAND,
+        period=period,
+        current_range=current_range,
+        compare_range=compare_range,
+    )
+    c_from, c_to, p_from, p_to = rp.windows.iso_tuple()
 
     client = QluentClient(load_config())
     results: list[tuple[str, dict[str, Any]]] = []
@@ -447,23 +453,24 @@ def investigate(
     use_last: bool,
 ) -> None:
     """Run a deterministic multi-step investigation bundle for a tree."""
-    cached = _resume_or_last(
+    rp = _resolve_period_or_raise(
         command=sessions.INVESTIGATE_COMMAND,
+        period=period,
+        current_range=current_range,
+        compare_range=compare_range,
         resume=resume,
         use_last=use_last,
         tree_id=tree_id,
     )
-    if cached is not None:
-        bundle = cached.load().get("result") or {}
-        _emit_investigation(bundle, as_json=as_json, run_id=cached.run_id, from_cache=True)
+    if rp.cached_run is not None:
+        bundle = rp.cached_run.load().get("result") or {}
+        _emit_investigation(bundle, as_json=as_json, run_id=rp.cached_run.run_id, from_cache=True)
         return
 
     config = load_config()
     client = QluentClient(config)
     parsed_filters = parse_filters(filters)
-    windows = resolve_windows(period, current_range, compare_range)
-    c_from, c_to = windows.current.iso_from, windows.current.iso_to
-    p_from, p_to = windows.comparison.iso_from, windows.comparison.iso_to
+    c_from, c_to, p_from, p_to = rp.windows.iso_tuple()
     period_label = format_period_label(c_from, c_to, p_from, p_to)
     reporter = RunReporter(
         command="investigate",
@@ -604,22 +611,23 @@ def deep_dive(
     use_last: bool,
 ) -> None:
     """Run investigations across every tree in parallel and bundle the results."""
-    cached = _resume_or_last(
+    rp = _resolve_period_or_raise(
         command=sessions.DEEP_DIVE_COMMAND,
+        period=period,
+        current_range=current_range,
+        compare_range=compare_range,
         resume=resume,
         use_last=use_last,
         tree_id=None,
     )
-    if cached is not None:
-        bundle = cached.load().get("result") or {}
-        _emit_deep_dive(bundle, as_json=as_json, run_id=cached.run_id, from_cache=True)
+    if rp.cached_run is not None:
+        bundle = rp.cached_run.load().get("result") or {}
+        _emit_deep_dive(bundle, as_json=as_json, run_id=rp.cached_run.run_id, from_cache=True)
         return
 
     config = load_config()
     client = QluentClient(config)
-    windows = resolve_windows(period, current_range, compare_range)
-    c_from, c_to = windows.current.iso_from, windows.current.iso_to
-    p_from, p_to = windows.comparison.iso_from, windows.comparison.iso_to
+    c_from, c_to, p_from, p_to = rp.windows.iso_tuple()
 
     trees_data = client.list_trees()
     available = [t.get("id") for t in trees_data.get("trees", []) if t.get("id")]

--- a/src/qluent_cli/trees.py
+++ b/src/qluent_cli/trees.py
@@ -16,6 +16,7 @@ import click
 from qluent_cli import sessions
 from qluent_cli.client import QluentClient
 from qluent_cli.client_configs import InvestigationParams
+from qluent_cli.command_runner import qluent_command
 from qluent_cli.config import QluentConfig, load_config
 from qluent_cli.rendering import Result, render, simple_result
 from qluent_cli.run_manager import RunManager
@@ -250,31 +251,28 @@ def _collect_trend_evaluations(
 
 @trees.command(name="list")
 @click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
-def list_trees(as_json: bool) -> None:
+@qluent_command
+def list_trees(client, config, *, as_json: bool) -> Result:
     """List available metric trees."""
-    client = QluentClient(load_config())
-    data = client.list_trees()
-    render(simple_result(data, formatter=format_tree_list), as_json=as_json)
+    return simple_result(client.list_trees(), formatter=format_tree_list)
 
 
 @trees.command()
 @click.argument("tree_id")
 @click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
-def get(tree_id: str, as_json: bool) -> None:
+@qluent_command
+def get(client, config, tree_id: str, *, as_json: bool) -> Result:
     """Show the structure of a metric tree."""
-    client = QluentClient(load_config())
-    data = client.get_tree(tree_id)
-    render(simple_result(data, formatter=format_tree_detail), as_json=as_json)
+    return simple_result(client.get_tree(tree_id), formatter=format_tree_detail)
 
 
 @trees.command()
 @click.argument("tree_id")
 @click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
-def validate(tree_id: str, as_json: bool) -> None:
+@qluent_command
+def validate(client, config, tree_id: str, *, as_json: bool) -> Result:
     """Validate a saved metric tree against its referenced metric SQL."""
-    client = QluentClient(load_config())
-    data = client.validate_tree(tree_id)
-    render(simple_result(data, formatter=format_tree_validation), as_json=as_json)
+    return simple_result(client.validate_tree(tree_id), formatter=format_tree_validation)
 
 
 @trees.command()

--- a/src/qluent_cli/trees.py
+++ b/src/qluent_cli/trees.py
@@ -15,8 +15,10 @@ import click
 
 from qluent_cli import sessions
 from qluent_cli.client import QluentClient
+from qluent_cli.client_configs import InvestigationParams
 from qluent_cli.config import QluentConfig, load_config
 from qluent_cli.rendering import Result, render, simple_result
+from qluent_cli.run_manager import RunManager
 from qluent_cli.runs import RunReporter, run_investigation
 from qluent_cli.tree_contracts import build_tree_query_contract
 from qluent_cli.formatters import (
@@ -480,67 +482,35 @@ def investigate(
     )
     if stream or not as_json:
         reporter.start()
-    trees_data = client.list_trees()
-    if stream or not as_json:
-        reporter.progress("awaiting_api")
 
-    bundle = run_investigation(
-        client,
-        tree_id=tree_id,
-        current_from=c_from,
-        current_to=c_to,
-        comparison_from=p_from,
-        comparison_to=p_to,
-        trees_data=trees_data,
-        progress_callback=lambda stage, elapsed: reporter.progress(stage, elapsed=elapsed),
-        trend_periods=trend_periods,
-        trend_grain=trend_grain,
-        trend_as_of=trend_as_of,
-        segment_by=list(segment_by),
+    params = InvestigationParams(
+        segment_by=tuple(segment_by),
         filters=parsed_filters,
-        compare_trees=list(compare_trees),
+        compare_trees=tuple(compare_trees),
         max_depth=max_depth,
         max_branching=max_branches,
         max_segments=max_segments,
         min_contribution_share=min_contribution_share,
+        trend_periods=trend_periods,
+        trend_grain=trend_grain,
+        trend_as_of=trend_as_of,
     )
-    if stream or not as_json:
-        reporter.progress("formatting")
-
-    record = _persist_run_safely(
-        command=sessions.INVESTIGATE_COMMAND,
-        tree_id=tree_id,
-        period_start=c_from,
-        period_end=c_to,
-        comparison_start=p_from,
-        comparison_end=p_to,
-        profile=_profile_for(config),
-        client_safe=config.client_safe,
-        args={
-            "period": period,
-            "current": current_range,
-            "compare": compare_range,
-            "trend_periods": trend_periods,
-            "trend_grain": trend_grain,
-            "trend_as_of": trend_as_of,
-            "segment_by": list(segment_by),
-            "filters": parsed_filters,
-            "compare_trees": list(compare_trees),
-            "max_depth": max_depth,
-            "max_branches": max_branches,
-            "max_segments": max_segments,
-            "min_contribution_share": min_contribution_share,
-        },
-        payload=bundle,
+    manager = RunManager(client, config, persist=True)
+    result = manager.investigate(
+        tree_id,
+        windows=rp.windows,
+        params=params,
+        reporter=reporter,
+        original_args={"period": period, "current": current_range, "compare": compare_range},
     )
 
     if stream:
-        reporter.complete(bundle, run_id=record.run_id if record else None)
+        reporter.complete(result.bundle, run_id=result.run_id)
         return
     _emit_investigation(
-        bundle,
+        result.bundle,
         as_json=as_json,
-        run_id=record.run_id if record else None,
+        run_id=result.run_id,
     )
 
 

--- a/src/qluent_cli/trees.py
+++ b/src/qluent_cli/trees.py
@@ -7,7 +7,6 @@ module, and render output.
 
 from __future__ import annotations
 
-import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date as dt_date
 from typing import Any
@@ -17,6 +16,7 @@ import click
 from qluent_cli import sessions
 from qluent_cli.client import QluentClient
 from qluent_cli.config import QluentConfig, load_config
+from qluent_cli.rendering import Result, render, simple_result
 from qluent_cli.runs import RunReporter, run_investigation
 from qluent_cli.tree_contracts import build_tree_query_contract
 from qluent_cli.formatters import (
@@ -258,11 +258,7 @@ def list_trees(as_json: bool) -> None:
     """List available metric trees."""
     client = QluentClient(load_config())
     data = client.list_trees()
-
-    if as_json:
-        click.echo(json.dumps(data, indent=2))
-    else:
-        click.echo(format_tree_list(data))
+    render(simple_result(data, formatter=format_tree_list), as_json=as_json)
 
 
 @trees.command()
@@ -272,11 +268,7 @@ def get(tree_id: str, as_json: bool) -> None:
     """Show the structure of a metric tree."""
     client = QluentClient(load_config())
     data = client.get_tree(tree_id)
-
-    if as_json:
-        click.echo(json.dumps(data, indent=2))
-    else:
-        click.echo(format_tree_detail(data))
+    render(simple_result(data, formatter=format_tree_detail), as_json=as_json)
 
 
 @trees.command()
@@ -286,11 +278,7 @@ def validate(tree_id: str, as_json: bool) -> None:
     """Validate a saved metric tree against its referenced metric SQL."""
     client = QluentClient(load_config())
     data = client.validate_tree(tree_id)
-
-    if as_json:
-        click.echo(json.dumps(data, indent=2))
-    else:
-        click.echo(format_tree_validation(data))
+    render(simple_result(data, formatter=format_tree_validation), as_json=as_json)
 
 
 @trees.command()
@@ -319,11 +307,12 @@ def evaluate(
     data = client.evaluate_tree(tree_id, c_from, c_to, p_from, p_to)
 
     if contract_output:
-        click.echo(json.dumps(build_tree_query_contract(data, config), indent=2))
-    elif as_json:
-        click.echo(json.dumps(data, indent=2))
-    else:
-        click.echo(format_evaluation(data))
+        render(
+            Result(json_payload=build_tree_query_contract(data, config), human=""),
+            as_json=True,
+        )
+        return
+    render(simple_result(data, formatter=format_evaluation), as_json=as_json)
 
 
 @trees.command()
@@ -359,11 +348,7 @@ def levers(
     data = _build_lever_analysis(evaluation, top_n=top, scenarios=scenarios)
     if data is None:
         raise click.ClickException("Could not compute lever analysis from the evaluation result.")
-
-    if as_json:
-        click.echo(json.dumps(data, indent=2))
-    else:
-        click.echo(format_levers(data))
+    render(simple_result(data, formatter=format_levers), as_json=as_json)
 
 
 @trees.command()
@@ -377,11 +362,11 @@ def trend(tree_id: str, periods: int, grain: str, as_of: str | None, as_json: bo
     client = QluentClient(load_config())
     evaluations = _collect_trend_evaluations(client, tree_id, periods, grain, as_of)
 
-    if as_json:
-        click.echo(json.dumps(evaluations, indent=2))
-    else:
-        tree_label = evaluations[0].get("tree_label", tree_id) if evaluations else tree_id
-        click.echo(format_trend(tree_label, evaluations, grain))
+    tree_label = evaluations[0].get("tree_label", tree_id) if evaluations else tree_id
+    render(
+        Result(json_payload=evaluations, human=lambda: format_trend(tree_label, evaluations, grain)),
+        as_json=as_json,
+    )
 
 
 @trees.command()
@@ -408,10 +393,13 @@ def compare(
         data = client.evaluate_tree(tree_id, c_from, c_to, p_from, p_to)
         results.append((data.get("tree_label", tree_id), data))
 
-    if as_json:
-        click.echo(json.dumps([data for _, data in results], indent=2))
-    else:
-        click.echo(format_comparison(results, format_period_label(c_from, c_to, p_from, p_to)))
+    render(
+        Result(
+            json_payload=[data for _, data in results],
+            human=lambda: format_comparison(results, format_period_label(c_from, c_to, p_from, p_to)),
+        ),
+        as_json=as_json,
+    )
 
 
 @trees.command()
@@ -556,13 +544,14 @@ def _emit_investigation(
     run_id: str | None,
     from_cache: bool = False,
 ) -> None:
-    if as_json:
-        click.echo(json.dumps(bundle, indent=2))
-    else:
-        click.echo(format_investigation(bundle))
+    def _human() -> str:
+        text = format_investigation(bundle)
         if run_id:
             tag = "(cached)" if from_cache else "(saved)"
-            click.echo(f"\nrun_id: {run_id} {tag}")
+            text = f"{text}\n\nrun_id: {run_id} {tag}"
+        return text
+
+    render(Result(json_payload=bundle, human=_human), as_json=as_json)
 
 
 @trees.command(name="deep-dive")
@@ -756,31 +745,30 @@ def _emit_deep_dive(
     run_id: str | None,
     from_cache: bool = False,
 ) -> None:
-    if as_json:
-        click.echo(json.dumps(bundle, indent=2))
-        return
+    def _human() -> str:
+        period = bundle.get("period") or {}
+        targets = bundle.get("trees_requested") or list((bundle.get("trees") or {}).keys())
+        ordered_results = bundle.get("trees") or {}
+        errors = bundle.get("errors") or {}
+        period_label = format_period_label(
+            period.get("current_from") or "",
+            period.get("current_to") or "",
+            period.get("comparison_from") or "",
+            period.get("comparison_to") or "",
+        )
+        lines = [f"Deep-dive across {len(targets)} tree(s) — {period_label}", ""]
+        for tid in targets:
+            lines.append("=" * 72)
+            lines.append(f"Tree: {tid}")
+            lines.append("=" * 72)
+            if tid in ordered_results:
+                lines.append(format_investigation(ordered_results[tid]))
+            else:
+                lines.append(f"  Failed: {errors.get(tid, 'unknown error')}")
+            lines.append("")
+        if run_id:
+            tag = "(cached)" if from_cache else "(saved)"
+            lines.append(f"run_id: {run_id} {tag}")
+        return "\n".join(lines)
 
-    period = bundle.get("period") or {}
-    targets = bundle.get("trees_requested") or list((bundle.get("trees") or {}).keys())
-    ordered_results = bundle.get("trees") or {}
-    errors = bundle.get("errors") or {}
-    period_label = format_period_label(
-        period.get("current_from") or "",
-        period.get("current_to") or "",
-        period.get("comparison_from") or "",
-        period.get("comparison_to") or "",
-    )
-    click.echo(f"Deep-dive across {len(targets)} tree(s) — {period_label}")
-    click.echo("")
-    for tid in targets:
-        click.echo("=" * 72)
-        click.echo(f"Tree: {tid}")
-        click.echo("=" * 72)
-        if tid in ordered_results:
-            click.echo(format_investigation(ordered_results[tid]))
-        else:
-            click.echo(f"  Failed: {errors.get(tid, 'unknown error')}")
-        click.echo("")
-    if run_id:
-        tag = "(cached)" if from_cache else "(saved)"
-        click.echo(f"run_id: {run_id} {tag}")
+    render(Result(json_payload=bundle, human=_human), as_json=as_json)

--- a/src/qluent_cli/window_resolver.py
+++ b/src/qluent_cli/window_resolver.py
@@ -1,0 +1,124 @@
+"""Framework-neutral period/window resolution.
+
+The CLI (`trees`, `rca`, `elasticity`) and the MCP server both need to turn
+a mix of `--period`, `--current`/`--compare`, `--resume`, and `--last` into
+a `DateWindows` plus an optional cached run.  Putting the lifecycle here
+keeps the logic in one place; adapters map any `PeriodResolutionError` to
+their own error shape (Click raises `ClickException`; MCP returns an error
+envelope).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date as _date
+from typing import Any
+
+from qluent_cli import sessions
+from qluent_cli.dates import DateWindows, infer_windows, resolve_windows
+
+
+class PeriodResolutionError(Exception):
+    """Raised by `resolve_period` for any user-facing resolution failure."""
+
+
+@dataclass
+class ResolvedPeriod:
+    """The result of resolving a period.
+
+    `windows` is always populated.  `cached_run` is set only when `resume`
+    or `use_last` produced a hit; callers may choose to short-circuit and
+    re-emit the cached payload instead of re-running.
+    """
+
+    windows: DateWindows
+    cached_run: sessions.RunRecord | None = None
+
+
+def resolve_period(
+    *,
+    period: str | None = None,
+    current_range: str | None = None,
+    compare_range: str | None = None,
+    resume: str | None = None,
+    use_last: bool = False,
+    command: str | None = None,
+    tree_id: str | None = None,
+    today: _date | None = None,
+) -> ResolvedPeriod:
+    """Single entry point for window resolution across CLI and MCP."""
+    if resume and use_last:
+        raise PeriodResolutionError("Use either --resume or --last, not both.")
+    if resume:
+        record = _lookup_resume(resume, command=command, tree_id=tree_id)
+        return ResolvedPeriod(windows=_windows_from_record(record), cached_run=record)
+    if use_last:
+        record = _lookup_last(command=command, tree_id=tree_id)
+        return ResolvedPeriod(windows=_windows_from_record(record), cached_run=record)
+
+    return ResolvedPeriod(
+        windows=_resolve_windows_with_today(period, current_range, compare_range, today),
+    )
+
+
+def _lookup_resume(
+    run_id: str, *, command: str | None, tree_id: str | None
+) -> sessions.RunRecord:
+    record = sessions.get_run(run_id)
+    if record is None:
+        raise PeriodResolutionError(f"No run found for run_id={run_id}")
+    if command and record.command != command:
+        raise PeriodResolutionError(
+            f"Run {run_id} is a {record.command!r} run, not {command!r}."
+        )
+    if tree_id and record.tree_id and record.tree_id != tree_id:
+        raise PeriodResolutionError(
+            f"Run {run_id} is for tree {record.tree_id!r}, not {tree_id!r}."
+        )
+    return record
+
+
+def _lookup_last(*, command: str | None, tree_id: str | None) -> sessions.RunRecord:
+    record = sessions.find_last_run(command=command, tree_id=tree_id)
+    if record is None:
+        target = f" for {tree_id}" if tree_id else ""
+        cmd = command or "investigate"
+        raise PeriodResolutionError(
+            f"No prior {cmd!r} run{target} found. Run it once to populate the cache."
+        )
+    return record
+
+
+def _windows_from_record(record: sessions.RunRecord) -> DateWindows:
+    """Reconstruct a `DateWindows` from a stored run."""
+    payload: dict[str, Any] = record.load() if record.path.exists() else {}
+    args = (payload.get("args") or {}) if isinstance(payload, dict) else {}
+    explicit_current = args.get("current") if isinstance(args, dict) else None
+    explicit_compare = args.get("compare") if isinstance(args, dict) else None
+    explicit_period = args.get("period") if isinstance(args, dict) else None
+
+    if record.period_start and record.period_end and record.comparison_start and record.comparison_end:
+        return resolve_windows(
+            None,
+            f"{record.period_start}:{record.period_end}",
+            f"{record.comparison_start}:{record.comparison_end}",
+        )
+    if explicit_current and explicit_compare:
+        return resolve_windows(None, explicit_current, explicit_compare)
+    return infer_windows(explicit_period or "last 7 days")
+
+
+def _resolve_windows_with_today(
+    period: str | None,
+    current_range: str | None,
+    compare_range: str | None,
+    today: _date | None,
+) -> DateWindows:
+    """Same as `dates.resolve_windows`, but accepts a frozen `today` for tests."""
+    if today is None:
+        return resolve_windows(period, current_range, compare_range)
+    if current_range and compare_range:
+        return resolve_windows(period, current_range, compare_range)
+    if current_range:
+        return resolve_windows(period, current_range, compare_range)
+    return infer_windows(period or "last 7 days", today=today)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -127,7 +127,7 @@ def test_root_cause_tree_sends_metric_when_provided(monkeypatch):
         )
     )
 
-    result = client.root_cause_tree(
+    result = client._root_cause_raw(
         "revenue",
         "2026-03-09",
         "2026-03-15",

--- a/tests/test_client_configs.py
+++ b/tests/test_client_configs.py
@@ -1,0 +1,130 @@
+"""Tests for client request configs (issue #79).
+
+Today the client takes long kwargs lists; defaults live in three places
+(Click options, MCP schemas, client method signatures).  The deepening:
+domain-shaped dataclasses own defaults; callers pass `params`, not 12 kwargs.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from qluent_cli.client import QluentClient
+from qluent_cli.client_configs import InvestigationParams, RcaParams
+from qluent_cli.config import QluentConfig
+from qluent_cli.dates import DateWindow, DateWindows
+
+
+def _config() -> QluentConfig:
+    return QluentConfig(
+        api_key="qk_test",
+        api_url="https://api.example.com",
+        project_uuid="project-123",
+        user_email="user@example.com",
+    )
+
+
+def _windows() -> DateWindows:
+    from datetime import date
+
+    return DateWindows(
+        current=DateWindow(date(2026, 3, 9), date(2026, 3, 15)),
+        comparison=DateWindow(date(2026, 3, 2), date(2026, 3, 8)),
+    )
+
+
+def _client_with_capture():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["json"] = httpx.Response(200, content=request.content).json()
+        return httpx.Response(200, json={"warnings": [], "findings": []})
+
+    client = QluentClient(_config())
+    client._client = httpx.Client(
+        headers={"X-API-Key": "qk_test"},
+        timeout=120.0,
+        transport=httpx.MockTransport(handler),
+    )
+    return client, captured
+
+
+def test_rca_params_defaults_are_canonical():
+    p = RcaParams()
+    assert p.max_depth == 3
+    assert p.max_branching == 2
+    assert p.max_segments == 5
+    assert p.min_contribution_share == 0.1
+    assert p.segment_by == ()
+    assert p.filters == {}
+    assert p.metric is None
+
+
+def test_rca_params_overrides_apply():
+    p = RcaParams(max_depth=4, segment_by=("region",), filters={"country": ["SE"]})
+    assert p.max_depth == 4
+    assert p.segment_by == ("region",)
+    assert p.filters == {"country": ["SE"]}
+    # untouched fields keep defaults
+    assert p.max_branching == 2
+
+
+def test_investigation_params_extends_rca_params():
+    p = InvestigationParams(max_depth=4, trend_periods=8, trend_grain="month")
+    assert p.max_depth == 4
+    assert p.trend_periods == 8
+    assert p.trend_grain == "month"
+    # Defaults
+    assert p.compare_trees == ()
+
+
+def test_root_cause_tree_accepts_rca_params():
+    client, captured = _client_with_capture()
+    client.root_cause_tree(
+        "revenue",
+        windows=_windows(),
+        params=RcaParams(
+            max_depth=4,
+            max_branching=3,
+            segment_by=("region",),
+            filters={"country": ["SE"]},
+        ),
+    )
+    body = captured["json"]
+    assert body["current_window"] == {"date_from": "2026-03-09", "date_to": "2026-03-15"}
+    assert body["comparison_window"] == {"date_from": "2026-03-02", "date_to": "2026-03-08"}
+    assert body["max_depth"] == 4
+    assert body["max_branching"] == 3
+    assert body["segment_by"] == ["region"]
+    assert body["filters"] == {"country": ["SE"]}
+
+
+def test_root_cause_tree_default_params_send_canonical_defaults():
+    """Calling without params must still send the documented defaults."""
+    client, captured = _client_with_capture()
+    client.root_cause_tree("revenue", windows=_windows())
+    body = captured["json"]
+    assert body["max_depth"] == 3
+    assert body["max_branching"] == 2
+    assert body["max_segments"] == 5
+    assert body["min_contribution_share"] == 0.1
+
+
+def test_investigate_tree_accepts_investigation_params():
+    client, captured = _client_with_capture()
+    client.investigate_tree(
+        "revenue",
+        windows=_windows(),
+        params=InvestigationParams(
+            trend_periods=12,
+            trend_grain="month",
+            compare_trees=("growth",),
+            max_depth=4,
+        ),
+    )
+    body = captured["json"]
+    assert body["trend_periods"] == 12
+    assert body["trend_grain"] == "month"
+    assert body["compare_trees"] == ["growth"]
+    assert body["max_depth"] == 4

--- a/tests/test_client_contracts.py
+++ b/tests/test_client_contracts.py
@@ -1,0 +1,125 @@
+"""Tests for client-boundary contract enrichment.
+
+The deepening goal (issue #80): `client.root_cause_tree(...)` must return an
+enriched RCA contract by construction, not raw API data.  Callers cannot
+forget to enrich because the client owns the contract.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from qluent_cli.client import QluentClient
+from qluent_cli.config import QluentConfig
+from qluent_cli.rca_contracts import RCA_SCHEMA_VERSION
+
+
+def _client_with_mock_transport(handler) -> QluentClient:
+    config = QluentConfig(
+        api_key="qk_test",
+        api_url="https://api.example.com",
+        project_uuid="project-123",
+        user_email="user@example.com",
+    )
+    client = QluentClient(config)
+    client._client = httpx.Client(
+        headers={"X-API-Key": "qk_test"},
+        timeout=120.0,
+        transport=httpx.MockTransport(handler),
+    )
+    return client
+
+
+def _raw_rca_response() -> dict:
+    return {
+        "tree_label": "Revenue",
+        "tree_id": "revenue",
+        "root_node_id": "revenue",
+        "current_window": {"date_from": "2026-03-09", "date_to": "2026-03-15"},
+        "comparison_window": {"date_from": "2026-03-02", "date_to": "2026-03-08"},
+        "current_value": 900,
+        "comparison_value": 1000,
+        "delta_value": -100,
+        "delta_ratio": -0.1,
+        "findings": [
+            {
+                "node_id": "orders",
+                "label": "Orders",
+                "depth": 1,
+                "path": ["revenue", "orders"],
+                "current_value": 100,
+                "comparison_value": 80,
+                "delta_value": 20,
+                "delta_ratio": 0.25,
+                "contribution_value": 35,
+                "contribution_share": 0.5,
+            }
+        ],
+        "warnings": [],
+    }
+
+
+def test_root_cause_tree_returns_enriched_contract():
+    """The public method must add schema_version, provenance, and
+    materiality fields — callers cannot forget."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_raw_rca_response())
+
+    client = _client_with_mock_transport(handler)
+    result = client.root_cause_tree(
+        "revenue",
+        "2026-03-09",
+        "2026-03-15",
+        "2026-03-02",
+        "2026-03-08",
+    )
+
+    assert result["schema_version"] == RCA_SCHEMA_VERSION
+    assert result["contract_kind"] == "deterministic_rca"
+    assert result["deterministic"] is True
+    assert result["provenance"]["source"] == "metric_tree_root_cause"
+    assert result["provenance"]["project_uuid"] == "project-123"
+    # findings get materiality stamped on
+    assert result["findings"][0]["share_of_parent_delta"] == 0.5
+
+
+def test_root_cause_tree_enrichment_uses_clients_own_config():
+    """Enrichment pulls project_uuid from the client, not from a caller."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_raw_rca_response())
+
+    client = _client_with_mock_transport(handler)
+    result = client.root_cause_tree(
+        "revenue",
+        "2026-03-09",
+        "2026-03-15",
+        "2026-03-02",
+        "2026-03-08",
+    )
+    assert result["provenance"]["project_uuid"] == "project-123"
+    assert result["provenance"]["tree_id"] == "revenue"
+
+
+def test_root_cause_tree_enrichment_does_not_double_apply():
+    """If the upstream API ever returns a partially-enriched payload, the
+    client should land at a coherent enriched shape, not stack twice."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = _raw_rca_response()
+        payload["schema_version"] = "qluent.rca.v1"
+        return httpx.Response(200, json=payload)
+
+    client = _client_with_mock_transport(handler)
+    result = client.root_cause_tree(
+        "revenue",
+        "2026-03-09",
+        "2026-03-15",
+        "2026-03-02",
+        "2026-03-08",
+    )
+    assert result["schema_version"] == "qluent.rca.v1"
+    # Provenance still set exactly once.
+    assert isinstance(result["provenance"], dict)

--- a/tests/test_command_runner.py
+++ b/tests/test_command_runner.py
@@ -1,0 +1,130 @@
+"""Tests for the command-runner decorator (issue #81).
+
+After the prior deepenings (rendering, window resolver, client configs,
+RunManager), every Click command still has the same skeleton:
+
+    config = load_config()
+    client = QluentClient(config)
+    try:
+        ... business logic returning a Result ...
+    except PeriodResolutionError as exc:
+        raise click.ClickException(str(exc))
+    render(result, as_json=as_json)
+
+The capstone collapses that skeleton into a decorator.  Business code
+returns a `Result`; the decorator handles config/client injection,
+error mapping, and rendering.
+"""
+
+from __future__ import annotations
+
+import json
+
+import click
+from click.testing import CliRunner
+
+from qluent_cli.command_runner import qluent_command
+from qluent_cli.config import QluentConfig
+from qluent_cli.rendering import Result, simple_result
+from qluent_cli.window_resolver import PeriodResolutionError
+
+
+def _stub_config(monkeypatch):
+    monkeypatch.setattr(
+        "qluent_cli.command_runner.load_config",
+        lambda: QluentConfig(
+            api_key="qk_test",
+            api_url="https://api.example.com",
+            project_uuid="project-123",
+            user_email="user@example.com",
+        ),
+    )
+
+
+class _FakeClient:
+    def __init__(self, config) -> None:
+        self.config = config
+
+    def list_trees(self) -> dict:
+        return {"trees": [{"id": "growth"}]}
+
+
+def _stub_client(monkeypatch):
+    monkeypatch.setattr("qluent_cli.command_runner.QluentClient", _FakeClient)
+
+
+def test_qluent_command_injects_client_and_config_and_renders(monkeypatch):
+    _stub_config(monkeypatch)
+    _stub_client(monkeypatch)
+
+    @click.command()
+    @click.option("--json-output", "as_json", is_flag=True)
+    @qluent_command
+    def my_cmd(client, config, *, as_json):
+        assert isinstance(config, QluentConfig)
+        return simple_result(client.list_trees(), formatter=lambda d: f"trees: {len(d['trees'])}")
+
+    out = CliRunner().invoke(my_cmd, []).output.strip()
+    assert out == "trees: 1"
+
+
+def test_qluent_command_emits_json_when_flag_set(monkeypatch):
+    _stub_config(monkeypatch)
+    _stub_client(monkeypatch)
+
+    @click.command()
+    @click.option("--json-output", "as_json", is_flag=True)
+    @qluent_command
+    def my_cmd(client, config, *, as_json):
+        return Result(json_payload={"ok": True}, human="HUMAN")
+
+    out = CliRunner().invoke(my_cmd, ["--json-output"]).output
+    assert json.loads(out) == {"ok": True}
+
+
+def test_qluent_command_maps_period_resolution_error_to_click_exception(monkeypatch):
+    _stub_config(monkeypatch)
+    _stub_client(monkeypatch)
+
+    @click.command()
+    @click.option("--json-output", "as_json", is_flag=True)
+    @qluent_command
+    def my_cmd(client, config, *, as_json):
+        raise PeriodResolutionError("Run XXX is for tree 'growth', not 'revenue'.")
+
+    result = CliRunner().invoke(my_cmd, [])
+    assert result.exit_code != 0
+    assert "Run XXX is for tree 'growth'" in result.output
+
+
+def test_qluent_command_passes_through_user_click_options(monkeypatch):
+    """User-defined Click options must still flow through unchanged."""
+    _stub_config(monkeypatch)
+    _stub_client(monkeypatch)
+
+    @click.command()
+    @click.argument("tree_id")
+    @click.option("--json-output", "as_json", is_flag=True)
+    @qluent_command
+    def my_cmd(client, config, tree_id, *, as_json):
+        return simple_result({"tree": tree_id}, formatter=lambda d: f"tree={d['tree']}")
+
+    out = CliRunner().invoke(my_cmd, ["growth"]).output.strip()
+    assert out == "tree=growth"
+
+
+def test_qluent_command_returning_none_emits_nothing(monkeypatch):
+    """Some commands (e.g. `qluent login`) handle their own output and
+    don't return a Result.  The decorator must not crash on `None`."""
+    _stub_config(monkeypatch)
+    _stub_client(monkeypatch)
+
+    @click.command()
+    @click.option("--json-output", "as_json", is_flag=True)
+    @qluent_command
+    def my_cmd(client, config, *, as_json):
+        click.echo("custom output")
+        return None
+
+    out = CliRunner().invoke(my_cmd, []).output.strip()
+    assert out == "custom output"

--- a/tests/test_elasticity.py
+++ b/tests/test_elasticity.py
@@ -17,16 +17,25 @@ class _StubClient:
     def elasticity_tree(
         self,
         tree_id,
-        current_from,
-        current_to,
-        comparison_from,
-        comparison_to,
+        current_from=None,
+        current_to=None,
+        comparison_from=None,
+        comparison_to=None,
         *,
-        outcome,
-        lever,
-        dimension,
-        filters,
+        windows=None,
+        params=None,
+        outcome=None,
+        lever=None,
+        dimension=None,
+        filters=None,
     ):
+        if windows is not None:
+            current_from, current_to, comparison_from, comparison_to = windows.iso_tuple()
+        if params is not None:
+            outcome = outcome or params.outcome
+            lever = lever or params.lever
+            dimension = dimension if dimension is not None else params.dimension
+            filters = filters if filters is not None else dict(params.filters)
         self.captured = {
             "tree_id": tree_id,
             "current_from": current_from,
@@ -127,16 +136,25 @@ def test_elasticity_command_outputs_agent_ready_json(monkeypatch):
     def mock_elasticity_tree(
         self,
         tree_id,
-        current_from,
-        current_to,
-        comparison_from,
-        comparison_to,
+        current_from=None,
+        current_to=None,
+        comparison_from=None,
+        comparison_to=None,
         *,
-        outcome,
-        lever,
-        dimension,
-        filters,
+        windows=None,
+        params=None,
+        outcome=None,
+        lever=None,
+        dimension=None,
+        filters=None,
     ):
+        if windows is not None:
+            current_from, current_to, comparison_from, comparison_to = windows.iso_tuple()
+        if params is not None:
+            outcome = outcome or params.outcome
+            lever = lever or params.lever
+            dimension = dimension if dimension is not None else params.dimension
+            filters = filters if filters is not None else dict(params.filters)
         assert tree_id == "revenue"
         assert outcome == "net_revenue"
         assert lever == "voucher_cost"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -78,10 +78,26 @@ class FakeClient:
         }
 
     def root_cause_tree(self, tree_id, c_from, c_to, p_from, p_to, **kwargs):
+        # Mirrors the production client: enrichment is part of the
+        # `root_cause_tree` contract, not a post-processing step.
+        from qluent_cli.rca_contracts import enrich_rca_output
+
         self.calls.append(
             ("root_cause_tree", (tree_id, c_from, c_to, p_from, p_to), kwargs)
         )
-        return {"tree_id": tree_id, "nodes": []}
+        raw = {
+            "tree_id": tree_id,
+            "root_node_id": tree_id,
+            "current_window": {"date_from": c_from, "date_to": c_to},
+            "comparison_window": {"date_from": p_from, "date_to": p_to},
+            "current_value": 100,
+            "comparison_value": 90,
+            "delta_value": 10,
+            "delta_ratio": 0.111,
+            "findings": [],
+            "warnings": [],
+        }
+        return enrich_rca_output(raw, CONFIG)
 
     def elasticity_tree(self, tree_id, c_from, c_to, p_from, p_to, **kwargs):
         self.calls.append(
@@ -267,6 +283,23 @@ def test_dispatch_rca_analyze_forwards_metric():
     )
     kwargs = client.calls[0][2]
     assert kwargs["metric"] == "orders"
+
+
+def test_dispatch_rca_analyze_returns_enriched_contract():
+    """MCP must surface the enriched RCA contract, just like the CLI does.
+    Provenance/schema_version cannot be skipped at the dispatch layer."""
+    client = FakeClient()
+    result = asyncio.run(
+        dispatch_tool(
+            "qluent_rca_analyze",
+            {"tree_id": "revenue", "period": "last 7 days"},
+            client=client,
+            config=CONFIG,
+        )
+    )
+    assert result["schema_version"] == "qluent.rca.v1"
+    assert result["contract_kind"] == "deterministic_rca"
+    assert result["provenance"]["project_uuid"] == "project-123"
 
 
 def test_dispatch_elasticity_attaches_provenance():

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -55,13 +55,17 @@ class FakeClient:
         self.calls.append(("get_tree", (tree_id,), {}))
         return {"id": tree_id, "nodes": []}
 
-    def evaluate_tree(self, tree_id, c_from, c_to, p_from, p_to):
+    def evaluate_tree(self, tree_id, c_from=None, c_to=None, p_from=None, p_to=None, *, windows=None):
+        if windows is not None:
+            c_from, c_to, p_from, p_to = windows.iso_tuple()
         self.calls.append(
             ("evaluate_tree", (tree_id, c_from, c_to, p_from, p_to), {})
         )
         return {"tree_id": tree_id, "current_value": 100.0, "comparison_value": 90.0}
 
-    def investigate_tree(self, tree_id, c_from, c_to, p_from, p_to, **kwargs):
+    def investigate_tree(self, tree_id, c_from=None, c_to=None, p_from=None, p_to=None, **kwargs):
+        if kwargs.get("windows") is not None:
+            c_from, c_to, p_from, p_to = kwargs["windows"].iso_tuple()
         self.calls.append(
             ("investigate_tree", (tree_id, c_from, c_to, p_from, p_to), kwargs)
         )
@@ -77,11 +81,13 @@ class FakeClient:
             },
         }
 
-    def root_cause_tree(self, tree_id, c_from, c_to, p_from, p_to, **kwargs):
+    def root_cause_tree(self, tree_id, c_from=None, c_to=None, p_from=None, p_to=None, **kwargs):
         # Mirrors the production client: enrichment is part of the
         # `root_cause_tree` contract, not a post-processing step.
         from qluent_cli.rca_contracts import enrich_rca_output
 
+        if kwargs.get("windows") is not None:
+            c_from, c_to, p_from, p_to = kwargs["windows"].iso_tuple()
         self.calls.append(
             ("root_cause_tree", (tree_id, c_from, c_to, p_from, p_to), kwargs)
         )
@@ -99,7 +105,9 @@ class FakeClient:
         }
         return enrich_rca_output(raw, CONFIG)
 
-    def elasticity_tree(self, tree_id, c_from, c_to, p_from, p_to, **kwargs):
+    def elasticity_tree(self, tree_id, c_from=None, c_to=None, p_from=None, p_to=None, **kwargs):
+        if kwargs.get("windows") is not None:
+            c_from, c_to, p_from, p_to = kwargs["windows"].iso_tuple()
         self.calls.append(
             ("elasticity_tree", (tree_id, c_from, c_to, p_from, p_to), kwargs)
         )
@@ -282,7 +290,8 @@ def test_dispatch_rca_analyze_forwards_metric():
         )
     )
     kwargs = client.calls[0][2]
-    assert kwargs["metric"] == "orders"
+    # metric now travels inside the typed params object.
+    assert kwargs["params"].metric == "orders"
 
 
 def test_dispatch_rca_analyze_returns_enriched_contract():

--- a/tests/test_rca.py
+++ b/tests/test_rca.py
@@ -225,7 +225,7 @@ def test_rca_analyze_formats_root_cause_output(monkeypatch):
             "warnings": [],
         }
 
-    monkeypatch.setattr("qluent_cli.rca.QluentClient.root_cause_tree", mock_root_cause_tree)
+    monkeypatch.setattr("qluent_cli.rca.QluentClient._root_cause_raw", mock_root_cause_tree)
 
     result = CliRunner().invoke(
         cli,
@@ -335,7 +335,7 @@ def test_rca_json_output_enriches_materiality_and_provenance(monkeypatch):
             "warnings": [],
         }
 
-    monkeypatch.setattr("qluent_cli.rca.QluentClient.root_cause_tree", mock_root_cause_tree)
+    monkeypatch.setattr("qluent_cli.rca.QluentClient._root_cause_raw", mock_root_cause_tree)
 
     result = CliRunner().invoke(
         cli,

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -1,0 +1,150 @@
+"""Tests for the rendering seam.
+
+The rendering seam is a single place where every command decides between
+JSON output (`--json-output`) and human-formatted output. Today every command
+duplicates this branch (see issue #76).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+import click
+
+from qluent_cli.rendering import Result, render
+
+
+def test_render_emits_json_when_as_json_true():
+    runner = CliRunner()
+
+    @click.command()
+    def cmd() -> None:
+        render(Result(json_payload={"hello": "world"}, human="HELLO"), as_json=True)
+
+    out = runner.invoke(cmd).output
+    assert json.loads(out) == {"hello": "world"}
+
+
+def test_render_emits_human_when_as_json_false():
+    runner = CliRunner()
+
+    @click.command()
+    def cmd() -> None:
+        render(Result(json_payload={"hello": "world"}, human="HELLO HUMAN"), as_json=False)
+
+    assert runner.invoke(cmd).output.strip() == "HELLO HUMAN"
+
+
+def test_render_supports_distinct_json_and_human_payloads():
+    """`compare` builds JSON from one shape and human from another."""
+    runner = CliRunner()
+    json_payload = [{"tree": "a"}, {"tree": "b"}]
+    human_text = "compare table"
+
+    @click.command()
+    def cmd_json() -> None:
+        render(Result(json_payload=json_payload, human=human_text), as_json=True)
+
+    @click.command()
+    def cmd_human() -> None:
+        render(Result(json_payload=json_payload, human=human_text), as_json=False)
+
+    assert json.loads(runner.invoke(cmd_json).output) == json_payload
+    assert runner.invoke(cmd_human).output.strip() == "compare table"
+
+
+def test_render_lazy_human_is_only_called_when_needed():
+    """Avoid running the human formatter when JSON output is requested."""
+    runner = CliRunner()
+    calls: list[int] = []
+
+    def expensive_formatter() -> str:
+        calls.append(1)
+        return "expensive"
+
+    @click.command()
+    def cmd() -> None:
+        render(Result(json_payload={"k": 1}, human=expensive_formatter), as_json=True)
+
+    runner.invoke(cmd)
+    assert calls == []  # not invoked on JSON path
+
+
+def test_render_lazy_human_is_called_when_human_requested():
+    runner = CliRunner()
+    calls: list[int] = []
+
+    def formatter() -> str:
+        calls.append(1)
+        return "human"
+
+    @click.command()
+    def cmd() -> None:
+        render(Result(json_payload={"k": 1}, human=formatter), as_json=False)
+
+    out = runner.invoke(cmd).output.strip()
+    assert out == "human"
+    assert calls == [1]
+
+
+def test_render_json_uses_two_space_indent():
+    """The legacy call sites all used `json.dumps(..., indent=2)` so output
+    diffs in scripts pinned to that shape stay quiet."""
+    runner = CliRunner()
+
+    @click.command()
+    def cmd() -> None:
+        render(Result(json_payload={"a": {"b": 1}}, human="x"), as_json=True)
+
+    out = runner.invoke(cmd).output
+    assert out == json.dumps({"a": {"b": 1}}, indent=2) + "\n"
+
+
+def test_render_handles_list_json_payload():
+    runner = CliRunner()
+
+    @click.command()
+    def cmd() -> None:
+        render(Result(json_payload=[1, 2, 3], human="list"), as_json=True)
+
+    assert json.loads(runner.invoke(cmd).output) == [1, 2, 3]
+
+
+def test_result_factory_for_simple_case():
+    """Common case: same data, single formatter.  Avoid making callers
+    construct `Result` by hand for the trivial mapping."""
+    from qluent_cli.rendering import simple_result
+
+    data = {"x": 1}
+    result = simple_result(data, formatter=lambda d: f"X is {d['x']}")
+    assert result.json_payload == data
+    # Human payload may be a callable; render() must accept it.
+    runner = CliRunner()
+
+    @click.command()
+    def cmd() -> None:
+        render(result, as_json=False)
+
+    assert runner.invoke(cmd).output.strip() == "X is 1"
+
+
+def test_render_reads_as_json_from_click_context_if_not_passed():
+    """Sugar: when commands don't explicitly pass `as_json`, the renderer
+    reads it from the Click context (set by the top-level `--json-output`)."""
+    runner = CliRunner()
+
+    @click.command()
+    @click.option("--json-output", "as_json", is_flag=True)
+    @click.pass_context
+    def cmd(ctx: click.Context, as_json: bool) -> None:
+        ctx.ensure_object(dict)
+        ctx.obj["as_json"] = as_json
+        render(Result(json_payload={"k": 1}, human="human"))  # no as_json kwarg
+
+    out = runner.invoke(cmd, ["--json-output"]).output
+    assert json.loads(out) == {"k": 1}
+    out2 = runner.invoke(cmd, []).output
+    assert out2.strip() == "human"

--- a/tests/test_run_manager.py
+++ b/tests/test_run_manager.py
@@ -54,7 +54,7 @@ class _FakeClient:
         return dict(self.bundle)
 
 
-def test_run_manager_investigate_returns_bundle_with_run_id():
+def test_run_manager_investigate_returns_bundle_without_run_id_when_not_persisted():
     client = _FakeClient()
     manager = RunManager(client, _config(), persist=False)
 
@@ -65,7 +65,7 @@ def test_run_manager_investigate_returns_bundle_with_run_id():
     )
 
     assert isinstance(result, RunResult)
-    assert result.run_id is not None
+    assert result.run_id is None
     assert result.bundle["tree_id"] == "growth"
     assert result.from_cache is False
 
@@ -161,6 +161,7 @@ def test_run_manager_continues_when_persist_fails(monkeypatch, capsys):
 
     # bundle still flows through
     assert result.bundle["tree_id"] == "growth"
+    assert result.run_id is None
     err = capsys.readouterr().err
     assert "failed to persist run" in err.lower()
 

--- a/tests/test_run_manager.py
+++ b/tests/test_run_manager.py
@@ -1,0 +1,181 @@
+"""Tests for the RunManager (issue #77).
+
+The investigation flow today is split across `trees.py` (Click command),
+`runs.py` (RunReporter + run_investigation), and `sessions.py` (persistence).
+RunManager owns the lifecycle so adapters say "investigate this tree" and
+get back a finished, persisted result.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+import pytest
+
+from qluent_cli.client_configs import InvestigationParams
+from qluent_cli.config import QluentConfig
+from qluent_cli.dates import DateWindow, DateWindows
+from qluent_cli.run_manager import RunManager, RunResult
+
+
+def _config() -> QluentConfig:
+    return QluentConfig(
+        api_key="qk_test",
+        api_url="https://api.example.com",
+        project_uuid="project-123",
+        user_email="user@example.com",
+    )
+
+
+def _windows() -> DateWindows:
+    return DateWindows(
+        current=DateWindow(date(2026, 3, 9), date(2026, 3, 15)),
+        comparison=DateWindow(date(2026, 3, 2), date(2026, 3, 8)),
+    )
+
+
+class _FakeClient:
+    """Minimal client double satisfying RunManager's needs."""
+
+    def __init__(self, bundle: dict[str, Any] | None = None) -> None:
+        self.bundle = bundle or {
+            "tree_id": "growth",
+            "agent": {"recommended_next_steps": []},
+        }
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def list_trees(self) -> dict[str, Any]:
+        self.calls.append(("list_trees", {}))
+        return {"trees": [{"id": "growth", "nodes": [{"id": "users"}]}]}
+
+    def investigate_tree(self, tree_id, **kwargs):
+        self.calls.append(("investigate_tree", {"tree_id": tree_id, **kwargs}))
+        return dict(self.bundle)
+
+
+def test_run_manager_investigate_returns_bundle_with_run_id():
+    client = _FakeClient()
+    manager = RunManager(client, _config(), persist=False)
+
+    result = manager.investigate(
+        "growth",
+        windows=_windows(),
+        params=InvestigationParams(),
+    )
+
+    assert isinstance(result, RunResult)
+    assert result.run_id is not None
+    assert result.bundle["tree_id"] == "growth"
+    assert result.from_cache is False
+
+
+def test_run_manager_passes_windows_and_params_to_client():
+    client = _FakeClient()
+    manager = RunManager(client, _config(), persist=False)
+    params = InvestigationParams(max_depth=4, segment_by=("region",))
+
+    manager.investigate("growth", windows=_windows(), params=params)
+
+    investigate_call = next(c for c in client.calls if c[0] == "investigate_tree")
+    kwargs = investigate_call[1]
+    assert kwargs["windows"].iso_tuple() == (
+        "2026-03-09",
+        "2026-03-15",
+        "2026-03-02",
+        "2026-03-08",
+    )
+    assert kwargs["params"] is params
+
+
+def test_run_manager_sanitizes_agent_next_steps():
+    """Sanitization (drop next-steps targeting non-tree ids) is part of the
+    contract — every adapter gets sanitized output, not raw."""
+    client = _FakeClient(
+        bundle={
+            "tree_id": "growth",
+            "agent": {
+                "recommended_next_steps": [
+                    {
+                        "command": "qluent trees compare growth nonexistent_tree",
+                        "why": "compare these.",
+                    }
+                ]
+            },
+        }
+    )
+    manager = RunManager(client, _config(), persist=False)
+    result = manager.investigate("growth", windows=_windows(), params=InvestigationParams())
+    step = result.bundle["agent"]["recommended_next_steps"][0]
+    assert "command" not in step  # invalid target was scrubbed
+
+
+def test_run_manager_persists_when_persist_true(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def fake_record_run(**kwargs):
+        captured.update(kwargs)
+        from pathlib import Path
+
+        from qluent_cli.sessions import RunRecord
+
+        return RunRecord(
+            run_id="ABCDEF1234567890",
+            command=kwargs["command"],
+            tree_id=kwargs["tree_id"],
+            period_start=kwargs["period_start"],
+            period_end=kwargs["period_end"],
+            comparison_start=kwargs["comparison_start"],
+            comparison_end=kwargs["comparison_end"],
+            started_at="2026-03-09T00:00:00Z",
+            profile=kwargs.get("profile"),
+            client_safe=kwargs.get("client_safe", False),
+            path=Path("/tmp/run.json"),
+        )
+
+    monkeypatch.setattr("qluent_cli.run_manager.sessions.record_run", fake_record_run)
+
+    client = _FakeClient()
+    manager = RunManager(client, _config(), persist=True)
+    result = manager.investigate("growth", windows=_windows(), params=InvestigationParams())
+
+    assert captured["tree_id"] == "growth"
+    assert captured["period_start"] == "2026-03-09"
+    assert captured["comparison_end"] == "2026-03-08"
+    # run_id from the persisted record propagates back to the result.
+    assert result.run_id == "ABCDEF1234567890"
+
+
+def test_run_manager_continues_when_persist_fails(monkeypatch, capsys):
+    """Persist failure must not lose the result. The bundle still flows back;
+    a warning goes to stderr."""
+
+    def boom(**_kwargs):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr("qluent_cli.run_manager.sessions.record_run", boom)
+
+    client = _FakeClient()
+    manager = RunManager(client, _config(), persist=True)
+    result = manager.investigate("growth", windows=_windows(), params=InvestigationParams())
+
+    # bundle still flows through
+    assert result.bundle["tree_id"] == "growth"
+    err = capsys.readouterr().err
+    assert "failed to persist run" in err.lower()
+
+
+def test_run_manager_does_not_persist_when_disabled(monkeypatch):
+    called = {"n": 0}
+
+    def fake_record_run(**_kwargs):
+        called["n"] += 1
+        raise AssertionError("should not be called when persist=False")
+
+    monkeypatch.setattr("qluent_cli.run_manager.sessions.record_run", fake_record_run)
+
+    client = _FakeClient()
+    manager = RunManager(client, _config(), persist=False)
+    manager.investigate("growth", windows=_windows(), params=InvestigationParams())
+
+    assert called["n"] == 0

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -261,7 +261,9 @@ def test_investigate_persists_run_and_resumable(isolated_config, monkeypatch):
 
     api_calls: list[str] = []
 
-    def mock_investigate(self, tree_id, c_from, c_to, p_from, p_to, **kwargs):
+    def mock_investigate(self, tree_id, c_from=None, c_to=None, p_from=None, p_to=None, **kwargs):
+        if kwargs.get("windows") is not None:
+            c_from, c_to, p_from, p_to = kwargs["windows"].iso_tuple()
         api_calls.append(tree_id)
         return {
             "tree_id": tree_id,
@@ -322,7 +324,9 @@ def test_investigate_stream_completion_run_id_is_resumable(isolated_config, monk
 
     api_calls: list[str] = []
 
-    def mock_investigate(self, tree_id, c_from, c_to, p_from, p_to, **kwargs):
+    def mock_investigate(self, tree_id, c_from=None, c_to=None, p_from=None, p_to=None, **kwargs):
+        if kwargs.get("windows") is not None:
+            c_from, c_to, p_from, p_to = kwargs["windows"].iso_tuple()
         api_calls.append(tree_id)
         return {
             "tree_id": tree_id,
@@ -437,7 +441,9 @@ def test_deep_dive_persists_run(isolated_config, monkeypatch):
         },
     )
 
-    def mock_investigate(self, tree_id, c_from, c_to, p_from, p_to, **kwargs):
+    def mock_investigate(self, tree_id, c_from=None, c_to=None, p_from=None, p_to=None, **kwargs):
+        if kwargs.get("windows") is not None:
+            c_from, c_to, p_from, p_to = kwargs["windows"].iso_tuple()
         return {"tree_id": tree_id, "agent": {}}
 
     monkeypatch.setattr(

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -459,8 +459,10 @@ def test_trees_investigate_delegates_to_server(monkeypatch):
     investigate_calls: list[dict] = []
 
     def mock_investigate_tree(
-        self, tree_id, c_from, c_to, p_from, p_to, **kwargs
+        self, tree_id, c_from=None, c_to=None, p_from=None, p_to=None, **kwargs
     ):
+        if kwargs.get("windows") is not None:
+            c_from, c_to, p_from, p_to = kwargs["windows"].iso_tuple()
         investigate_calls.append({"tree_id": tree_id, "c_from": c_from, **kwargs})
         return {
             "tree_id": tree_id,
@@ -513,8 +515,10 @@ def test_trees_investigate_delegates_to_server(monkeypatch):
     assert payload["agent"]["status"] == "resolved"
     assert len(investigate_calls) == 1
     assert investigate_calls[0]["tree_id"] == "revenue"
-    assert investigate_calls[0]["compare_trees"] == ["orders"]
-    assert investigate_calls[0]["filters"] == {"country": ["SE"]}
+    # InvestigationParams now carries these — they used to be raw kwargs.
+    params = investigate_calls[0]["params"]
+    assert list(params.compare_trees) == ["orders"]
+    assert params.filters == {"country": ["SE"]}
 
 
 def test_trees_investigate_converts_metric_compare_recommendation(monkeypatch):
@@ -544,7 +548,7 @@ def test_trees_investigate_converts_metric_compare_recommendation(monkeypatch):
     )
     monkeypatch.setattr(
         "qluent_cli.trees.QluentClient.investigate_tree",
-        lambda self, tree_id, c_from, c_to, p_from, p_to, **kwargs: {
+        lambda self, tree_id, c_from=None, c_to=None, p_from=None, p_to=None, **kwargs: {
             "tree_id": tree_id,
             "tree_label": "Revenue",
             "agent": {
@@ -610,7 +614,7 @@ def test_trees_investigate_strips_invalid_compare_recommendation(monkeypatch):
     )
     monkeypatch.setattr(
         "qluent_cli.trees.QluentClient.investigate_tree",
-        lambda self, tree_id, c_from, c_to, p_from, p_to, **kwargs: {
+        lambda self, tree_id, c_from=None, c_to=None, p_from=None, p_to=None, **kwargs: {
             "tree_id": tree_id,
             "tree_label": "Revenue",
             "agent": {
@@ -646,7 +650,9 @@ def test_trees_investigate_keeps_json_on_stdout_and_progress_on_stderr(monkeypat
         "qluent_cli.trees.QluentClient.list_trees",
         lambda self: {"trees": [{"id": "revenue", "nodes": []}]},
     )
-    def mock_investigate(self, tree_id, c_from, c_to, p_from, p_to, **kwargs):
+    def mock_investigate(self, tree_id, c_from=None, c_to=None, p_from=None, p_to=None, **kwargs):
+        if kwargs.get("windows") is not None:
+            c_from, c_to, p_from, p_to = kwargs["windows"].iso_tuple()
         kwargs["progress_callback"]("awaiting_api", 30.0)
         return {
             "tree_id": tree_id,
@@ -673,7 +679,7 @@ def test_quiet_suppresses_investigate_progress(monkeypatch):
     )
     monkeypatch.setattr(
         "qluent_cli.trees.QluentClient.investigate_tree",
-        lambda self, tree_id, c_from, c_to, p_from, p_to, **kwargs: {
+        lambda self, tree_id, c_from=None, c_to=None, p_from=None, p_to=None, **kwargs: {
             "tree_id": tree_id,
             "agent": {},
         },
@@ -697,7 +703,7 @@ def test_trees_investigate_stream_emits_jsonl(monkeypatch):
     )
     monkeypatch.setattr(
         "qluent_cli.trees.QluentClient.investigate_tree",
-        lambda self, tree_id, c_from, c_to, p_from, p_to, **kwargs: {
+        lambda self, tree_id, c_from=None, c_to=None, p_from=None, p_to=None, **kwargs: {
             "tree_id": tree_id,
             "agent": {"status": "resolved"},
         },
@@ -761,7 +767,9 @@ def test_trees_deep_dive_runs_all_trees(monkeypatch):
 
     calls: list[str] = []
 
-    def mock_investigate(self, tree_id, c_from, c_to, p_from, p_to, **kwargs):
+    def mock_investigate(self, tree_id, c_from=None, c_to=None, p_from=None, p_to=None, **kwargs):
+        if kwargs.get("windows") is not None:
+            c_from, c_to, p_from, p_to = kwargs["windows"].iso_tuple()
         calls.append(tree_id)
         return {
             "tree_id": tree_id,
@@ -808,7 +816,9 @@ def test_trees_deep_dive_filters_to_requested_trees(monkeypatch):
     )
     calls: list[str] = []
 
-    def mock_investigate(self, tree_id, c_from, c_to, p_from, p_to, **kwargs):
+    def mock_investigate(self, tree_id, c_from=None, c_to=None, p_from=None, p_to=None, **kwargs):
+        if kwargs.get("windows") is not None:
+            c_from, c_to, p_from, p_to = kwargs["windows"].iso_tuple()
         calls.append(tree_id)
         return {"tree_id": tree_id, "agent": {}}
 
@@ -874,7 +884,9 @@ def test_trees_deep_dive_captures_per_tree_errors(monkeypatch):
         },
     )
 
-    def mock_investigate(self, tree_id, c_from, c_to, p_from, p_to, **kwargs):
+    def mock_investigate(self, tree_id, c_from=None, c_to=None, p_from=None, p_to=None, **kwargs):
+        if kwargs.get("windows") is not None:
+            c_from, c_to, p_from, p_to = kwargs["windows"].iso_tuple()
         if tree_id == "growth":
             raise RuntimeError("upstream timeout")
         return {"tree_id": tree_id, "agent": {}}

--- a/tests/test_window_resolver.py
+++ b/tests/test_window_resolver.py
@@ -1,0 +1,195 @@
+"""Tests for the framework-neutral period/window resolver.
+
+Today every adapter (Click commands in `trees.py`, MCP tools in
+`mcp_server.py`) re-implements the period -> 4 ISO strings dance, plus the
+`--resume` / `--last` cache lookup is Click-specific and re-implemented
+informally elsewhere.  This module owns the lifecycle as a single seam.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from qluent_cli.window_resolver import (
+    PeriodResolutionError,
+    ResolvedPeriod,
+    resolve_period,
+)
+from qluent_cli.dates import DateWindows
+
+
+# -- iso_tuple helper ---------------------------------------------------------
+
+
+def test_date_windows_iso_tuple_returns_four_strings():
+    windows = resolve_period(period="last week", today=date(2026, 4, 29)).windows
+    iso = windows.iso_tuple()
+    assert iso == (
+        windows.current.iso_from,
+        windows.current.iso_to,
+        windows.comparison.iso_from,
+        windows.comparison.iso_to,
+    )
+    assert all(isinstance(s, str) for s in iso)
+
+
+# -- period resolution --------------------------------------------------------
+
+
+def test_resolve_period_uses_natural_language_period():
+    rp = resolve_period(period="last week", today=date(2026, 4, 29))
+    assert isinstance(rp, ResolvedPeriod)
+    assert rp.cached_run is None
+    # Last full week before Wednesday 2026-04-29 is Mon 2026-04-20 to Sun 2026-04-26
+    assert rp.windows.current.iso_from == "2026-04-20"
+    assert rp.windows.current.iso_to == "2026-04-26"
+
+
+def test_resolve_period_uses_explicit_ranges_verbatim():
+    rp = resolve_period(
+        current_range="2026-03-01:2026-03-31",
+        compare_range="2026-02-01:2026-02-28",
+    )
+    assert rp.cached_run is None
+    assert rp.windows.iso_tuple() == (
+        "2026-03-01",
+        "2026-03-31",
+        "2026-02-01",
+        "2026-02-28",
+    )
+
+
+def test_resolve_period_defaults_to_last_seven_days_when_nothing_given():
+    rp = resolve_period(today=date(2026, 4, 29))
+    assert rp.windows.current.iso_to == "2026-04-29"
+
+
+# -- resume/last lookup -------------------------------------------------------
+
+
+def test_resolve_period_with_resume_returns_cached_run(monkeypatch):
+    fake_record = _fake_run_record(
+        run_id="01234567ABCDEFGH",
+        command="trees investigate",
+        tree_id="growth",
+        period_start="2026-03-01",
+        period_end="2026-03-07",
+        comparison_start="2026-02-22",
+        comparison_end="2026-02-28",
+    )
+    _patch_session_lookup(monkeypatch, get_run=fake_record)
+
+    rp = resolve_period(
+        resume="01234567ABCDEFGH",
+        command="trees investigate",
+        tree_id="growth",
+    )
+    assert rp.cached_run is fake_record
+    assert rp.windows.iso_tuple() == (
+        "2026-03-01",
+        "2026-03-07",
+        "2026-02-22",
+        "2026-02-28",
+    )
+
+
+def test_resolve_period_resume_missing_raises_neutral_error(monkeypatch):
+    _patch_session_lookup(monkeypatch, get_run=None)
+    with pytest.raises(PeriodResolutionError, match="No run found"):
+        resolve_period(resume="DEADBEEFDEADBEEF", command="trees investigate")
+
+
+def test_resolve_period_resume_with_wrong_command_raises(monkeypatch):
+    fake_record = _fake_run_record(command="trees deep-dive")
+    _patch_session_lookup(monkeypatch, get_run=fake_record)
+    with pytest.raises(PeriodResolutionError, match="not 'trees investigate'"):
+        resolve_period(resume="any", command="trees investigate")
+
+
+def test_resolve_period_resume_with_wrong_tree_raises(monkeypatch):
+    fake_record = _fake_run_record(tree_id="growth", command="trees investigate")
+    _patch_session_lookup(monkeypatch, get_run=fake_record)
+    with pytest.raises(PeriodResolutionError, match="not 'revenue'"):
+        resolve_period(
+            resume="any",
+            command="trees investigate",
+            tree_id="revenue",
+        )
+
+
+def test_resolve_period_use_last_returns_most_recent(monkeypatch):
+    fake_record = _fake_run_record(
+        run_id="LASTRUN1234567XX",
+        command="trees investigate",
+        tree_id="growth",
+        period_start="2026-03-01",
+        period_end="2026-03-07",
+        comparison_start="2026-02-22",
+        comparison_end="2026-02-28",
+    )
+    _patch_session_lookup(monkeypatch, find_last_run=fake_record)
+
+    rp = resolve_period(
+        use_last=True,
+        command="trees investigate",
+        tree_id="growth",
+    )
+    assert rp.cached_run is fake_record
+
+
+def test_resolve_period_use_last_missing_raises_neutral_error(monkeypatch):
+    _patch_session_lookup(monkeypatch, find_last_run=None)
+    with pytest.raises(PeriodResolutionError, match="No prior"):
+        resolve_period(use_last=True, command="trees investigate", tree_id="growth")
+
+
+def test_resolve_period_resume_and_use_last_are_mutually_exclusive():
+    with pytest.raises(PeriodResolutionError, match="not both"):
+        resolve_period(resume="abc", use_last=True, command="trees investigate")
+
+
+# -- helpers ------------------------------------------------------------------
+
+
+def _fake_run_record(
+    *,
+    run_id: str = "01234567ABCDEFGH",
+    command: str = "trees investigate",
+    tree_id: str | None = "growth",
+    period_start: str | None = "2026-03-01",
+    period_end: str | None = "2026-03-07",
+    comparison_start: str | None = "2026-02-22",
+    comparison_end: str | None = "2026-02-28",
+):
+    from pathlib import Path
+
+    from qluent_cli.sessions import RunRecord
+
+    return RunRecord(
+        run_id=run_id,
+        command=command,
+        tree_id=tree_id,
+        period_start=period_start,
+        period_end=period_end,
+        comparison_start=comparison_start,
+        comparison_end=comparison_end,
+        started_at="2026-03-01T00:00:00Z",
+        profile=None,
+        client_safe=False,
+        path=Path("/tmp/run.json"),
+    )
+
+
+def _patch_session_lookup(monkeypatch, *, get_run=..., find_last_run=...):
+    from qluent_cli import window_resolver
+
+    if get_run is not ...:
+        monkeypatch.setattr(window_resolver.sessions, "get_run", lambda _id: get_run)
+    if find_last_run is not ...:
+        monkeypatch.setattr(
+            window_resolver.sessions,
+            "find_last_run",
+            lambda **_kwargs: find_last_run,
+        )


### PR DESCRIPTION
Applies the [`improve-codebase-architecture`](https://github.com/mattpocock/skills/tree/main/skills/engineering/improve-codebase-architecture) skill: surface architectural friction, then turn shallow modules (interface nearly as wide as the implementation) into deep ones (lots of behaviour behind a small interface).

Six independent commits, each issue-tracked and TDD-driven. Suite grew from 180 → **217 passing** with no regressions. Every commit was red → green → refactor.

## Commits

| # | Issue | Commit | What deepened |
|---|---|---|---|
| 1 | #76 | `d72f84a` | Rendering seam — every command's `if as_json: dumps else: format` collapsed into `render(Result, as_json=...)`. New `rendering.py`. |
| 2 | #78 | `434c249` | Period resolver — framework-neutral `resolve_period(...)` shared by CLI and MCP; `PeriodResolutionError` replaces the Click-only `_resume_or_last`. New `window_resolver.py`. |
| 3 | #80 | `74c9558` | Contract enrichment — `client.root_cause_tree(...)` returns an enriched `RCAOutput` by construction. Callers can no longer forget `enrich_rca_output`. |
| 4 | #79 | `9fcd04b` | Domain-shaped configs — `RcaParams`, `InvestigationParams`, `ElasticityParams` own the defaults; client methods take `windows=` and `params=` instead of 12 kwargs. New `client_configs.py`. |
| 5 | #77 | `d071707` | RunManager — owns reporter + sanitization + persistence + stable run_id. Persist failure no longer silently loses the result. New `run_manager.py`. |
| 6 | #81 | `6b43dcd` | Command-runner capstone — `@qluent_command` decorator composes the seams above. Business code returns a `Result`; the decorator handles config/client injection, error mapping, rendering. New `command_runner.py`. |

## Why this was worth doing (per the skill's vocabulary)

- **Leverage** — every adapter (CLI, MCP, future SDK) now shares window resolution, contract enrichment, run lifecycle, and rendering. One seam, many callers.
- **Locality** — RCA schema/provenance lives only in `rca_contracts.py`; cache lookup only in `window_resolver.py`; persistence only in `RunManager`; JSON shaping only in `rendering.py`. Fix once, fixed everywhere.
- **Deletion test** — each new module fails the test in the right way: deleting any of them re-distributes complexity across N adapters. They are earning their keep.

## What changed at the call sites

Before (typical command):

```python
config = load_config()
client = QluentClient(config)
windows = resolve_windows(period, current_range, compare_range)
c_from, c_to = windows.current.iso_from, windows.current.iso_to
p_from, p_to = windows.comparison.iso_from, windows.comparison.iso_to
data = client.root_cause_tree(
    tree_id, c_from, c_to, p_from, p_to,
    segment_by=list(segment_by), filters=parsed_filters, metric=metric,
    max_depth=max_depth, max_branching=max_branches,
    max_segments=max_segments, min_contribution_share=min_contribution_share,
)
data = enrich_rca_output(data, config)
if as_json:
    click.echo(json.dumps(data, indent=2))
else:
    click.echo(format_root_cause(data))
```

After:

```python
@qluent_command
def analyze(client, config, tree_id, ..., *, as_json):
    rp = resolve_period(period=period, current_range=current_range, compare_range=compare_range)
    params = RcaParams(metric=metric, segment_by=tuple(segment_by), filters=parse_filters(filters), ...)
    data = client.root_cause_tree(tree_id, windows=rp.windows, params=params)
    return simple_result(data, formatter=format_root_cause)
```

## Test plan

- [x] `uv run pytest` — 217 passed, 0 failed (started from 180 baseline)
- [x] 41 new tests across `test_rendering.py`, `test_window_resolver.py`, `test_client_contracts.py`, `test_client_configs.py`, `test_run_manager.py`, `test_command_runner.py`
- [x] Every existing test still passes — JSON output shapes are byte-identical (still `indent=2`); CLI help text unchanged; existing run-persistence behaviour unchanged.
- [x] MCP RCA dispatch now has a contract-enforcing test that the response carries `schema_version` + `provenance`.
- [ ] Manual smoke: `qluent trees list`, `trees evaluate`, `rca analyze`, `elasticity` against a real project (recommended before merge).

## Out of scope / follow-ups

Noted in the issue threads and commit messages:

- `trees deep-dive` still uses the legacy `run_investigation` orchestrator. Its parallel semantics warrant a separate `RunManager.investigate_many(...)` — deferred.
- `mcp_server._investigate` still calls `run_investigation` directly; routing it through `RunManager` would change MCP behaviour (start persisting). Worth doing but out of scope here.
- `main.py` (login/setup/status/whoami/runs) commands are untouched — they're a different shape and don't fit the `Result`-returning pattern cleanly.

Closes #76, #77, #78, #79, #80, #81.

https://claude.ai/code/session_01LzSfxhccbt9dJ8oX91Ukd2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzSfxhccbt9dJ8oX91Ukd2)_