### PR TITLE
Add `qluent query` — ad-hoc NL queries via the workflow query engine

### DIFF
--- a/src/qluent_cli/agent_instructions.md
+++ b/src/qluent_cli/agent_instructions.md
@@ -20,6 +20,7 @@ qluent trees trend <tree_id> --periods 3 --grain month      # Monthly trend
 qluent trees compare <tree_id> <tree_id> --period "last week"  # Side-by-side tree comparison
 qluent trees investigate <tree_id> --period "last week"     # Validate + trend + evaluate + RCA bundle
 qluent rca analyze revenue --period "last week"             # Deterministic tree + segment RCA
+qluent query "<question>" [--thread <id>]                   # Ad-hoc NL question -> SQL -> results (LLM, non-deterministic)
 ```
 
 All commands support `--json-output` for raw JSON. The `trend` command supports `--as-of YYYY-MM-DD`
@@ -91,6 +92,34 @@ Use these rules:
 - Reuse the exact windows from the last investigation for follow-ups unless the user explicitly changes the period.
 - Never parse saved tool-result temp files or write ad-hoc Python to extract values from prior bash output. Use the structured JSON from `investigate`, `evaluate`, or `levers` directly.
 - Do not rerun both JSON and non-JSON versions of the same qluent command unless the JSON is genuinely insufficient.
+
+## When to use `qluent query` vs metric-tree commands
+
+The tree commands (`investigate`, `evaluate`, `trend`, `rca analyze`, ...) are
+deterministic, fast, and reproducible — always prefer them when the question maps
+to a tree's KPIs, child nodes, or declared dimensions ("why did revenue drop",
+trends, drivers, elasticity).
+
+`qluent query` runs the backend's LLM query workflow (natural language -> generated
+SQL -> execution) and is for everything trees cannot answer:
+
+- Row-level or entity-level questions ("top 10 customers by refunds", "list last
+  week's failed orders").
+- Arbitrary aggregations, filters, or joins over metrics and dimensions no tree declares.
+- Explicit raw-data requests (a table, an export, the SQL itself).
+
+It is non-deterministic, slower (can take minutes), and returns the generated `sql`,
+up to 1000 inline rows in `data`, plus a `download_url` for the full result set.
+
+Rules:
+
+- Use `--json-output` and check `status`: `ok`, `clarification_needed`, or `error`.
+- If `status = clarification_needed`, answer by re-running
+  `qluent query "<your answer>" --thread <thread_id>` with the `thread_id` from the response.
+- Reuse `thread_id` for follow-up questions that build on the same result.
+- Verify the returned `sql` matches the user's intent before presenting numbers, and
+  present the numbers as coming from an ad-hoc query, never as deterministic tree evidence.
+- Never use `qluent query` to re-derive numbers a tree command already returned.
 
 ## Manual root cause analysis workflow
 

--- a/src/qluent_cli/client.py
+++ b/src/qluent_cli/client.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import os
 import random
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from typing import Any
@@ -27,6 +28,7 @@ from qluent_cli.rca_contracts import RCAOutput, enrich_rca_output
 
 
 _INVESTIGATE_TIMEOUT = 300.0
+_QUERY_TIMEOUT = 300.0
 _PROGRESS_INTERVAL_SECONDS = 30.0
 
 # Heartbeat callback used by `investigate_tree` to surface that a long-running
@@ -146,6 +148,10 @@ class _RetryTransport(httpx.BaseTransport):
 
 def _default_jitter(base: float) -> float:
     return base * random.uniform(0.7, 1.3)
+
+
+class QueryStreamUnsupported(Exception):
+    """The backend does not expose the streaming query endpoint."""
 
 
 def _build_transport() -> httpx.BaseTransport:
@@ -398,26 +404,117 @@ class QluentClient:
             "compare_trees": list(merged.compare_trees),
         })
         url = f"{self._base}/metric-trees/{tree_id}/investigate/"
-
-        if progress_callback is None:
-            resp = self._client.post(url, json=body, timeout=_INVESTIGATE_TIMEOUT)
-        else:
-            started = time.monotonic()
-            done = threading.Event()
-
-            def tick() -> None:
-                while not done.wait(_PROGRESS_INTERVAL_SECONDS):
-                    progress_callback("awaiting_api", time.monotonic() - started)
-
-            heartbeat = threading.Thread(target=tick, daemon=True)
-            heartbeat.start()
-            try:
-                resp = self._client.post(url, json=body, timeout=_INVESTIGATE_TIMEOUT)
-            finally:
-                done.set()
-
+        resp = self._post_with_heartbeat(
+            url, body, timeout=_INVESTIGATE_TIMEOUT, progress_callback=progress_callback
+        )
         resp.raise_for_status()
         return resp.json()
+
+    def _post_with_heartbeat(
+        self,
+        url: str,
+        body: dict[str, Any],
+        *,
+        timeout: float,
+        progress_callback: ProgressCallback | None,
+    ) -> httpx.Response:
+        """POST with an optional daemon-thread heartbeat.
+
+        When `progress_callback` is supplied, it receives an
+        `("awaiting_api", elapsed_seconds)` heartbeat every
+        `_PROGRESS_INTERVAL_SECONDS` until the POST returns. The thread is
+        torn down before the response is returned, regardless of outcome.
+        """
+        if progress_callback is None:
+            return self._client.post(url, json=body, timeout=timeout)
+
+        started = time.monotonic()
+        done = threading.Event()
+
+        def tick() -> None:
+            while not done.wait(_PROGRESS_INTERVAL_SECONDS):
+                progress_callback("awaiting_api", time.monotonic() - started)
+
+        heartbeat = threading.Thread(target=tick, daemon=True)
+        heartbeat.start()
+        try:
+            return self._client.post(url, json=body, timeout=timeout)
+        finally:
+            done.set()
+
+    def _query_body(self, question: str, thread_id: str | None) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "question": question,
+            "user_email": self._config.user_email,
+        }
+        if thread_id:
+            body["thread_id"] = thread_id
+        return body
+
+    def query(
+        self,
+        question: str,
+        *,
+        thread_id: str | None = None,
+        progress_callback: ProgressCallback | None = None,
+    ) -> dict[str, Any]:
+        """Run an ad-hoc natural-language query via the sync endpoint.
+
+        A 422 response is a valid outcome (clarification needed / cannot
+        answer) and is returned as a payload, not raised.
+        """
+        resp = self._post_with_heartbeat(
+            f"{self._base}/query/",
+            self._query_body(question, thread_id),
+            timeout=_QUERY_TIMEOUT,
+            progress_callback=progress_callback,
+        )
+        if resp.status_code == 422:
+            return resp.json()
+        resp.raise_for_status()
+        return resp.json()
+
+    def iter_query_events(
+        self,
+        question: str,
+        *,
+        thread_id: str | None = None,
+    ) -> Iterator[tuple[str, dict[str, Any]]]:
+        """Stream an ad-hoc query over SSE, yielding `(event_name, payload)`.
+
+        Yields `status` events while the workflow runs, optionally a `sql`
+        event, then exactly one terminal `result` / `clarification` / `error`
+        event. Raises `QueryStreamUnsupported` when the backend predates the
+        streaming endpoint (404/405 before any event) so callers can fall
+        back to the sync path — no server-side work has started at that
+        point. The per-read timeout resets on every received event.
+        """
+        with self._client.stream(
+            "POST",
+            f"{self._base}/query/stream",
+            json=self._query_body(question, thread_id),
+            headers={"Accept": "text/event-stream"},
+            timeout=httpx.Timeout(_QUERY_TIMEOUT, connect=10.0),
+        ) as resp:
+            if resp.status_code in (404, 405):
+                raise QueryStreamUnsupported()
+            if resp.status_code >= 400:
+                resp.read()
+                resp.raise_for_status()
+
+            event_name: str | None = None
+            data_lines: list[str] = []
+            for line in resp.iter_lines():
+                if line == "":
+                    if event_name and data_lines:
+                        yield event_name, json.loads("\n".join(data_lines))
+                    event_name = None
+                    data_lines = []
+                elif line.startswith("event:"):
+                    event_name = line[len("event:"):].strip()
+                elif line.startswith("data:"):
+                    data_lines.append(line[len("data:"):].lstrip())
+                # SSE comments (":") and unknown fields are ignored.
 
     def root_cause_tree(
         self,

--- a/src/qluent_cli/formatters/__init__.py
+++ b/src/qluent_cli/formatters/__init__.py
@@ -10,6 +10,7 @@ from qluent_cli.formatters.comparison import format_comparison
 from qluent_cli.formatters.elasticity import format_elasticity
 from qluent_cli.formatters.evaluation import format_evaluation, format_levers
 from qluent_cli.formatters.investigation import format_investigation
+from qluent_cli.formatters.query import format_query_clarification, format_query_result
 from qluent_cli.formatters.rca import format_root_cause
 from qluent_cli.formatters.trees import format_tree_detail, format_tree_list
 from qluent_cli.formatters.trend import format_trend
@@ -22,6 +23,8 @@ __all__ = [
     "format_investigation",
     "format_levers",
     "format_period_label",
+    "format_query_clarification",
+    "format_query_result",
     "format_root_cause",
     "format_tree_detail",
     "format_tree_list",

--- a/src/qluent_cli/formatters/query.py
+++ b/src/qluent_cli/formatters/query.py
@@ -1,0 +1,105 @@
+"""Formatter for ad-hoc natural-language query results."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from qluent_cli.query_contracts import QueryContract
+
+
+_MAX_TABLE_ROWS = 20
+_MAX_CELL_WIDTH = 40
+
+
+def _fmt_cell(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, float):
+        text = f"{value:,.2f}".rstrip("0").rstrip(".")
+    elif isinstance(value, int) and not isinstance(value, bool):
+        text = f"{value:,}"
+    else:
+        text = str(value)
+    if len(text) > _MAX_CELL_WIDTH:
+        text = text[: _MAX_CELL_WIDTH - 1] + "…"
+    return text
+
+
+def _format_table(columns: list[str], rows: list[dict[str, Any]]) -> list[str]:
+    cells = [[_fmt_cell(row.get(col)) for col in columns] for row in rows]
+    widths = [
+        max(len(col), *(len(r[i]) for r in cells)) if cells else len(col)
+        for i, col in enumerate(columns)
+    ]
+    lines = ["  " + "  ".join(col.ljust(widths[i]) for i, col in enumerate(columns))]
+    for row in cells:
+        lines.append("  " + "  ".join(v.ljust(widths[i]) for i, v in enumerate(row)))
+    return lines
+
+
+def format_query_result(
+    contract: QueryContract, *, show_sql: bool = True, max_rows: int = _MAX_TABLE_ROWS
+) -> str:
+    """Human-readable rendering of a successful query contract."""
+    lines: list[str] = []
+
+    answer = contract.get("answer")
+    if answer:
+        lines.append(str(answer).strip())
+
+    columns = contract.get("columns") or []
+    data = contract.get("data") or []
+    row_count = contract.get("row_count")
+    total = row_count if isinstance(row_count, int) else len(data)
+
+    if columns and data:
+        if lines:
+            lines.append("")
+        lines.extend(_format_table(list(columns), data[:max_rows]))
+        if total > min(len(data), max_rows):
+            shown = min(len(data), max_rows)
+            lines.append(
+                f"  (showing {shown} of {total:,} rows — full data:"
+                " --json-output or the download link)"
+            )
+
+    sql = contract.get("sql")
+    if sql and show_sql:
+        lines.append("")
+        lines.append(f"SQL: {sql}")
+
+    footer: list[str] = []
+    if total:
+        footer.append(f"Rows: {total:,}")
+    if contract.get("download_url"):
+        footer.append(f"Download: {contract['download_url']}")
+    if contract.get("google_sheets_url"):
+        footer.append(f"Sheets: {contract['google_sheets_url']}")
+    if footer:
+        lines.append("")
+        lines.append("   ".join(footer))
+
+    thread_id = contract.get("thread_id")
+    if thread_id:
+        lines.append(f"Thread: {thread_id} — follow up with:")
+        lines.append(f'  qluent query "<follow-up question>" --thread {thread_id}')
+
+    return "\n".join(lines) if lines else "No answer returned."
+
+
+def format_query_clarification(contract: QueryContract) -> str:
+    """Human-readable rendering of a clarification request."""
+    clarification = contract.get("clarification") or {}
+    lines = ["Clarification needed:"]
+    message = clarification.get("message") or contract.get("answer")
+    if message:
+        lines.append(f"  {message}")
+    for i, option in enumerate(clarification.get("options") or [], start=1):
+        lines.append(f"    {i}. {option}")
+
+    thread_id = contract.get("thread_id")
+    if thread_id:
+        lines.append("")
+        lines.append("Answer with:")
+        lines.append(f'  qluent query "<your answer>" --thread {thread_id}')
+    return "\n".join(lines)

--- a/src/qluent_cli/main.py
+++ b/src/qluent_cli/main.py
@@ -14,6 +14,7 @@ from qluent_cli.client import QluentClient
 from qluent_cli.config import load_config
 from qluent_cli.elasticity import elasticity
 from qluent_cli.formatters import format_tree_list
+from qluent_cli.query import query
 from qluent_cli.rca import rca
 from qluent_cli.suggestions import suggestions
 from qluent_cli.trees import trees
@@ -420,6 +421,7 @@ def setup(
 
 
 cli.add_command(trees)
+cli.add_command(query)
 cli.add_command(rca)
 cli.add_command(elasticity)
 cli.add_command(suggestions)
@@ -578,7 +580,7 @@ def _format_runs_table(records: list[Any]) -> str:
     "--command",
     "command_filter",
     default=None,
-    type=click.Choice(["trees investigate", "trees deep-dive"]),
+    type=click.Choice(["trees investigate", "trees deep-dive", "query"]),
     help="Filter by command kind.",
 )
 @click.option(
@@ -639,7 +641,7 @@ def runs_list(
     "--command",
     "command_filter",
     default=None,
-    type=click.Choice(["trees investigate", "trees deep-dive"]),
+    type=click.Choice(["trees investigate", "trees deep-dive", "query"]),
     help="When used with --last, filter by command kind.",
 )
 @click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")

--- a/src/qluent_cli/mcp_server.py
+++ b/src/qluent_cli/mcp_server.py
@@ -18,6 +18,7 @@ from qluent_cli.client import QluentClient
 from qluent_cli.client_configs import RcaParams
 from qluent_cli.config import QluentConfig, load_config
 from qluent_cli.elasticity import analyze_elasticity
+from qluent_cli.query_contracts import build_query_contract
 from qluent_cli.runs import run_investigation
 from qluent_cli.suggestions import build_suggestions
 from qluent_cli.utils import parse_filters
@@ -249,6 +250,35 @@ def _tool_definitions() -> list[dict[str, Any]]:
             },
         },
         {
+            "name": "qluent_query",
+            "description": (
+                "Ask an ad-hoc natural-language question against the project's data. "
+                "Runs the LLM query workflow (NL -> SQL -> execution) — non-deterministic, "
+                "may take minutes. Use for row-level or arbitrary questions not covered by "
+                "metric trees; prefer the deterministic tree tools when one fits. Pass "
+                "thread_id from a previous result to follow up or answer a clarification "
+                "(status = clarification_needed)."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "question": {
+                        "type": "string",
+                        "description": "The natural-language question to answer.",
+                    },
+                    "thread_id": {
+                        "type": "string",
+                        "description": (
+                            "Thread id from a previous qluent_query result for "
+                            "follow-ups or clarification answers."
+                        ),
+                    },
+                },
+                "required": ["question"],
+                "additionalProperties": False,
+            },
+        },
+        {
             "name": "qluent_suggestions",
             "description": (
                 "Return project-specific example questions and matching CLI commands "
@@ -409,6 +439,11 @@ async def _elasticity(client: QluentClient, config: QluentConfig, args: dict[str
     )
 
 
+async def _query(client: QluentClient, config: QluentConfig, args: dict[str, Any]) -> dict[str, Any]:
+    raw = client.query(args["question"], thread_id=args.get("thread_id"))
+    return build_query_contract(raw, config)
+
+
 async def _suggestions(client: QluentClient, _config: QluentConfig, args: dict[str, Any]) -> dict[str, Any]:
     trees_data = client.list_trees()
     items = build_suggestions(trees_data)
@@ -426,6 +461,7 @@ HANDLERS: dict[str, ToolHandler] = {
     "qluent_deep_dive": _deep_dive,
     "qluent_rca_analyze": _rca_analyze,
     "qluent_elasticity": _elasticity,
+    "qluent_query": _query,
     "qluent_suggestions": _suggestions,
 }
 

--- a/src/qluent_cli/query.py
+++ b/src/qluent_cli/query.py
@@ -1,0 +1,158 @@
+"""Ad-hoc natural-language query command.
+
+Unlike the metric-tree commands, `qluent query` drives the backend's LLM
+workflow engine (NL -> SQL -> execution -> results). It streams SSE progress
+by default so multi-minute runs show stage updates; `--sync` uses the plain
+POST endpoint. Results are non-deterministic — the JSON contract marks them
+as such.
+"""
+
+from __future__ import annotations
+
+import click
+import httpx
+
+from qluent_cli import sessions
+from qluent_cli.client import QluentClient, QueryStreamUnsupported
+from qluent_cli.config import QluentConfig, load_config
+from qluent_cli.formatters import format_query_clarification, format_query_result
+from qluent_cli.output import echo_status
+from qluent_cli.query_contracts import (
+    STATUS_CLARIFICATION,
+    STATUS_OK,
+    QueryContract,
+    build_query_contract,
+)
+from qluent_cli.rendering import Result, render
+
+
+def _persist_run_safely(**kwargs):
+    try:
+        return sessions.record_run(**kwargs)
+    except Exception as exc:
+        click.echo(f"Warning: failed to persist run: {exc}", err=True)
+        return None
+
+
+def _heartbeat(_stage: str, elapsed: float) -> None:
+    echo_status(f"[qluent] awaiting response... ({int(elapsed)}s)")
+
+
+def _run_streaming(
+    client: QluentClient,
+    config: QluentConfig,
+    question: str,
+    thread_id: str | None,
+) -> QueryContract:
+    sql: str | None = None
+    terminal: tuple[str, dict] | None = None
+    thread_seen: str | None = None
+    try:
+        for event, payload in client.iter_query_events(question, thread_id=thread_id):
+            if event == "status":
+                message = payload.get("message")
+                if message:
+                    echo_status(f"[qluent] {message}")
+                thread_seen = payload.get("thread_id") or thread_seen
+            elif event == "sql":
+                sql = payload.get("sql")
+            elif event in ("result", "clarification", "error"):
+                terminal = (event, payload)
+                break
+    except (httpx.ReadTimeout, httpx.RemoteProtocolError) as exc:
+        hint = f" on thread {thread_seen}" if thread_seen else ""
+        raise click.ClickException(
+            f"Stream interrupted ({type(exc).__name__}). The query may still "
+            f"complete server-side — re-run to retry{hint}."
+        ) from exc
+
+    if terminal is None:
+        raise click.ClickException("Stream ended without a result — re-run to retry.")
+    event, payload = terminal
+    return build_query_contract(payload, config, event=event, sql=sql)
+
+
+@click.command()
+@click.argument("question")
+@click.option(
+    "--thread",
+    "thread_id",
+    default=None,
+    help="Thread id from a previous query — continues that conversation "
+    "(also used to answer clarification questions).",
+)
+@click.option(
+    "--sync",
+    "use_sync",
+    is_flag=True,
+    help="Use the synchronous endpoint instead of streaming progress.",
+)
+@click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
+def query(question: str, thread_id: str | None, use_sync: bool, as_json: bool) -> None:
+    """Ask an ad-hoc natural-language question against your data.
+
+    Runs the backend's LLM query workflow (NL -> SQL -> execution). Use this
+    for row-level or arbitrary questions the metric trees don't cover; it is
+    non-deterministic and can take minutes. Follow up (or answer a
+    clarification) by re-running with --thread <thread_id>.
+    """
+    config = load_config()
+    client = QluentClient(config)
+
+    try:
+        if use_sync:
+            raw = client.query(question, thread_id=thread_id, progress_callback=_heartbeat)
+            contract = build_query_contract(raw, config)
+        else:
+            try:
+                contract = _run_streaming(client, config, question, thread_id)
+            except QueryStreamUnsupported:
+                echo_status(
+                    "[qluent] backend does not support streaming; using sync endpoint"
+                )
+                raw = client.query(
+                    question, thread_id=thread_id, progress_callback=_heartbeat
+                )
+                contract = build_query_contract(raw, config)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 429:
+            raise click.ClickException(
+                "Rate limited by the API — wait a moment and retry."
+            ) from exc
+        raise click.ClickException(
+            f"API error {exc.response.status_code}: {exc.response.text[:500]}"
+        ) from exc
+
+    status = contract.get("status")
+    if status == STATUS_OK:
+        record = _persist_run_safely(
+            command=sessions.QUERY_COMMAND,
+            tree_id=None,
+            period_start=None,
+            period_end=None,
+            comparison_start=None,
+            comparison_end=None,
+            profile=f"{config.user_email}@{config.api_url}",
+            client_safe=config.client_safe,
+            args={"question": question, "thread": thread_id, "sync": use_sync},
+            payload=contract,
+        )
+
+        def _human() -> str:
+            text = format_query_result(contract, show_sql=not config.client_safe)
+            if record:
+                text = f"{text}\n\nrun_id: {record.run_id} (saved)"
+            return text
+
+        render(Result(json_payload=contract, human=_human), as_json=as_json)
+    elif status == STATUS_CLARIFICATION:
+        render(
+            Result(
+                json_payload=contract,
+                human=lambda: format_query_clarification(contract),
+            ),
+            as_json=as_json,
+        )
+    else:
+        code = contract.get("error_code") or "QUERY_FAILED"
+        raise click.ClickException(f"{code}: {contract.get('error') or 'query failed'}")

--- a/src/qluent_cli/query_contracts.py
+++ b/src/qluent_cli/query_contracts.py
@@ -1,0 +1,145 @@
+"""Stable JSON contract for ad-hoc natural-language queries.
+
+Unlike the metric-tree contracts, these results come from the backend's LLM
+workflow (NL -> SQL -> execution), so the contract is explicitly marked
+non-deterministic. The builder is the single normalization seam for the two
+wire shapes the backend emits:
+
+- the sync ``POST /query/`` response (``explanation``, nested
+  ``clarification: {message, questions}``), and
+- the SSE terminal events from ``POST /query/stream`` (``result`` uses
+  ``explanation`` but carries ``sql`` in a separate event; ``clarification``
+  is flat ``{message, options}``; ``error`` is flat).
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+from qluent_cli.config import QluentConfig
+from qluent_cli.contract_helpers import ProjectContext, Provenance
+
+
+QUERY_SCHEMA_VERSION = "qluent.query.v1"
+
+STATUS_OK = "ok"
+STATUS_CLARIFICATION = "clarification_needed"
+STATUS_ERROR = "error"
+
+
+class QueryClarification(TypedDict):
+    message: str
+    options: list[str]
+
+
+class QueryContract(TypedDict, total=False):
+    schema_version: str
+    contract_kind: str
+    deterministic: bool
+    status: str
+    question: str | None
+    answer: str | None
+    sql: str | None
+    columns: list[str] | None
+    data: list[dict[str, Any]] | None
+    row_count: int | None
+    truncated: bool
+    download_url: str | None
+    google_sheets_url: str | None
+    thread_id: str | None
+    message_id: str | None
+    clarification: QueryClarification | None
+    error_code: str | None
+    error: str | None
+    project_context: ProjectContext
+    provenance: Provenance
+
+
+def _normalize_clarification(
+    raw: dict[str, Any], *, event: str | None
+) -> QueryClarification | None:
+    if event == "clarification":
+        return {
+            "message": str(raw.get("message") or ""),
+            "options": list(raw.get("options") or []),
+        }
+    nested = raw.get("clarification")
+    if isinstance(nested, dict):
+        return {
+            "message": str(nested.get("message") or ""),
+            "options": list(nested.get("options") or nested.get("questions") or []),
+        }
+    return None
+
+
+def _derive_status(raw: dict[str, Any], clarification: QueryClarification | None) -> str:
+    if raw.get("success"):
+        return STATUS_OK
+    if clarification is not None or raw.get("error_code") == "CLARIFICATION_NEEDED":
+        return STATUS_CLARIFICATION
+    return STATUS_ERROR
+
+
+def build_query_contract(
+    raw: dict[str, Any],
+    config: QluentConfig,
+    *,
+    event: str | None = None,
+    sql: str | None = None,
+) -> QueryContract:
+    """Normalize a query response (sync body or SSE terminal event payload).
+
+    ``event`` is the SSE event name when the payload came off the stream
+    (``result`` / ``clarification`` / ``error``); ``None`` means the sync
+    response body. ``sql`` carries the stream's separate ``sql`` event, which
+    wins over any inline field.
+    """
+    clarification = _normalize_clarification(raw, event=event)
+    if event == "clarification":
+        status = STATUS_CLARIFICATION
+    elif event == "error":
+        status = STATUS_ERROR
+    elif event == "result":
+        status = STATUS_OK if raw.get("success", True) else STATUS_ERROR
+    else:
+        status = _derive_status(raw, clarification)
+
+    data = raw.get("data")
+    row_count = raw.get("row_count")
+    truncated = bool(
+        isinstance(row_count, int) and isinstance(data, list) and row_count > len(data)
+    )
+
+    project_context: ProjectContext = {
+        "project_uuid": config.project_uuid,
+        "user_email": config.user_email,
+        "api_url": config.api_url,
+        "client_safe": config.client_safe,
+    }
+    prov: Provenance = {
+        "source": "nl_query",
+        "project_uuid": config.project_uuid,
+    }
+
+    return {
+        "schema_version": QUERY_SCHEMA_VERSION,
+        "contract_kind": "nl_query",
+        "deterministic": False,
+        "status": status,
+        "question": raw.get("question"),
+        "answer": raw.get("explanation") or raw.get("answer"),
+        "sql": sql if sql is not None else raw.get("sql"),
+        "columns": raw.get("columns"),
+        "data": data,
+        "row_count": row_count,
+        "truncated": truncated,
+        "download_url": raw.get("download_url"),
+        "google_sheets_url": raw.get("google_sheets_url"),
+        "thread_id": raw.get("thread_id"),
+        "message_id": raw.get("message_id"),
+        "clarification": clarification,
+        "error_code": raw.get("error_code"),
+        "error": raw.get("error"),
+        "project_context": project_context,
+        "provenance": prov,
+    }

--- a/src/qluent_cli/sessions.py
+++ b/src/qluent_cli/sessions.py
@@ -22,7 +22,8 @@ from qluent_cli import config as _config_module
 
 INVESTIGATE_COMMAND = "trees investigate"
 DEEP_DIVE_COMMAND = "trees deep-dive"
-KNOWN_COMMANDS = (INVESTIGATE_COMMAND, DEEP_DIVE_COMMAND)
+QUERY_COMMAND = "query"
+KNOWN_COMMANDS = (INVESTIGATE_COMMAND, DEEP_DIVE_COMMAND, QUERY_COMMAND)
 
 
 # Crockford base32 (no I, L, O, U) — gives a time-sortable, unambiguous ID.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import json
+
 import click
 import httpx
 import pytest
 
-from qluent_cli.client import QluentClient, _RetryTransport
+from qluent_cli.client import QluentClient, QueryStreamUnsupported, _RetryTransport
 from qluent_cli.config import QluentConfig
 
 
@@ -464,3 +466,113 @@ def test_retry_log_suppressed_by_click_quiet(capsys, monkeypatch):
     with click.Context(click.Command("qluent"), obj={"quiet": True}):
         _default_log(1, 3, "502", 0.5)
     assert capsys.readouterr().err == ""
+
+
+def _make_query_client(handler) -> QluentClient:
+    """Build a QluentClient backed by a MockTransport for wire-level tests."""
+    config = QluentConfig(
+        api_key="qk_test",
+        api_url="https://api.example.com",
+        project_uuid="project-123",
+        user_email="user@example.com",
+    )
+    client = QluentClient(config)
+    client._client = httpx.Client(
+        headers={"X-API-Key": "qk_test"},
+        transport=httpx.MockTransport(handler),
+    )
+    return client
+
+
+def test_query_posts_question_and_thread():
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["json"] = json.loads(request.content)
+        return httpx.Response(200, json={"success": True, "thread_id": "th_1"})
+
+    client = _make_query_client(handler)
+    result = client.query("top customers?", thread_id="th_0")
+
+    assert result == {"success": True, "thread_id": "th_1"}
+    assert captured["url"] == "https://api.example.com/api/v1/project/project-123/query/"
+    assert captured["json"] == {
+        "question": "top customers?",
+        "user_email": "user@example.com",
+        "thread_id": "th_0",
+    }
+
+
+def test_query_omits_thread_id_when_absent():
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["json"] = json.loads(request.content)
+        return httpx.Response(200, json={"success": True})
+
+    client = _make_query_client(handler)
+    client.query("q")
+
+    assert "thread_id" not in captured["json"]
+
+
+def test_query_returns_422_clarification_payload_without_raising():
+    payload = {
+        "success": False,
+        "thread_id": "th_2",
+        "error_code": "CLARIFICATION_NEEDED",
+        "clarification": {"message": "Which one?", "questions": ["A", "B"]},
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(422, json=payload)
+
+    client = _make_query_client(handler)
+
+    assert client.query("q") == payload
+
+
+def test_iter_query_events_parses_sse_frames():
+    body = (
+        b'event: status\ndata: {"message": "Starting...", "request_id": "r1"}\n\n'
+        b": keepalive comment\n\n"
+        b'event: status\ndata: {"message": "Generating SQL", "stage": "sql_generation"}\n\n'
+        b'event: sql\ndata: {"sql": "SELECT 1"}\n\n'
+        b'event: result\ndata: {"success": true, "thread_id": "th_1", "data": []}\n\n'
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert str(request.url).endswith("/query/stream")
+        assert json.loads(request.content)["question"] == "q"
+        return httpx.Response(
+            200, content=body, headers={"Content-Type": "text/event-stream"}
+        )
+
+    client = _make_query_client(handler)
+    events = list(client.iter_query_events("q"))
+
+    assert [name for name, _ in events] == ["status", "status", "sql", "result"]
+    assert events[0][1] == {"message": "Starting...", "request_id": "r1"}
+    assert events[2][1] == {"sql": "SELECT 1"}
+    assert events[3][1]["thread_id"] == "th_1"
+
+
+def test_iter_query_events_raises_stream_unsupported_on_404():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"detail": "Not Found"})
+
+    client = _make_query_client(handler)
+
+    with pytest.raises(QueryStreamUnsupported):
+        list(client.iter_query_events("q"))
+
+
+def test_iter_query_events_raises_http_error_on_other_statuses():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"detail": "boom"})
+
+    client = _make_query_client(handler)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        list(client.iter_query_events("q"))

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -113,6 +113,20 @@ class FakeClient:
         )
         return {"tree_id": tree_id}
 
+    def query(self, question, *, thread_id=None, progress_callback=None):
+        self.calls.append(("query", (question,), {"thread_id": thread_id}))
+        return {
+            "success": True,
+            "thread_id": "th_1",
+            "message_id": "msg_1",
+            "question": question,
+            "explanation": "Answer.",
+            "sql": "SELECT 1",
+            "data": [{"a": 1}],
+            "columns": ["a"],
+            "row_count": 1,
+        }
+
 
 def test_tool_definitions_cover_acceptance_criteria_tools():
     names = {tool["name"] for tool in _tool_definitions()}
@@ -124,6 +138,7 @@ def test_tool_definitions_cover_acceptance_criteria_tools():
         "qluent_deep_dive",
         "qluent_rca_analyze",
         "qluent_elasticity",
+        "qluent_query",
         "qluent_suggestions",
     }
     assert names == set(HANDLERS)
@@ -331,6 +346,28 @@ def test_dispatch_elasticity_attaches_provenance():
     assert result["provenance"]["project_uuid"] == "project-123"
     assert result["outcome"] == "net_revenue"
     assert result["lever"] == "orders"
+
+
+def test_dispatch_query_returns_contract_and_forwards_thread_id():
+    client = FakeClient()
+
+    result = asyncio.run(
+        dispatch_tool(
+            "qluent_query",
+            {"question": "top customers?", "thread_id": "th_0"},
+            client=client,
+            config=CONFIG,
+        )
+    )
+
+    assert client.calls == [("query", ("top customers?",), {"thread_id": "th_0"})]
+    assert result["schema_version"] == "qluent.query.v1"
+    assert result["contract_kind"] == "nl_query"
+    assert result["deterministic"] is False
+    assert result["status"] == "ok"
+    assert result["answer"] == "Answer."
+    assert result["sql"] == "SELECT 1"
+    assert result["thread_id"] == "th_1"
 
 
 def test_dispatch_suggestions_filters_by_tree_id():

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from click.testing import CliRunner
+
+from qluent_cli.config import QluentConfig
+from qluent_cli.main import cli
+from qluent_cli.query_contracts import QUERY_SCHEMA_VERSION
+
+
+def _config(**overrides: Any) -> QluentConfig:
+    defaults = dict(
+        api_key="qk_test",
+        api_url="https://api.example.com",
+        project_uuid="project-123",
+        user_email="user@example.com",
+    )
+    defaults.update(overrides)
+    return QluentConfig(**defaults)
+
+
+RESULT_EVENT = {
+    "success": True,
+    "thread_id": "th_1",
+    "message_id": "msg_1",
+    "question": "top customers?",
+    "explanation": "Acme leads on revenue.",
+    "data": [
+        {"customer": "Acme", "revenue": 120340},
+        {"customer": "Globex", "revenue": 98110},
+    ],
+    "columns": ["customer", "revenue"],
+    "row_count": 2,
+    "download_url": "https://example.com/dl",
+    "google_sheets_url": None,
+}
+
+
+class FakeStreamingClient:
+    """Streams a canned event sequence; records constructor + call args."""
+
+    events: list[tuple[str, dict[str, Any]]] = []
+    calls: list[dict[str, Any]] = []
+
+    def __init__(self, config: QluentConfig) -> None:
+        self.config = config
+
+    def iter_query_events(self, question: str, *, thread_id: str | None = None):
+        type(self).calls.append({"question": question, "thread_id": thread_id})
+        yield from type(self).events
+
+    def query(self, question: str, *, thread_id: str | None = None, progress_callback=None):
+        type(self).calls.append(
+            {"question": question, "thread_id": thread_id, "sync": True}
+        )
+        raise AssertionError("sync path should not be used in this test")
+
+
+def _wire(monkeypatch, client_cls, config: QluentConfig | None = None) -> None:
+    monkeypatch.setattr("qluent_cli.query.load_config", lambda: config or _config())
+    monkeypatch.setattr("qluent_cli.query.QluentClient", client_cls)
+    client_cls.calls = []
+
+
+def test_query_streaming_success_renders_human_output(monkeypatch, isolated_config):
+    FakeStreamingClient.events = [
+        ("status", {"message": "Generating SQL", "stage": "sql_generation"}),
+        ("sql", {"sql": "SELECT customer, revenue FROM t"}),
+        ("result", dict(RESULT_EVENT)),
+    ]
+    _wire(monkeypatch, FakeStreamingClient)
+
+    result = CliRunner().invoke(cli, ["query", "top customers?"])
+
+    assert result.exit_code == 0, result.output
+    assert "Acme leads on revenue." in result.output
+    assert "customer" in result.output
+    assert "Acme" in result.output
+    assert "SQL: SELECT customer, revenue FROM t" in result.output
+    assert "Download: https://example.com/dl" in result.output
+    assert "Thread: th_1" in result.output
+    assert "--thread th_1" in result.output
+    assert "run_id:" in result.output
+
+
+def test_query_streaming_persists_run(monkeypatch, isolated_config):
+    FakeStreamingClient.events = [("result", dict(RESULT_EVENT))]
+    _wire(monkeypatch, FakeStreamingClient)
+
+    result = CliRunner().invoke(cli, ["query", "top customers?"])
+    assert result.exit_code == 0, result.output
+
+    from qluent_cli import sessions
+
+    record = sessions.find_last_run(command=sessions.QUERY_COMMAND)
+    assert record is not None
+    assert record.tree_id is None
+    stored = record.load()
+    assert stored["args"]["question"] == "top customers?"
+    assert stored["result"]["schema_version"] == QUERY_SCHEMA_VERSION
+
+
+def test_query_json_output_emits_contract(monkeypatch, isolated_config):
+    FakeStreamingClient.events = [
+        ("sql", {"sql": "SELECT 1"}),
+        ("result", dict(RESULT_EVENT)),
+    ]
+    _wire(monkeypatch, FakeStreamingClient)
+
+    result = CliRunner().invoke(cli, ["query", "top customers?", "--json-output"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == QUERY_SCHEMA_VERSION
+    assert payload["status"] == "ok"
+    assert payload["deterministic"] is False
+    assert payload["sql"] == "SELECT 1"
+    assert payload["answer"] == "Acme leads on revenue."
+
+
+def test_query_clarification_renders_options_and_exits_zero(
+    monkeypatch, isolated_config
+):
+    FakeStreamingClient.events = [
+        (
+            "clarification",
+            {
+                "success": False,
+                "thread_id": "th_9",
+                "message_id": "msg_9",
+                "question": "revenue?",
+                "message": "Which revenue do you mean?",
+                "options": ["Gross revenue", "Net revenue"],
+            },
+        ),
+    ]
+    _wire(monkeypatch, FakeStreamingClient)
+
+    result = CliRunner().invoke(cli, ["query", "revenue?"])
+
+    assert result.exit_code == 0, result.output
+    assert "Clarification needed:" in result.output
+    assert "Which revenue do you mean?" in result.output
+    assert "1. Gross revenue" in result.output
+    assert "--thread th_9" in result.output
+
+
+def test_query_error_event_exits_nonzero_with_code(monkeypatch, isolated_config):
+    FakeStreamingClient.events = [
+        ("error", {"success": False, "error_code": "EXECUTION_ERROR", "error": "boom"}),
+    ]
+    _wire(monkeypatch, FakeStreamingClient)
+
+    result = CliRunner().invoke(cli, ["query", "q"])
+
+    assert result.exit_code != 0
+    assert "EXECUTION_ERROR: boom" in result.output
+
+
+def test_query_thread_option_is_forwarded(monkeypatch, isolated_config):
+    FakeStreamingClient.events = [("result", dict(RESULT_EVENT))]
+    _wire(monkeypatch, FakeStreamingClient)
+
+    result = CliRunner().invoke(cli, ["query", "follow up", "--thread", "th_1"])
+
+    assert result.exit_code == 0, result.output
+    assert FakeStreamingClient.calls[0]["thread_id"] == "th_1"
+
+
+def test_query_sync_flag_uses_sync_endpoint(monkeypatch, isolated_config):
+    class FakeSyncClient:
+        calls: list[dict[str, Any]] = []
+
+        def __init__(self, config: QluentConfig) -> None:
+            pass
+
+        def iter_query_events(self, *args: Any, **kwargs: Any):
+            raise AssertionError("streaming path should not be used with --sync")
+
+        def query(self, question, *, thread_id=None, progress_callback=None):
+            type(self).calls.append({"question": question, "thread_id": thread_id})
+            raw = dict(RESULT_EVENT)
+            raw["sql"] = "SELECT 3"
+            return raw
+
+    _wire(monkeypatch, FakeSyncClient)
+
+    result = CliRunner().invoke(cli, ["query", "q", "--sync"])
+
+    assert result.exit_code == 0, result.output
+    assert FakeSyncClient.calls == [{"question": "q", "thread_id": None}]
+    assert "SQL: SELECT 3" in result.output
+
+
+def test_query_falls_back_to_sync_when_stream_unsupported(
+    monkeypatch, isolated_config
+):
+    from qluent_cli.client import QueryStreamUnsupported
+
+    class FakeFallbackClient:
+        calls: list[str] = []
+
+        def __init__(self, config: QluentConfig) -> None:
+            pass
+
+        def iter_query_events(self, question, *, thread_id=None):
+            type(self).calls.append("stream")
+            raise QueryStreamUnsupported()
+            yield  # pragma: no cover
+
+        def query(self, question, *, thread_id=None, progress_callback=None):
+            type(self).calls.append("sync")
+            return dict(RESULT_EVENT)
+
+    _wire(monkeypatch, FakeFallbackClient)
+
+    result = CliRunner().invoke(cli, ["query", "q"])
+
+    assert result.exit_code == 0, result.output
+    assert FakeFallbackClient.calls == ["stream", "sync"]
+    assert "Acme leads on revenue." in result.output
+
+
+def test_query_truncation_footer_shown_for_large_row_counts(
+    monkeypatch, isolated_config
+):
+    big = dict(RESULT_EVENT)
+    big["data"] = [{"customer": f"c{i}", "revenue": i} for i in range(30)]
+    big["row_count"] = 4200
+    FakeStreamingClient.events = [("result", big)]
+    _wire(monkeypatch, FakeStreamingClient)
+
+    result = CliRunner().invoke(cli, ["query", "all customers"])
+
+    assert result.exit_code == 0, result.output
+    assert "showing 20 of 4,200 rows" in result.output
+
+
+def test_query_client_safe_hides_sql_in_human_output(monkeypatch, isolated_config):
+    FakeStreamingClient.events = [
+        ("sql", {"sql": "SELECT secret FROM t"}),
+        ("result", dict(RESULT_EVENT)),
+    ]
+    _wire(monkeypatch, FakeStreamingClient, config=_config(client_safe=True))
+
+    result = CliRunner().invoke(cli, ["query", "q"])
+
+    assert result.exit_code == 0, result.output
+    assert "SELECT secret" not in result.output
+
+    # JSON output keeps the SQL and flags client-safe mode for agents.
+    FakeStreamingClient.events = [
+        ("sql", {"sql": "SELECT secret FROM t"}),
+        ("result", dict(RESULT_EVENT)),
+    ]
+    result = CliRunner().invoke(cli, ["query", "q", "--json-output"])
+    payload = json.loads(result.stdout)
+    assert payload["sql"] == "SELECT secret FROM t"
+    assert payload["project_context"]["client_safe"] is True
+
+
+def test_runs_list_accepts_query_command_filter(monkeypatch, isolated_config):
+    FakeStreamingClient.events = [("result", dict(RESULT_EVENT))]
+    _wire(monkeypatch, FakeStreamingClient)
+
+    assert CliRunner().invoke(cli, ["query", "q"]).exit_code == 0
+
+    result = CliRunner().invoke(
+        cli, ["runs", "list", "--command", "query", "--json-output"]
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert len(payload) == 1
+    assert payload[0]["command"] == "query"

--- a/tests/test_query_contracts.py
+++ b/tests/test_query_contracts.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from qluent_cli.config import QluentConfig
+from qluent_cli.query_contracts import (
+    QUERY_SCHEMA_VERSION,
+    STATUS_CLARIFICATION,
+    STATUS_ERROR,
+    STATUS_OK,
+    build_query_contract,
+)
+
+
+CONFIG = QluentConfig(
+    api_key="qk_test",
+    api_url="https://api.example.com",
+    project_uuid="project-123",
+    user_email="user@example.com",
+)
+
+
+def test_sync_success_normalizes_explanation_to_answer():
+    raw = {
+        "success": True,
+        "thread_id": "th_1",
+        "message_id": "msg_1",
+        "question": "top customers?",
+        "sql": "SELECT 1",
+        "explanation": "Here are the top customers.",
+        "data": [{"customer": "Acme", "revenue": 100}],
+        "columns": ["customer", "revenue"],
+        "row_count": 1,
+        "download_url": "https://example.com/dl",
+    }
+
+    contract = build_query_contract(raw, CONFIG)
+
+    assert contract["schema_version"] == QUERY_SCHEMA_VERSION
+    assert contract["contract_kind"] == "nl_query"
+    assert contract["deterministic"] is False
+    assert contract["status"] == STATUS_OK
+    assert contract["answer"] == "Here are the top customers."
+    assert contract["sql"] == "SELECT 1"
+    assert contract["truncated"] is False
+    assert contract["thread_id"] == "th_1"
+    assert contract["project_context"]["project_uuid"] == "project-123"
+    assert contract["provenance"]["source"] == "nl_query"
+
+
+def test_sync_truncation_derived_from_row_count():
+    raw = {
+        "success": True,
+        "thread_id": "th_1",
+        "message_id": "msg_1",
+        "question": "q",
+        "data": [{"a": 1}, {"a": 2}],
+        "columns": ["a"],
+        "row_count": 5000,
+    }
+
+    contract = build_query_contract(raw, CONFIG)
+
+    assert contract["truncated"] is True
+
+
+def test_sync_clarification_normalizes_nested_questions_to_options():
+    raw = {
+        "success": False,
+        "thread_id": "th_2",
+        "message_id": "msg_2",
+        "question": "revenue?",
+        "clarification": {
+            "message": "Which revenue do you mean?",
+            "questions": ["Gross revenue", "Net revenue"],
+        },
+        "error_code": "CLARIFICATION_NEEDED",
+    }
+
+    contract = build_query_contract(raw, CONFIG)
+
+    assert contract["status"] == STATUS_CLARIFICATION
+    assert contract["clarification"] == {
+        "message": "Which revenue do you mean?",
+        "options": ["Gross revenue", "Net revenue"],
+    }
+
+
+def test_stream_result_event_merges_separate_sql_event():
+    raw = {
+        "success": True,
+        "thread_id": "th_3",
+        "message_id": "msg_3",
+        "question": "q",
+        "explanation": "Answer.",
+        "data": [],
+        "columns": [],
+        "row_count": 0,
+    }
+
+    contract = build_query_contract(raw, CONFIG, event="result", sql="SELECT 2")
+
+    assert contract["status"] == STATUS_OK
+    assert contract["sql"] == "SELECT 2"
+    assert contract["answer"] == "Answer."
+
+
+def test_stream_clarification_event_uses_flat_options():
+    raw = {
+        "success": False,
+        "thread_id": "th_4",
+        "message_id": "msg_4",
+        "question": "q",
+        "message": "Need more detail.",
+        "options": ["Option A", "Option B"],
+    }
+
+    contract = build_query_contract(raw, CONFIG, event="clarification")
+
+    assert contract["status"] == STATUS_CLARIFICATION
+    assert contract["clarification"] == {
+        "message": "Need more detail.",
+        "options": ["Option A", "Option B"],
+    }
+    assert contract["thread_id"] == "th_4"
+
+
+def test_stream_error_event_maps_to_error_status():
+    raw = {"success": False, "error_code": "EXECUTION_ERROR", "error": "boom"}
+
+    contract = build_query_contract(raw, CONFIG, event="error")
+
+    assert contract["status"] == STATUS_ERROR
+    assert contract["error_code"] == "EXECUTION_ERROR"
+    assert contract["error"] == "boom"


### PR DESCRIPTION
Exposes the backend's LLM query workflow (NL -> SQL -> execution) through
the CLI, at parity with the metric-tree surface:

- `qluent query "<question>" [--thread <id>] [--sync] [--json-output]`:
  streams SSE progress by default (plain-httpx SSE parser, per-read 300s
  timeout), falls back to the sync endpoint when the backend predates
  /query/stream. 422 clarification responses are valid outcomes (exit 0)
  rendered with options and a --thread answer hint.
- `qluent.query.v1` JSON contract (query_contracts.py) normalizes the sync
  and stream wire shapes (explanation/answer, nested questions vs flat
  options, separate sql event) and is explicitly marked non-deterministic.
- Human formatter with truncated result table, SQL (suppressed client-side
  in client-safe mode), download/Sheets links, and thread follow-up hint.
- Successful runs persist via sessions (command="query") so thread_ids are
  recoverable through `qluent runs show --last --command query`.
- New `qluent_query` MCP tool returning the same contract.
- agent_instructions.md documents when to use query vs the deterministic
  tree commands.

## Verification
- `uv run pytest` — 251 passed (30 new tests: SSE parsing, 422 clarification passthrough, contract normalization, CLI UX, MCP dispatch, runs filter).
- `qluent query --help` / root help registration smoke-checked.

Companion PR in qluent-plugin-cc adds the `/qluent:query` slash command and analyst routing on top of this command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)