### PR TITLE
Fix CLI security review findings

### DIFF
--- a/.github/workflows/qluent-cli-binaries.yml
+++ b/.github/workflows/qluent-cli-binaries.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     permissions:
-      contents: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -38,8 +38,6 @@ jobs:
 
       - name: Build standalone binary
         run: python -m qluent_cli.build_binary
-        env:
-          QLUENT_SIGNING_PRIVATE_KEY: ${{ secrets.QLUENT_SIGNING_PRIVATE_KEY }}
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4
@@ -62,6 +60,40 @@ jobs:
         with:
           path: release-assets
           merge-multiple: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install signing dependencies
+        run: python -m pip install "cryptography>=43.0"
+
+      - name: Sign checksum files
+        env:
+          QLUENT_SIGNING_PRIVATE_KEY: ${{ secrets.QLUENT_SIGNING_PRIVATE_KEY }}
+        run: |
+          python - <<'PY'
+          import base64
+          import os
+          from pathlib import Path
+
+          from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+          private_key_pem = os.environ.get("QLUENT_SIGNING_PRIVATE_KEY")
+          if not private_key_pem:
+              raise SystemExit("QLUENT_SIGNING_PRIVATE_KEY is required for releases")
+
+          private_key = load_pem_private_key(private_key_pem.encode(), password=None)
+          checksum_paths = sorted(Path("release-assets").glob("*.sha256"))
+          if not checksum_paths:
+              raise SystemExit("No checksum files found to sign")
+
+          for checksum_path in checksum_paths:
+              signature = private_key.sign(checksum_path.read_bytes())
+              sig_path = checksum_path.with_name(f"{checksum_path.name}.sig")
+              sig_path.write_text(base64.b64encode(signature).decode() + "\n")
+              print(f"Signed {sig_path}")
+          PY
 
       - name: Publish GitHub release assets
         uses: softprops/action-gh-release@v2

--- a/npm/lib/installer.js
+++ b/npm/lib/installer.js
@@ -96,8 +96,7 @@ const TRUSTED_PUBLIC_KEYS = [
   "a77fa57c27605d474e172ed4473996980cf7c96e78b06bdb07f8ad210d13e7b9",
 ];
 
