### PR TITLE
chore: bump version to 0.1.14

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qluent/cli",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Install the Qluent CLI",
   "license": "UNLICENSED",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qluent-cli"
-version = "0.1.13"
+version = "0.1.14"
 description = "CLI for Qluent metric tree analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/qluent_cli/__init__.py
+++ b/src/qluent_cli/__init__.py
@@ -1,3 +1,3 @@
 """Qluent CLI — metric tree analysis from the command line."""
 
-__version__ = "0.1.13"
+__version__ = "0.1.14"

--- a/uv.lock
+++ b/uv.lock
@@ -672,7 +672,7 @@ wheels = [
 
 [[package]]
 name = "qluent-cli"
-version = "0.1.13"
+version = "0.1.14"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
Bumps @qluent/cli to 0.1.14, shipping recent CLI security and test improvements.

Commits since v0.1.13:
- 0c64bae Fix CLI security review findings (#84)
- 85acd2d test: cover loopback userinfo spoof URLs (#86)

## Test plan
- [ ] CI green on this PR
- [ ] After merge, push `v0.1.14` tag and confirm `qluent-cli-binaries.yml` produces all 9 release assets (darwin-arm64, linux-x64, windows-x64 × {binary, .sha256, .sha256.sig})
- [ ] After release assets are live, publish `@qluent/cli@0.1.14` to npm and verify `npm view @qluent/cli version`