### PR TITLE
Default CLI login to production

### DIFF
--- a/src/qluent_cli/config.py
+++ b/src/qluent_cli/config.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 
 CONFIG_DIR = Path.home() / ".qluent"
 CONFIG_FILE = CONFIG_DIR / "config.json"
-DEFAULT_API_URL = "https://api.app-development.qluent.com"
+DEFAULT_API_URL = "https://api.app.qluent.com"
 LOCAL_API_URL = "http://localhost:8001"
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -143,6 +143,10 @@ def test_api_url_to_ui_url_development():
     assert _api_url_to_ui_url("https://api.app-development.qluent.com") == "https://app-development.qluent.com"
 
 
+def test_api_url_to_ui_url_production():
+    assert _api_url_to_ui_url("https://api.app.qluent.com") == "https://app.qluent.com"
+
+
 def test_api_url_to_ui_url_development_trailing_slash():
     assert _api_url_to_ui_url("https://api.app-development.qluent.com/") == "https://app-development.qluent.com"
 


### PR DESCRIPTION
## Summary
- Change the public CLI default API URL from app-development to production.
- Bump the CLI/npm package version to `0.1.17` for the next release.
- Add coverage that the production API URL maps to the production UI login host.

## Why
`qluent login` and `qluent setup` currently fall back to `DEFAULT_API_URL`, which points users at the development environment. Production project URLs from app.qluent.com can fail or appear missing when the CLI authenticates against app-development.

## Release notes
After merge, tag the merge commit as `v0.1.17` to trigger `.github/workflows/qluent-cli-binaries.yml`, then publish `npm/` as `@qluent/cli@0.1.17` once the GitHub release assets are available.

## Validation
- `uv run pytest tests/test_config.py tests/test_login.py tests/test_setup.py tests/test_auth.py`
- `npm test`