### PR TITLE
feat: qluent catalog + qluent plan commands, compose MCP tools

### DIFF
--- a/src/qluent_cli/agent_instructions.md
+++ b/src/qluent_cli/agent_instructions.md
@@ -21,6 +21,8 @@ qluent trees compare <tree_id> <tree_id> --period "last week"  # Side-by-side tr
 qluent trees investigate <tree_id> --period "last week"     # Validate + trend + evaluate + RCA bundle
 qluent rca analyze revenue --period "last week"             # Deterministic tree + segment RCA
 qluent query "<question>" [--thread <id>]                   # Ad-hoc NL question -> SQL -> results (LLM, non-deterministic)
+qluent catalog [--json-output]                              # Show the query catalog: the vocabulary + plan schema for `qluent plan`
+qluent plan '<QueryPlan JSON>' [--file <path>]              # Compile + run a typed QueryPlan (deterministic, catalog-checked)
 ```
 
 All commands support `--json-output` for raw JSON. The `trend` command supports `--as-of YYYY-MM-DD`
@@ -93,15 +95,33 @@ Use these rules:
 - Never parse saved tool-result temp files or write ad-hoc Python to extract values from prior bash output. Use the structured JSON from `investigate`, `evaluate`, or `levers` directly.
 - Do not rerun both JSON and non-JSON versions of the same qluent command unless the JSON is genuinely insufficient.
 
-## When to use `qluent query` vs metric-tree commands
+## When to use `qluent plan` / `qluent query` vs metric-tree commands
 
 The tree commands (`investigate`, `evaluate`, `trend`, `rca analyze`, ...) are
 deterministic, fast, and reproducible — always prefer them when the question maps
 to a tree's KPIs, child nodes, or declared dimensions ("why did revenue drop",
 trends, drivers, elasticity).
 
+`qluent plan` compiles a typed QueryPlan you author against the project's
+closed-world query catalog — deterministic (the same plan always produces the
+same SQL) and correct-by-construction (anything outside the catalog is rejected
+with a repairable message). Prefer it over `qluent query` for ad-hoc
+aggregations, breakdowns, filters and rankings whenever the catalog's
+bases/metrics/dimensions cover the question:
+
+- Run `qluent catalog --json-output` once per session; it returns the full
+  vocabulary and the QueryPlan JSON schema (`plan_schema`).
+- Author the plan (source -> filter_by -> group_by -> top_k / window) and
+  submit it with `qluent plan --file <path> --json-output`.
+- `status = plan_invalid` is a repair instruction, not a failure: fix the plan
+  from the error message and re-run. Only fall back to `qluent query` when the
+  catalog genuinely lacks the vocabulary (a column/metric that does not exist).
+- Before combining numbers across several plan results, check `grain` and
+  `metrics[*].summable`: only summable metrics (plain sums, row counts) may be
+  added across result sets — recompute averages, ratios and distinct counts.
+
 `qluent query` runs the backend's LLM query workflow (natural language -> generated
-SQL -> execution) and is for everything trees cannot answer:
+SQL -> execution) and is for everything neither trees nor the catalog can answer:
 
 - Row-level or entity-level questions ("top 10 customers by refunds", "list last
   week's failed orders").

--- a/src/qluent_cli/client.py
+++ b/src/qluent_cli/client.py
@@ -474,6 +474,44 @@ class QluentClient:
         resp.raise_for_status()
         return resp.json()
 
+    def get_query_catalog(self) -> dict[str, Any]:
+        """Fetch the project's closed-world query catalog + QueryPlan schema.
+
+        A 422 (project has no loadable query_catalog) is returned as a payload
+        so the caller can surface the backend's explanation.
+        """
+        resp = self._client.get(
+            f"{self._base}/query-catalog/",
+            params={"user_email": self._config.user_email},
+        )
+        if resp.status_code == 422:
+            return resp.json()
+        resp.raise_for_status()
+        return resp.json()
+
+    def execute_plan(
+        self,
+        plan: dict[str, Any],
+        *,
+        progress_callback: ProgressCallback | None = None,
+    ) -> dict[str, Any]:
+        """Compile and execute a typed QueryPlan via the compose endpoint.
+
+        A 422 response is a valid outcome (repairable compiler / scope error;
+        the caller owns the fix-and-retry loop) and is returned as a payload,
+        not raised.
+        """
+        resp = self._post_with_heartbeat(
+            f"{self._base}/query-plan/",
+            {"user_email": self._config.user_email, "plan": plan},
+            timeout=_QUERY_TIMEOUT,
+            progress_callback=progress_callback,
+        )
+        if resp.status_code == 422:
+            return resp.json()
+        resp.raise_for_status()
+        return resp.json()
+
     def iter_query_events(
         self,
         question: str,

--- a/src/qluent_cli/main.py
+++ b/src/qluent_cli/main.py
@@ -14,6 +14,7 @@ from qluent_cli.client import QluentClient
 from qluent_cli.config import load_config
 from qluent_cli.elasticity import elasticity
 from qluent_cli.formatters import format_tree_list
+from qluent_cli.plan import catalog, plan
 from qluent_cli.query import query
 from qluent_cli.rca import rca
 from qluent_cli.suggestions import suggestions
@@ -422,6 +423,8 @@ def setup(
 
 cli.add_command(trees)
 cli.add_command(query)
+cli.add_command(catalog)
+cli.add_command(plan)
 cli.add_command(rca)
 cli.add_command(elasticity)
 cli.add_command(suggestions)

--- a/src/qluent_cli/mcp_server.py
+++ b/src/qluent_cli/mcp_server.py
@@ -18,6 +18,7 @@ from qluent_cli.client import QluentClient
 from qluent_cli.client_configs import RcaParams
 from qluent_cli.config import QluentConfig, load_config
 from qluent_cli.elasticity import analyze_elasticity
+from qluent_cli.plan_contracts import build_catalog_contract, build_plan_contract
 from qluent_cli.query_contracts import build_query_contract
 from qluent_cli.runs import run_investigation
 from qluent_cli.suggestions import build_suggestions
@@ -279,6 +280,50 @@ def _tool_definitions() -> list[dict[str, Any]]:
             },
         },
         {
+            "name": "qluent_compose_catalog",
+            "description": (
+                "Fetch the project's closed-world query catalog: bases (with "
+                "columns), metrics (with the bases that can compute them), "
+                "relationships, derived dimensions and aliases — plus the "
+                "QueryPlan JSON schema (plan_schema) accepted by "
+                "qluent_compose_query. Fetch once per session; it is the whole "
+                "vocabulary needed to author plans."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "qluent_compose_query",
+            "description": (
+                "Compile and execute a typed QueryPlan against the project's "
+                "query catalog (see qluent_compose_catalog). Deterministic and "
+                "correct-by-construction: the same plan always produces the "
+                "same SQL, and anything outside the catalog is rejected with "
+                "status 'plan_invalid' and a repairable error message — fix "
+                "the plan and retry. Prefer this over qluent_query when the "
+                "catalog vocabulary covers the question. When combining "
+                "several results, aggregate early (group_by) and only add "
+                "metrics whose metadata marks them summable."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "plan": {
+                        "type": "object",
+                        "description": (
+                            "QueryPlan document; must satisfy the plan_schema "
+                            "from qluent_compose_catalog."
+                        ),
+                    },
+                },
+                "required": ["plan"],
+                "additionalProperties": False,
+            },
+        },
+        {
             "name": "qluent_suggestions",
             "description": (
                 "Return project-specific example questions and matching CLI commands "
@@ -453,6 +498,23 @@ async def _suggestions(client: QluentClient, _config: QluentConfig, args: dict[s
     return {"suggestions": items}
 
 
+async def _compose_catalog(
+    client: QluentClient, config: QluentConfig, _args: dict[str, Any]
+) -> dict[str, Any]:
+    raw = client.get_query_catalog()
+    return build_catalog_contract(raw, config)
+
+
+async def _compose_query(
+    client: QluentClient, config: QluentConfig, args: dict[str, Any]
+) -> dict[str, Any]:
+    plan = args.get("plan")
+    if not isinstance(plan, dict):
+        raise ValueError("'plan' must be a QueryPlan JSON object")
+    raw = client.execute_plan(plan)
+    return build_plan_contract(raw, config)
+
+
 HANDLERS: dict[str, ToolHandler] = {
     "qluent_list_trees": _list_trees,
     "qluent_get_tree": _get_tree,
@@ -462,6 +524,8 @@ HANDLERS: dict[str, ToolHandler] = {
     "qluent_rca_analyze": _rca_analyze,
     "qluent_elasticity": _elasticity,
     "qluent_query": _query,
+    "qluent_compose_catalog": _compose_catalog,
+    "qluent_compose_query": _compose_query,
     "qluent_suggestions": _suggestions,
 }
 

--- a/src/qluent_cli/plan.py
+++ b/src/qluent_cli/plan.py
@@ -1,0 +1,225 @@
+"""Composable query-plan commands: `qluent catalog` and `qluent plan`.
+
+The deterministic sibling of `qluent query`: instead of sending natural
+language through the backend's LLM workflow, the caller (typically an agent)
+authors a typed QueryPlan against the project's closed-world catalog and the
+backend compiles it to SQL. Unknown columns/metrics are rejected with a
+repairable message (status ``plan_invalid``) — fix the plan and re-run.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+import httpx
+
+from qluent_cli import sessions
+from qluent_cli.client import QluentClient
+from qluent_cli.config import QluentConfig, load_config
+from qluent_cli.formatters import format_query_result
+from qluent_cli.output import echo_status
+from qluent_cli.plan_contracts import (
+    STATUS_OK,
+    STATUS_PLAN_INVALID,
+    CatalogContract,
+    PlanContract,
+    build_catalog_contract,
+    build_plan_contract,
+)
+from qluent_cli.rendering import Result, render
+
+
+def _heartbeat(_stage: str, elapsed: float) -> None:
+    echo_status(f"[qluent] awaiting response... ({int(elapsed)}s)")
+
+
+def _persist_run_safely(**kwargs):
+    try:
+        return sessions.record_run(**kwargs)
+    except Exception as exc:
+        click.echo(f"Warning: failed to persist run: {exc}", err=True)
+        return None
+
+
+def _format_catalog(contract: CatalogContract) -> str:
+    """Compact human listing of the vocabulary a plan may use."""
+    catalog = contract.get("catalog") or {}
+    lines: list[str] = []
+
+    bases = catalog.get("bases") or {}
+    lines.append(f"bases ({len(bases)}):")
+    for name, base in sorted(bases.items()):
+        columns = base.get("columns") or []
+        lines.append(f"  {name}: {len(columns)} columns")
+
+    metrics = catalog.get("metrics") or {}
+    lines.append(f"metrics ({len(metrics)}):")
+    for name, metric_bases in sorted(metrics.items()):
+        on = f" [{', '.join(metric_bases)}]" if metric_bases else ""
+        lines.append(f"  {name}{on}")
+
+    relationships = catalog.get("relationships") or {}
+    if relationships:
+        lines.append(f"relationships ({len(relationships)}):")
+        for name, rel in sorted(relationships.items()):
+            lines.append(
+                f"  {name}: {rel.get('left_base')} {rel.get('cardinality')} "
+                f"{rel.get('right_base')}"
+            )
+
+    derived = catalog.get("derived_dimensions") or []
+    if derived:
+        lines.append(f"derived dimensions: {', '.join(derived)}")
+
+    lines.append("")
+    lines.append(
+        "Full vocabulary, aliases and the QueryPlan JSON schema: --json-output"
+    )
+    return "\n".join(lines)
+
+
+def _format_plan_result(contract: PlanContract, *, show_sql: bool) -> str:
+    """Table via the shared query formatter, plus the plan-specific metadata
+    an agent (or human) needs before combining results."""
+    text = format_query_result(contract, show_sql=show_sql)
+    extras: list[str] = []
+    grain = contract.get("grain")
+    if grain:
+        extras.append(f"grain: {', '.join(grain)}")
+    metrics = contract.get("metrics") or {}
+    non_summable = sorted(
+        name for name, info in metrics.items() if not info.get("summable", False)
+    )
+    if non_summable:
+        extras.append(
+            f"not summable across results: {', '.join(non_summable)} "
+            "(recompute instead of adding)"
+        )
+    if extras:
+        text = f"{text}\n\n" + "\n".join(extras)
+    return text
+
+
+@click.command()
+@click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
+def catalog(as_json: bool) -> None:
+    """Show the project's query catalog — the vocabulary for `qluent plan`.
+
+    Lists the bases, metrics (with the bases that can compute them),
+    relationships and derived dimensions a QueryPlan may reference. The JSON
+    output additionally carries the QueryPlan JSON schema (`plan_schema`).
+    """
+    config = load_config()
+    client = QluentClient(config)
+
+    try:
+        raw = client.get_query_catalog()
+    except httpx.HTTPStatusError as exc:
+        raise click.ClickException(
+            f"API error {exc.response.status_code}: {exc.response.text[:500]}"
+        ) from exc
+
+    contract = build_catalog_contract(raw, config)
+    if contract.get("status") != STATUS_OK:
+        code = contract.get("error_code") or "CATALOG_UNAVAILABLE"
+        raise click.ClickException(
+            f"{code}: {contract.get('error') or 'could not load the query catalog'}"
+        )
+    render(
+        Result(json_payload=contract, human=lambda: _format_catalog(contract)),
+        as_json=as_json,
+    )
+
+
+def _load_plan_document(
+    plan_json: str | None, plan_file: str | None
+) -> dict:
+    if bool(plan_json) == bool(plan_file):
+        raise click.ClickException(
+            "Provide the plan exactly one way: as the PLAN_JSON argument or "
+            "via --file."
+        )
+    text = Path(plan_file).read_text() if plan_file else str(plan_json)
+    try:
+        document = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise click.ClickException(f"Plan is not valid JSON: {exc}") from exc
+    if not isinstance(document, dict):
+        raise click.ClickException("Plan must be a JSON object (a QueryPlan document).")
+    return document
+
+
+@click.command()
+@click.argument("plan_json", required=False)
+@click.option(
+    "--file",
+    "plan_file",
+    type=click.Path(exists=True, dir_okay=False),
+    default=None,
+    help="Read the QueryPlan JSON from a file instead of the argument.",
+)
+@click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
+def plan(plan_json: str | None, plan_file: str | None, as_json: bool) -> None:
+    """Compile and run a typed QueryPlan against the project's query catalog.
+
+    PLAN_JSON is a QueryPlan document (see `qluent catalog` for the vocabulary
+    and `plan_schema`). Deterministic: the same plan always compiles to the
+    same SQL, and the compiler rejects anything outside the catalog. A
+    rejected plan renders with status "plan_invalid" and a repairable error
+    message — fix the plan and re-run.
+    """
+    config = load_config()
+    client = QluentClient(config)
+    document = _load_plan_document(plan_json, plan_file)
+
+    try:
+        raw = client.execute_plan(document, progress_callback=_heartbeat)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 429:
+            raise click.ClickException(
+                "Rate limited by the API — wait a moment and retry."
+            ) from exc
+        raise click.ClickException(
+            f"API error {exc.response.status_code}: {exc.response.text[:500]}"
+        ) from exc
+
+    contract = build_plan_contract(raw, config)
+    status = contract.get("status")
+    if status == STATUS_OK:
+        record = _persist_run_safely(
+            command=sessions.PLAN_COMMAND,
+            tree_id=None,
+            period_start=None,
+            period_end=None,
+            comparison_start=None,
+            comparison_end=None,
+            profile=f"{config.user_email}@{config.api_url}",
+            client_safe=config.client_safe,
+            args={"plan": document},
+            payload=contract,
+        )
+
+        def _human() -> str:
+            text = _format_plan_result(contract, show_sql=not config.client_safe)
+            if record:
+                text = f"{text}\n\nrun_id: {record.run_id} (saved)"
+            return text
+
+        render(Result(json_payload=contract, human=_human), as_json=as_json)
+    elif status == STATUS_PLAN_INVALID:
+        # A repairable outcome, not a failure: render the contract (exit 0) so
+        # an agent reads the error from stdout, corrects the plan, and re-runs.
+        def _human_invalid() -> str:
+            return (
+                f"Plan rejected ({contract.get('error_code')}): "
+                f"{contract.get('error')}\n\nFix the plan and re-run."
+            )
+
+        render(Result(json_payload=contract, human=_human_invalid), as_json=as_json)
+    else:
+        code = contract.get("error_code") or "PLAN_FAILED"
+        raise click.ClickException(
+            f"{code}: {contract.get('error') or 'plan execution failed'}"
+        )

--- a/src/qluent_cli/plan_contracts.py
+++ b/src/qluent_cli/plan_contracts.py
@@ -1,0 +1,122 @@
+"""Stable JSON contracts for the composable query-plan commands.
+
+Unlike ``qluent query`` (the backend's LLM workflow, marked non-deterministic),
+a QueryPlan compiles deterministically against the project's closed-world
+catalog: the same plan always produces the same SQL, and a plan the compiler
+rejects comes back as a *repairable* error the caller fixes and resubmits.
+The contracts mark that provenance so downstream consumers (plugin skills,
+agents) can treat plan results as deterministic evidence.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+from qluent_cli.config import QluentConfig
+from qluent_cli.contract_helpers import ProjectContext, Provenance
+
+PLAN_SCHEMA_VERSION = "qluent.plan.v1"
+CATALOG_SCHEMA_VERSION = "qluent.catalog.v1"
+
+STATUS_OK = "ok"
+# The compiler (or scope guard) rejected the plan with a repairable message —
+# fix the plan and re-run. Deliberately distinct from STATUS_ERROR so agents
+# know retrying with the same plan is pointless but a *corrected* plan is not.
+STATUS_PLAN_INVALID = "plan_invalid"
+STATUS_ERROR = "error"
+
+_REPAIRABLE_ERROR_CODES = frozenset(
+    {"PLAN_INVALID", "PLAN_SCOPE_VIOLATION", "QUERY_CATALOG_INVALID"}
+)
+
+
+class PlanContract(TypedDict, total=False):
+    schema_version: str
+    contract_kind: str
+    deterministic: bool
+    status: str
+    sql: str | None
+    columns: list[str] | None
+    data: list[dict[str, Any]] | None
+    row_count: int | None
+    grain: list[str] | None
+    metrics: dict[str, Any] | None
+    plan_summary: dict[str, Any] | None
+    error_code: str | None
+    error: str | None
+    project_context: ProjectContext
+    provenance: Provenance
+
+
+class CatalogContract(TypedDict, total=False):
+    schema_version: str
+    contract_kind: str
+    status: str
+    catalog: dict[str, Any] | None
+    plan_schema: dict[str, Any] | None
+    error_code: str | None
+    error: str | None
+    project_context: ProjectContext
+    provenance: Provenance
+
+
+def _project_context(config: QluentConfig) -> ProjectContext:
+    return {
+        "project_uuid": config.project_uuid,
+        "user_email": config.user_email,
+        "api_url": config.api_url,
+        "client_safe": config.client_safe,
+    }
+
+
+def _derive_status(raw: dict[str, Any]) -> str:
+    if raw.get("success"):
+        return STATUS_OK
+    if raw.get("error_code") in _REPAIRABLE_ERROR_CODES:
+        return STATUS_PLAN_INVALID
+    return STATUS_ERROR
+
+
+def build_plan_contract(raw: dict[str, Any], config: QluentConfig) -> PlanContract:
+    """Normalize a query-plan response (success body or 422 error body)."""
+    metadata = raw.get("metadata") or {}
+    return {
+        "schema_version": PLAN_SCHEMA_VERSION,
+        "contract_kind": "query_plan",
+        "deterministic": True,
+        "status": _derive_status(raw),
+        "sql": raw.get("sql"),
+        "columns": metadata.get("columns"),
+        "data": raw.get("rows"),
+        "row_count": raw.get("row_count"),
+        "grain": metadata.get("grain"),
+        "metrics": metadata.get("metrics"),
+        "plan_summary": raw.get("plan_summary"),
+        "error_code": raw.get("error_code"),
+        "error": raw.get("error"),
+        "project_context": _project_context(config),
+        "provenance": {
+            "source": "query_plan",
+            "project_uuid": config.project_uuid,
+        },
+    }
+
+
+def build_catalog_contract(
+    raw: dict[str, Any], config: QluentConfig
+) -> CatalogContract:
+    """Normalize a query-catalog response (success body or 422 error body)."""
+    return {
+        "schema_version": CATALOG_SCHEMA_VERSION,
+        "contract_kind": "query_catalog",
+        "status": STATUS_OK if raw.get("success") else STATUS_ERROR,
+        "catalog": raw.get("catalog"),
+        "plan_schema": raw.get("plan_schema"),
+        "error_code": raw.get("error_code"),
+        "error": raw.get("error"),
+        "project_context": _project_context(config),
+        "provenance": {
+            "source": "query_catalog",
+            "project_uuid": config.project_uuid,
+        },
+    }

--- a/src/qluent_cli/sessions.py
+++ b/src/qluent_cli/sessions.py
@@ -23,7 +23,8 @@ from qluent_cli import config as _config_module
 INVESTIGATE_COMMAND = "trees investigate"
 DEEP_DIVE_COMMAND = "trees deep-dive"
 QUERY_COMMAND = "query"
-KNOWN_COMMANDS = (INVESTIGATE_COMMAND, DEEP_DIVE_COMMAND, QUERY_COMMAND)
+PLAN_COMMAND = "plan"
+KNOWN_COMMANDS = (INVESTIGATE_COMMAND, DEEP_DIVE_COMMAND, QUERY_COMMAND, PLAN_COMMAND)
 
 
 # Crockford base32 (no I, L, O, U) — gives a time-sortable, unambiguous ID.

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 from typing import Any
 
+import pytest
 from click.testing import CliRunner
 
 from qluent_cli.config import QluentConfig
@@ -127,6 +128,31 @@ class FakeClient:
             "row_count": 1,
         }
 
+    def get_query_catalog(self):
+        self.calls.append(("get_query_catalog", (), {}))
+        return {
+            "success": True,
+            "schema_version": 1,
+            "catalog": {"bases": {"orders": {"columns": ["brand"]}}},
+            "plan_schema": {"type": "object"},
+        }
+
+    def execute_plan(self, plan, *, progress_callback=None):
+        self.calls.append(("execute_plan", (plan,), {}))
+        return {
+            "success": True,
+            "schema_version": 1,
+            "sql": "WITH src AS (SELECT 1) SELECT * FROM src",
+            "rows": [{"brand": "acme", "gfv": 12.5}],
+            "row_count": 1,
+            "metadata": {
+                "columns": ["brand", "gfv"],
+                "grain": ["brand"],
+                "metrics": {"gfv": {"kind": "sum", "summable": True}},
+            },
+            "plan_summary": {"bases": ["orders"]},
+        }
+
 
 def test_tool_definitions_cover_acceptance_criteria_tools():
     names = {tool["name"] for tool in _tool_definitions()}
@@ -139,6 +165,8 @@ def test_tool_definitions_cover_acceptance_criteria_tools():
         "qluent_rca_analyze",
         "qluent_elasticity",
         "qluent_query",
+        "qluent_compose_catalog",
+        "qluent_compose_query",
         "qluent_suggestions",
     }
     assert names == set(HANDLERS)
@@ -485,3 +513,39 @@ def test_qluent_mcp_serve_invokes_serve_stdio(monkeypatch):
     result = runner.invoke(cli, ["mcp", "serve"])
     assert result.exit_code == 0, result.output
     assert called == {"ok": True}
+
+
+def test_dispatch_compose_catalog_returns_catalog_contract():
+    client = FakeClient()
+    result = asyncio.run(
+        dispatch_tool("qluent_compose_catalog", {}, client=client, config=CONFIG)
+    )
+    assert client.calls == [("get_query_catalog", (), {})]
+    assert result["contract_kind"] == "query_catalog"
+    assert result["status"] == "ok"
+    assert "orders" in result["catalog"]["bases"]
+    assert result["plan_schema"] == {"type": "object"}
+
+
+def test_dispatch_compose_query_returns_deterministic_plan_contract():
+    client = FakeClient()
+    plan = {"nodes": [{"op": "source", "id": "src", "base": "orders"}], "output": "src"}
+    result = asyncio.run(
+        dispatch_tool("qluent_compose_query", {"plan": plan}, client=client, config=CONFIG)
+    )
+    assert client.calls == [("execute_plan", (plan,), {})]
+    assert result["contract_kind"] == "query_plan"
+    assert result["deterministic"] is True
+    assert result["status"] == "ok"
+    assert result["grain"] == ["brand"]
+    assert result["metrics"]["gfv"]["summable"] is True
+
+
+def test_dispatch_compose_query_rejects_non_object_plan():
+    client = FakeClient()
+    with pytest.raises(ValueError):
+        asyncio.run(
+            dispatch_tool(
+                "qluent_compose_query", {"plan": "[1]"}, client=client, config=CONFIG
+            )
+        )

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from click.testing import CliRunner
+
+from qluent_cli.config import QluentConfig
+from qluent_cli.main import cli
+from qluent_cli.plan_contracts import PLAN_SCHEMA_VERSION
+
+
+def _config(**overrides: Any) -> QluentConfig:
+    defaults = dict(
+        api_key="qk_test",
+        api_url="https://api.example.com",
+        project_uuid="project-123",
+        user_email="user@example.com",
+    )
+    defaults.update(overrides)
+    return QluentConfig(**defaults)
+
+
+PLAN = {
+    "nodes": [
+        {"op": "source", "id": "src", "base": "orders"},
+        {
+            "op": "group_by",
+            "id": "g",
+            "input": "src",
+            "dims": ["brand"],
+            "metrics": ["gfv"],
+        },
+    ],
+    "output": "g",
+}
+
+OK_RESPONSE = {
+    "success": True,
+    "schema_version": 1,
+    "sql": "WITH src AS (SELECT 1) SELECT * FROM g",
+    "rows": [
+        {"brand": "acme", "gfv": 12.5},
+        {"brand": "globex", "gfv": 9.0},
+    ],
+    "row_count": 2,
+    "metadata": {
+        "columns": ["brand", "gfv"],
+        "grain": ["brand"],
+        "metrics": {"gfv": {"kind": "sum", "summable": True}},
+    },
+    "plan_summary": {"bases": ["orders"], "metrics": ["gfv"]},
+}
+
+INVALID_RESPONSE = {
+    "success": False,
+    "error_code": "PLAN_INVALID",
+    "error": "group_by.dims: unknown column 'brnd'; available ['brand', 'gfv_eur']",
+}
+
+CATALOG_RESPONSE = {
+    "success": True,
+    "schema_version": 1,
+    "catalog": {
+        "bases": {"orders": {"columns": ["brand", "gfv_eur"]}},
+        "metrics": {"gfv": ["orders"]},
+        "relationships": {},
+        "derived_dimensions": ["order_month"],
+    },
+    "plan_schema": {"type": "object", "properties": {}},
+}
+
+
+class FakePlanClient:
+    """Records calls; returns the canned payloads set on the class."""
+
+    catalog_response: dict[str, Any] = {}
+    plan_response: dict[str, Any] = {}
+    calls: list[tuple[str, Any]] = []
+
+    def __init__(self, config: QluentConfig) -> None:
+        self.config = config
+
+    def get_query_catalog(self) -> dict[str, Any]:
+        type(self).calls.append(("get_query_catalog", None))
+        return dict(type(self).catalog_response)
+
+    def execute_plan(self, plan: dict[str, Any], *, progress_callback=None) -> dict[str, Any]:
+        type(self).calls.append(("execute_plan", plan))
+        return dict(type(self).plan_response)
+
+
+def _wire(monkeypatch, config: QluentConfig | None = None) -> None:
+    monkeypatch.setattr("qluent_cli.plan.load_config", lambda: config or _config())
+    monkeypatch.setattr("qluent_cli.plan.QluentClient", FakePlanClient)
+    FakePlanClient.calls = []
+
+
+def test_catalog_renders_vocabulary(monkeypatch):
+    FakePlanClient.catalog_response = dict(CATALOG_RESPONSE)
+    _wire(monkeypatch)
+
+    result = CliRunner().invoke(cli, ["catalog"])
+
+    assert result.exit_code == 0, result.output
+    assert "orders: 2 columns" in result.output
+    assert "gfv [orders]" in result.output
+    assert "order_month" in result.output
+
+
+def test_catalog_json_output_carries_plan_schema(monkeypatch):
+    FakePlanClient.catalog_response = dict(CATALOG_RESPONSE)
+    _wire(monkeypatch)
+
+    result = CliRunner().invoke(cli, ["catalog", "--json-output"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["contract_kind"] == "query_catalog"
+    assert payload["plan_schema"] == {"type": "object", "properties": {}}
+    assert payload["catalog"]["metrics"] == {"gfv": ["orders"]}
+
+
+def test_catalog_missing_is_an_error(monkeypatch):
+    FakePlanClient.catalog_response = {
+        "success": False,
+        "error_code": "QUERY_CATALOG_INVALID",
+        "error": "The project has no loadable query_catalog",
+    }
+    _wire(monkeypatch)
+
+    result = CliRunner().invoke(cli, ["catalog"])
+
+    assert result.exit_code != 0
+    assert "QUERY_CATALOG_INVALID" in result.output
+
+
+def test_plan_happy_path_renders_table_and_metadata(monkeypatch, isolated_config):
+    FakePlanClient.plan_response = dict(OK_RESPONSE)
+    _wire(monkeypatch)
+
+    result = CliRunner().invoke(cli, ["plan", json.dumps(PLAN)])
+
+    assert result.exit_code == 0, result.output
+    assert "acme" in result.output
+    assert "grain: brand" in result.output
+    assert "SQL: WITH src" in result.output
+    assert "run_id:" in result.output
+    assert FakePlanClient.calls == [("execute_plan", PLAN)]
+
+
+def test_plan_persists_run(monkeypatch, isolated_config):
+    FakePlanClient.plan_response = dict(OK_RESPONSE)
+    _wire(monkeypatch)
+
+    result = CliRunner().invoke(cli, ["plan", json.dumps(PLAN)])
+    assert result.exit_code == 0, result.output
+
+    from qluent_cli import sessions
+
+    record = sessions.find_last_run(command=sessions.PLAN_COMMAND)
+    assert record is not None
+    stored = record.load()
+    assert stored["args"]["plan"] == PLAN
+    assert stored["result"]["schema_version"] == PLAN_SCHEMA_VERSION
+    assert stored["result"]["deterministic"] is True
+
+
+def test_plan_from_file(monkeypatch, isolated_config, tmp_path):
+    FakePlanClient.plan_response = dict(OK_RESPONSE)
+    _wire(monkeypatch)
+    plan_file = tmp_path / "plan.json"
+    plan_file.write_text(json.dumps(PLAN))
+
+    result = CliRunner().invoke(cli, ["plan", "--file", str(plan_file)])
+
+    assert result.exit_code == 0, result.output
+    assert FakePlanClient.calls == [("execute_plan", PLAN)]
+
+
+def test_plan_invalid_is_a_repairable_zero_exit(monkeypatch):
+    FakePlanClient.plan_response = dict(INVALID_RESPONSE)
+    _wire(monkeypatch)
+
+    result = CliRunner().invoke(cli, ["plan", json.dumps(PLAN)])
+
+    assert result.exit_code == 0, result.output
+    assert "Plan rejected" in result.output
+    assert "unknown column 'brnd'" in result.output
+    assert "re-run" in result.output
+
+
+def test_plan_invalid_json_contract_marks_status(monkeypatch):
+    FakePlanClient.plan_response = dict(INVALID_RESPONSE)
+    _wire(monkeypatch)
+
+    result = CliRunner().invoke(cli, ["plan", json.dumps(PLAN), "--json-output"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["status"] == "plan_invalid"
+    assert payload["error_code"] == "PLAN_INVALID"
+
+
+def test_plan_hard_error_raises(monkeypatch):
+    FakePlanClient.plan_response = {
+        "success": False,
+        "error_code": "DATA_SOURCE_ERROR",
+        "error": "Query execution failed.",
+    }
+    _wire(monkeypatch)
+
+    result = CliRunner().invoke(cli, ["plan", json.dumps(PLAN)])
+
+    assert result.exit_code != 0
+    assert "DATA_SOURCE_ERROR" in result.output
+
+
+def test_plan_requires_exactly_one_input(monkeypatch, tmp_path):
+    _wire(monkeypatch)
+
+    neither = CliRunner().invoke(cli, ["plan"])
+    assert neither.exit_code != 0
+    assert "exactly one way" in neither.output
+
+    plan_file = tmp_path / "plan.json"
+    plan_file.write_text("{}")
+    both = CliRunner().invoke(
+        cli, ["plan", "{}", "--file", str(plan_file)]
+    )
+    assert both.exit_code != 0
+    assert "exactly one way" in both.output
+
+
+def test_plan_rejects_malformed_json(monkeypatch):
+    _wire(monkeypatch)
+
+    result = CliRunner().invoke(cli, ["plan", "{not json"])
+
+    assert result.exit_code != 0
+    assert "not valid JSON" in result.output

--- a/tests/test_plan_contracts.py
+++ b/tests/test_plan_contracts.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Any
+
+from qluent_cli.config import QluentConfig
+from qluent_cli.plan_contracts import (
+    CATALOG_SCHEMA_VERSION,
+    PLAN_SCHEMA_VERSION,
+    STATUS_ERROR,
+    STATUS_OK,
+    STATUS_PLAN_INVALID,
+    build_catalog_contract,
+    build_plan_contract,
+)
+
+CONFIG = QluentConfig(
+    api_key="qk_test",
+    api_url="https://api.example.com",
+    project_uuid="project-123",
+    user_email="user@example.com",
+)
+
+
+def _ok_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "success": True,
+        "schema_version": 1,
+        "sql": "WITH g AS (SELECT 1) SELECT * FROM g",
+        "rows": [{"brand": "acme", "gfv": 1.0}],
+        "row_count": 1,
+        "metadata": {
+            "columns": ["brand", "gfv"],
+            "grain": ["brand"],
+            "metrics": {"gfv": {"kind": "sum", "summable": True}},
+        },
+        "plan_summary": {"bases": ["orders"]},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_plan_contract_marks_deterministic_provenance():
+    contract = build_plan_contract(_ok_payload(), CONFIG)
+
+    assert contract["schema_version"] == PLAN_SCHEMA_VERSION
+    assert contract["contract_kind"] == "query_plan"
+    assert contract["deterministic"] is True
+    assert contract["status"] == STATUS_OK
+    assert contract["columns"] == ["brand", "gfv"]
+    assert contract["grain"] == ["brand"]
+    assert contract["metrics"]["gfv"]["summable"] is True
+    assert contract["data"] == [{"brand": "acme", "gfv": 1.0}]
+    assert contract["provenance"] == {
+        "source": "query_plan",
+        "project_uuid": "project-123",
+    }
+
+
+def test_plan_contract_repairable_codes_map_to_plan_invalid():
+    for code in ("PLAN_INVALID", "PLAN_SCOPE_VIOLATION", "QUERY_CATALOG_INVALID"):
+        contract = build_plan_contract(
+            {"success": False, "error_code": code, "error": "fix me"}, CONFIG
+        )
+        assert contract["status"] == STATUS_PLAN_INVALID
+        assert contract["error"] == "fix me"
+
+
+def test_plan_contract_other_failures_are_errors():
+    contract = build_plan_contract(
+        {"success": False, "error_code": "DATA_SOURCE_ERROR", "error": "boom"},
+        CONFIG,
+    )
+    assert contract["status"] == STATUS_ERROR
+
+
+def test_catalog_contract_passthrough():
+    contract = build_catalog_contract(
+        {
+            "success": True,
+            "catalog": {"bases": {"orders": {"columns": ["brand"]}}},
+            "plan_schema": {"type": "object"},
+        },
+        CONFIG,
+    )
+    assert contract["schema_version"] == CATALOG_SCHEMA_VERSION
+    assert contract["status"] == STATUS_OK
+    assert contract["catalog"]["bases"] == {"orders": {"columns": ["brand"]}}
+    assert contract["plan_schema"] == {"type": "object"}
+    assert contract["provenance"]["source"] == "query_catalog"


### PR DESCRIPTION
Second of three PRs positioning the compose engine as an agent-facing query surface (backend qluent/qluent-ui#506 → **this** → qluent-plugin-cc).

## What

The deterministic sibling of `qluent query`. Instead of sending natural language through the backend's LLM workflow, an agent:

1. **`qluent catalog [--json-output]`** — fetches the project's closed-world query vocabulary (bases with columns, metrics with the bases that can compute them, relationships, derived dimensions, aliases) plus the QueryPlan JSON schema (`plan_schema`). A few KB; fetch once per session.
2. **`qluent plan '<json>' | --file plan.json`** — submits a typed QueryPlan; the backend compiles it against the catalog and executes. Deterministic: same plan → same SQL.

Plus two MCP tools (`qluent_compose_catalog`, `qluent_compose_query`) so non-Claude agents get the same surface over stdio.

## Design decisions

- **`plan_invalid` is a status, not an error.** A compiler rejection is a *repairable* outcome — the CLI exits 0 and renders the fix instruction (matching how `query` treats `clarification_needed`), so an agent reads it off stdout, corrects the plan, and re-runs. Hard failures (data source errors, 5xx) still raise.
- **A new provenance tier.** Contracts are marked `deterministic: true` with `source: query_plan` — between deterministic tree evidence and non-deterministic NL queries. The plugin's interpretation protocol can rely on this.
- **Composition safety is surfaced, not implied.** Results carry `grain` and per-metric `summable` flags; the human output prints "not summable across results: …" so neither agents nor humans silently add distinct counts or ratios from separate queries.
- **`agent_instructions.md` routing updated**: trees first, then `plan` when the catalog covers the question, `query` only for what neither can express.
- Client returns 422 bodies as payloads (repairable), everything else raises — consistent with `query()`.

## Tests

`test_plan.py` (11: catalog rendering/JSON/missing-catalog, plan happy path + run persistence + `--file`, plan_invalid zero-exit + JSON status, hard-error, input validation), `test_plan_contracts.py` (4), MCP dispatch tests for both tools. Full suite: **270 passed**.

Requires qluent/qluent-ui#506; gate on `schema_version` if deploying out of order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
