### PR TITLE
[codex] Cover loopback userinfo spoof URLs

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,6 +14,8 @@ def test_default_client_safe_prefers_hosted_urls():
     assert config_module.default_client_safe("http://[::1]:8001") is False
     assert config_module.default_client_safe("http://localhost.evil.example") is True
     assert config_module.default_client_safe("http://127.0.0.1.evil.example") is True
+    assert config_module.default_client_safe("http://localhost@evil.example") is True
+    assert config_module.default_client_safe("http://127.0.0.1@evil.example") is True
 
 
 def test_load_config_defaults_to_production_api_url(isolated_config):
@@ -77,6 +79,8 @@ def test_load_config_rejects_http_non_local_url(isolated_config):
     [
         "http://localhost.evil.example",
         "http://127.0.0.1.evil.example",
+        "http://localhost@evil.example",
+        "http://127.0.0.1@evil.example",
     ],
 )
 def test_load_config_rejects_http_loopback_prefix_spoof(api_url, isolated_config):


### PR DESCRIPTION
## Summary

- Add regression coverage for HTTP URLs that put a loopback-looking value in the userinfo component, such as `http://localhost@evil.example`.
- Verify those URLs are treated as non-local and rejected by the plain-HTTP guard.

## Why

Issue #85 covers local-host prefix spoofing around the `is_local_url()` guard. The production parser-based host comparison landed in #84; this PR adds follow-up regression coverage for another URL confusion form where the visible prefix looks local but `parsed.hostname` is attacker-controlled.

Adds regression coverage for #85 after the production fix landed in #84.

## Validation

- `uv run pytest tests/test_config.py`