### PR TITLE
chore: bump version to 0.1.16

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qluent/cli",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Install the Qluent CLI",
   "license": "UNLICENSED",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qluent-cli"
-version = "0.1.15"
+version = "0.1.16"
 description = "CLI for Qluent metric tree analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/qluent_cli/__init__.py
+++ b/src/qluent_cli/__init__.py
@@ -1,3 +1,3 @@
 """Qluent CLI — metric tree analysis from the command line."""
 
-__version__ = "0.1.15"
+__version__ = "0.1.16"

--- a/uv.lock
+++ b/uv.lock
@@ -672,7 +672,7 @@ wheels = [
 
 [[package]]
 name = "qluent-cli"
-version = "0.1.15"
+version = "0.1.16"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Bumps `@qluent/cli` from 0.1.15 → 0.1.16.

## Changes since v0.1.15
- Add \`qluent query\` — ad-hoc NL queries via the workflow query engine (#92)

## Version files updated
- \`pyproject.toml\`
- \`src/qluent_cli/__init__.py\`
- \`npm/package.json\`
- \`uv.lock\` (refreshed via \`uv lock\`)

## Test plan
- [ ] CI green on the PR
- [ ] After merge: tag \`v0.1.16\`, wait for binary build + release assets, then \`npm publish\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)