-// Set to true once all active releases include .sha256.sig files.
-const SIGNATURE_REQUIRED = false;
+const SIGNATURE_REQUIRED = true;
 
 function download(url, destination, { env = process.env, redirectsRemaining = 5, maxSize = MAX_BINARY_SIZE } = {}) {
   const safeUrl = assertSecureUrl(url, { env }).toString();
@@ -311,6 +310,16 @@ async function installBinary({
     );
   }
 
+  if (
+    env.QLUENT_CLI_SKIP_SIGNATURE_VERIFICATION === "1" &&
+    !allowInsecureDownload(env)
+  ) {
+    throw new Error(
+      "Refusing to skip signature verification outside local development. " +
+        "Set QLUENT_CLI_ALLOW_INSECURE_DOWNLOAD=1 only for local development."
+    );
+  }
+
   const binaryName = platform === "win32" ? "qluent.exe" : "qluent";
   const destination = path.join(binDir, binaryName);
   const tempDestination = `${destination}.tmp`;
@@ -337,25 +346,12 @@ async function installBinary({
       );
     } else {
       const signatureUrl = resolveSignatureUrl(checksumUrl);
-      try {
-        const signatureBody = await downloadText(signatureUrl, {
-          env,
-          maxSize: MAX_SIGNATURE_SIZE,
-        });
-        verifySignature(checksumBody, signatureBody, { trustedKeys });
-        logger.log("Signature verification passed");
-      } catch (sigError) {
-        if (
-          SIGNATURE_REQUIRED ||
-          !sigError.message.includes("Download failed with status")
-        ) {
-          throw sigError;
-        }
-        logger.log(
-          "WARNING: Signature file not found. " +
-            "Signature verification will be required in a future release."
-        );
-      }
+      const signatureBody = await downloadText(signatureUrl, {
+        env,
+        maxSize: MAX_SIGNATURE_SIZE,
+      });
+      verifySignature(checksumBody, signatureBody, { trustedKeys });
+      logger.log("Signature verification passed");
     }
 
     const expectedChecksum = parseChecksumFile(

--- a/npm/tests/installer.test.js
+++ b/npm/tests/installer.test.js
@@ -888,8 +888,8 @@ test("MAX_SIGNATURE_SIZE has a sane default", () => {
   assert.equal(MAX_SIGNATURE_SIZE, 256);
 });
 
-test("SIGNATURE_REQUIRED is false during transition", () => {
-  assert.equal(SIGNATURE_REQUIRED, false);
+test("SIGNATURE_REQUIRED is true for production installs", () => {
+  assert.equal(SIGNATURE_REQUIRED, true);
 });
 
 // ---------------------------------------------------------------------------
@@ -1033,7 +1033,7 @@ test("installBinary cleans up .tmp on signature verification failure", async () 
   }
 });
 
-test("installBinary warns but succeeds when .sig is missing and SIGNATURE_REQUIRED is false", async () => {
+test("installBinary fails when .sig is missing", async () => {
   const server = await createTestServer();
   const tempDir = makeTempDir();
   const binDir = path.join(tempDir, "bin");
@@ -1057,21 +1057,21 @@ test("installBinary warns but succeeds when .sig is missing and SIGNATURE_REQUIR
   });
 
   try {
-    const dest = await installBinary({
-      version: "1.0.0",
-      env: insecureEnv({ QLUENT_CLI_DIST_BASE_URL: server.url }),
-      binDir,
-      platform: "darwin",
-      arch: "arm64",
-      logger,
-      trustedKeys: [generateSigningKeyPair().publicKeyHex],
-    });
-
-    assert.ok(fs.existsSync(dest));
-    assert.ok(
-      logger.messages.some((m) => m.includes("Signature file not found")),
-      "expected a warning about missing signature"
+    await assert.rejects(
+      () =>
+        installBinary({
+          version: "1.0.0",
+          env: insecureEnv({ QLUENT_CLI_DIST_BASE_URL: server.url }),
+          binDir,
+          platform: "darwin",
+          arch: "arm64",
+          logger,
+          trustedKeys: [generateSigningKeyPair().publicKeyHex],
+        }),
+      /Download failed with status 404/
     );
+    assert.equal(fs.existsSync(path.join(binDir, "qluent")), false);
+    assert.equal(fs.existsSync(path.join(binDir, "qluent.tmp")), false);
   } finally {
     server.close();
   }
@@ -1120,4 +1120,25 @@ test("installBinary skips signature check when QLUENT_CLI_SKIP_SIGNATURE_VERIFIC
   } finally {
     server.close();
   }
+});
+
+test("installBinary refuses to skip signature check outside local development", async () => {
+  const tempDir = makeTempDir();
+  const binDir = path.join(tempDir, "bin");
+
+  await assert.rejects(
+    () =>
+      installBinary({
+        version: "1.0.0",
+        env: {
+          QLUENT_CLI_SKIP_SIGNATURE_VERIFICATION: "1",
+          QLUENT_CLI_BIN_URL: "https://example.com/qluent",
+        },
+        binDir,
+        platform: "darwin",
+        arch: "arm64",
+        logger: captureLogger(),
+      }),
+    /Refusing to skip signature verification/
+  );
 });

--- a/src/qluent_cli/config.py
+++ b/src/qluent_cli/config.py
@@ -7,6 +7,7 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 CONFIG_DIR = Path.home() / ".qluent"
 CONFIG_FILE = CONFIG_DIR / "config.json"
@@ -32,11 +33,10 @@ def _parse_bool(value: Any) -> bool:
 
 
 def is_local_url(api_url: str) -> bool:
-    """Check whether a URL points to localhost or 127.0.0.1."""
-    normalized = api_url.rstrip("/").lower()
-    return normalized.startswith("http://localhost") or normalized.startswith(
-        "http://127.0.0.1"
-    )
+    """Check whether a URL points to an explicit loopback host."""
+    parsed = urlparse(api_url)
+    host = (parsed.hostname or "").lower()
+    return host in {"localhost", "127.0.0.1", "::1"}
 
 
 def default_client_safe(api_url: str) -> bool:

--- a/src/qluent_cli/sessions.py
+++ b/src/qluent_cli/sessions.py
@@ -109,7 +109,9 @@ class RunRecord:
 def _connect() -> sqlite3.Connection:
     index = _index_path()
     index.parent.mkdir(parents=True, exist_ok=True)
+    index.parent.chmod(0o700)
     conn = sqlite3.connect(str(index))
+    index.chmod(0o600)
     conn.row_factory = sqlite3.Row
     conn.execute(
         """
@@ -181,6 +183,10 @@ def record_run(
 
     base = _sessions_dir() / f"{now:%Y/%m/%d}"
     base.mkdir(parents=True, exist_ok=True)
+    _sessions_dir().chmod(0o700)
+    for parent in base.relative_to(_sessions_dir()).parents:
+        (_sessions_dir() / parent).chmod(0o700)
+    base.chmod(0o700)
     file_name = f"{_safe_filename_component(tree_id)}-{run_id}.json"
     path = base / file_name
 
@@ -202,6 +208,7 @@ def record_run(
     }
     with open(path, "w") as f:
         json.dump(file_payload, f, indent=2, default=str)
+    path.chmod(0o600)
 
     try:
         with _connect() as conn:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,9 @@ def test_default_client_safe_prefers_hosted_urls():
     assert config_module.default_client_safe("https://api.example.com") is True
     assert config_module.default_client_safe("http://localhost:8001") is False
     assert config_module.default_client_safe("http://127.0.0.1:8001") is False
+    assert config_module.default_client_safe("http://[::1]:8001") is False
+    assert config_module.default_client_safe("http://localhost.evil.example") is True
+    assert config_module.default_client_safe("http://127.0.0.1.evil.example") is True
 
 
 def test_load_config_defaults_to_production_api_url(isolated_config):
@@ -59,6 +62,31 @@ def test_load_config_rejects_http_non_local_url(isolated_config):
             {
                 "api_key": "qk_test",
                 "api_url": "http://api.example.com",
+                "project_uuid": "project-123",
+                "user_email": "user@example.com",
+            }
+        )
+    )
+
+    with pytest.raises(SystemExit, match="Refusing to connect over plain HTTP"):
+        config_module.load_config()
+
+
+@pytest.mark.parametrize(
+    "api_url",
+    [
+        "http://localhost.evil.example",
+        "http://127.0.0.1.evil.example",
+    ],
+)
+def test_load_config_rejects_http_loopback_prefix_spoof(api_url, isolated_config):
+    config_dir, config_file = isolated_config
+    config_dir.mkdir()
+    config_file.write_text(
+        json.dumps(
+            {
+                "api_key": "qk_test",
+                "api_url": api_url,
                 "project_uuid": "project-123",
                 "user_email": "user@example.com",
             }

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import stat
 import time
 from datetime import datetime, timedelta, timezone
 
@@ -85,6 +86,16 @@ def test_record_run_writes_file_and_indexes(isolated_config):
     body = json.loads(record.path.read_text())
     assert body["run_id"] == record.run_id
     assert body["result"] == {"tree_id": "revenue", "delta": 10}
+
+
+def test_record_run_uses_private_file_modes(isolated_config):
+    record = _record(payload={"tree_id": "revenue", "delta": 10})
+    config_dir, _config_file = isolated_config
+
+    assert stat.S_IMODE((config_dir / "sessions").stat().st_mode) == 0o700
+    assert stat.S_IMODE(record.path.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(record.path.stat().st_mode) == 0o600
+    assert stat.S_IMODE((config_dir / "sessions" / "index.db").stat().st_mode) == 0o600
 
 
 def test_record_run_sanitizes_tree_id_for_filename(isolated_config):


### PR DESCRIPTION
## Summary
- parse API URLs before treating loopback hosts as safe for HTTP
- require signed npm release checksums by default and restrict signature-skip to explicit local development
- move release signing out of the build job and reduce build job permissions
- write session artifacts and index with private file modes

## TDD / Tests
- added regression tests for loopback-prefix spoofing
- added installer tests for mandatory signatures and signature-skip restrictions
- added session file mode regression test

## Verification
- uv run pytest
- uv run pytest tests/test_config.py tests/test_sessions.py
- npm test