### PR TITLE
chore: bump version to 0.1.15

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qluent/cli",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Install the Qluent CLI",
   "license": "UNLICENSED",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qluent-cli"
-version = "0.1.14"
+version = "0.1.15"
 description = "CLI for Qluent metric tree analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/qluent_cli/__init__.py
+++ b/src/qluent_cli/__init__.py
@@ -1,3 +1,3 @@
 """Qluent CLI — metric tree analysis from the command line."""
 
-__version__ = "0.1.14"
+__version__ = "0.1.15"

--- a/uv.lock
+++ b/uv.lock
@@ -672,7 +672,7 @@ wheels = [
 
 [[package]]
 name = "qluent-cli"
-version = "0.1.14"
+version = "0.1.15"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Bumps `pyproject.toml`, `src/qluent_cli/__init__.py`, `npm/package.json`, and `uv.lock` from `0.1.14` to `0.1.15`.

Picks up one commit since the last release:

- efc2714 Expose analysis run handles (#89)

## Release follow-up

After merge:
1. Tag `v0.1.15` on `main` and push → triggers `.github/workflows/qluent-cli-binaries.yml` to build platform binaries and publish the GitHub Release.
2. `cd npm && npm publish --access restricted`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8WNgVdjbWDwHnT9jsrrtm)_