### PR TITLE
Release 0.1.17

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qluent/cli",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Install the Qluent CLI",
   "license": "UNLICENSED",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qluent-cli"
-version = "0.1.16"
+version = "0.1.17"
 description = "CLI for Qluent metric tree analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/qluent_cli/__init__.py
+++ b/src/qluent_cli/__init__.py
@@ -1,3 +1,3 @@
 """Qluent CLI — metric tree analysis from the command line."""
 
-__version__ = "0.1.16"
+__version__ = "0.1.17"

--- a/uv.lock
+++ b/uv.lock
@@ -672,7 +672,7 @@ wheels = [
 
 [[package]]
 name = "qluent-cli"
-version = "0.1.16"
+version = "0.1.17"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bump Python CLI metadata to `0.1.17`.
- Bump npm wrapper package to `0.1.17`.
- Refresh `uv.lock` for the package version.

## Why
PR #94 fixed the default login target on `main`, but it merged before the version bump landed. This follow-up prepares the release version for the production-login fix.

## Release follow-up
After this merges:
1. Create and push tag `v0.1.17` on the merge commit. That triggers `.github/workflows/qluent-cli-binaries.yml` and publishes GitHub release assets.
2. Once release assets and signatures are available, publish `npm/` as `@qluent/cli@0.1.17`.

## Validation
- `uv run pytest tests/test_config.py tests/test_login.py tests/test_setup.py tests/test_auth.py`
- `npm test`