### PR TITLE
feat: make querying the default workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Qluent CLI
 
-`qluent` is a client-facing CLI for deterministic metric-tree analysis and root-cause analysis.
+`qluent` is a client-facing CLI for business querying and deterministic
+metric-tree analysis. Querying is the default workflow; metric trees add
+advanced governed RCA, trend, and lever analysis.
 This README is written for the standalone `qluent-cli` repository layout.
 
 ## Client Install
@@ -65,6 +67,10 @@ clients that follow the convention) prefer it over `AGENTS.md` for that run.
 ## First Commands
 
 ```bash
+qluent status
+qluent suggestions --json-output
+qluent catalog --json-output
+qluent query "Show revenue by region last month" --json-output
 qluent trees list
 qluent trees trend revenue --periods 4 --grain week
 qluent trees investigate revenue --period "last week" --json-output
@@ -72,9 +78,11 @@ qluent rca analyze revenue --period "last week"
 qluent elasticity revenue --outcome net_revenue --lever voucher_cost --dimension region --period "last week" --json-output
 ```
 
-For Claude Code, the recommended flow is `qluent trees list --json-output` to
-discover available trees, then `qluent trees investigate <tree_id> --period
-"<period>" --json-output` for the chosen tree. The bundled response includes
+For Claude Code, start with `qluent suggestions --json-output` and the query
+workflow. Catalog-covered questions use deterministic composed plans; the
+NL-to-SQL query is the fallback. When the user explicitly requests governed
+KPI movement analysis and a matching tree is configured, run `qluent trees
+investigate <tree_id> --period "<period>" --json-output`. The bundle includes
 `agent.status`, `agent.top_findings`, `agent.gaps`, and
 `agent.recommended_next_steps` so the model can continue RCA without manually
 inventing the next command.

--- a/src/qluent_cli/agent_instructions.md
+++ b/src/qluent_cli/agent_instructions.md
@@ -1,13 +1,17 @@
-# Qluent Metric Trees
+# Qluent
 
-You have access to the `qluent` CLI for deterministic KPI analysis. Use it to answer
-questions about business performance, revenue drivers, cost breakdowns, and trend changes.
+You have access to the `qluent` CLI for business querying and deterministic
+KPI analysis. Querying is the default workflow; metric trees are the advanced
+workflow for governed movement analysis, RCA, trends, and levers.
 
 ## Commands
 
 ```bash
-qluent trees list                                           # List available metric trees (start here for any natural-language question)
-qluent suggestions --json-output                           # Project-specific example questions and commands
+qluent suggestions --json-output                           # Start here: query-first project examples plus advanced tree analyses
+qluent catalog --json-output                               # Catalog vocabulary + plan schema for deterministic queries
+qluent plan '<QueryPlan JSON>' [--file <path>]              # Deterministic, catalog-checked query
+qluent query "<question>" [--thread <id>]                   # NL-to-SQL fallback when the catalog cannot cover the question
+qluent trees list                                           # List advanced metric trees
 qluent trees get <tree_id>                                  # Show tree hierarchy
 qluent trees validate <tree_id>                             # Validate tree SQL contracts and dimensions
 qluent trees evaluate <tree_id> --period "last week"        # Evaluate with natural language period
@@ -20,9 +24,6 @@ qluent trees trend <tree_id> --periods 3 --grain month      # Monthly trend
 qluent trees compare <tree_id> <tree_id> --period "last week"  # Side-by-side tree comparison
 qluent trees investigate <tree_id> --period "last week"     # Validate + trend + evaluate + RCA bundle
 qluent rca analyze revenue --period "last week"             # Deterministic tree + segment RCA
-qluent query "<question>" [--thread <id>]                   # Ad-hoc NL question -> SQL -> results (LLM, non-deterministic)
-qluent catalog [--json-output]                              # Show the query catalog: the vocabulary + plan schema for `qluent plan`
-qluent plan '<QueryPlan JSON>' [--file <path>]              # Compile + run a typed QueryPlan (deterministic, catalog-checked)
 ```
 
 All commands support `--json-output` for raw JSON. The `trend` command supports `--as-of YYYY-MM-DD`
@@ -34,9 +35,13 @@ Supported periods: "last week", "this week", "last month", "this month", "last q
 
 ## Preferred agent workflow
 
-**Pick a tree, then `investigate`.** The qluent server is deterministic and does
-not match natural-language questions to trees — the agent must select the tree
-client-side and pass it as an explicit positional argument.
+**Start with query discovery.** Run `qluent suggestions --json-output` and
+prefer its catalog-backed query examples. Author a composed plan when the
+catalog covers the question; use `qluent query` as the NL-to-SQL fallback.
+
+Metric trees are advanced and optional. Use them when the user explicitly asks
+for deterministic KPI movement, RCA, trend classification, mix-shift, or
+lever analysis and a matching tree is configured.
 
 If the user already named the tree (e.g. "investigate revenue last week"), run:
 
@@ -44,15 +49,18 @@ If the user already named the tree (e.g. "investigate revenue last week"), run:
 qluent trees investigate <tree_id> --period "<period>" --json-output
 ```
 
-If the user asked what they can do with the connected project, run:
+If the user asks what they can do with the connected project, run:
 
 ```bash
 qluent suggestions --json-output
 ```
 
-If the user asked a natural-language question without naming a tree, list the
-available trees first and pick the best fit by matching the question against
-each tree's `id`, `label`, `description`, child node labels, and declared
+For a general natural-language question, use the query workflow described
+below. Do not require or probe metric trees first.
+
+For an explicit advanced investigation without a named tree, list the
+available trees and pick the best fit by matching the question against each
+tree's `id`, `label`, `description`, child node labels, and declared
 `dimensions`:
 
 ```bash
@@ -97,10 +105,12 @@ Use these rules:
 
 ## When to use `qluent plan` / `qluent query` vs metric-tree commands
 
-The tree commands (`investigate`, `evaluate`, `trend`, `rca analyze`, ...) are
-deterministic, fast, and reproducible — always prefer them when the question maps
-to a tree's KPIs, child nodes, or declared dimensions ("why did revenue drop",
-trends, drivers, elasticity).
+The query workflow is the default for values, aggregations, breakdowns,
+rankings, comparisons, and general business questions. The tree commands
+(`investigate`, `evaluate`, `trend`, `rca analyze`, ...) are deterministic,
+fast, and reproducible, but advanced: use them for explicit governed movement
+analysis, RCA, trend, mix, or elasticity requests that map to a configured
+tree.
 
 `qluent plan` compiles a typed QueryPlan you author against the project's
 closed-world query catalog — deterministic (the same plan always produces the

--- a/src/qluent_cli/main.py
+++ b/src/qluent_cli/main.py
@@ -17,6 +17,7 @@ from qluent_cli.formatters import format_tree_list
 from qluent_cli.plan import catalog, plan
 from qluent_cli.query import query
 from qluent_cli.rca import rca
+from qluent_cli.sessions import KNOWN_COMMANDS
 from qluent_cli.suggestions import suggestions
 from qluent_cli.trees import trees
 from qluent_cli.output import echo_status
@@ -91,7 +92,7 @@ def _build_status_payload() -> dict[str, Any]:
             }
         )
 
-    first_tree = normalized_trees[0]["id"] if normalized_trees else "<tree_id>"
+    tree_count = len(normalized_trees)
     return {
         "connected": True,
         "project": {
@@ -101,9 +102,20 @@ def _build_status_payload() -> dict[str, Any]:
             "client_safe": config.client_safe,
         },
         "trees": normalized_trees,
-        "suggested_first_command": (
-            f'qluent trees investigate {first_tree} --period "last month" --json-output'
-        ),
+        "capabilities": {
+            "query": {
+                "available": True,
+                "status": "ready",
+                "default": True,
+            },
+            "metric_trees": {
+                "available": tree_count > 0,
+                "status": "ready" if tree_count else "not_configured",
+                "count": tree_count,
+                "advanced": True,
+            },
+        },
+        "suggested_first_command": "qluent suggestions --json-output",
     }
 
 
@@ -125,8 +137,15 @@ def _format_status(payload: dict[str, Any]) -> str:
         f"  User: {project['user_email']}",
         f"  Client safe: {project['client_safe']}",
         "",
-        "Available trees",
+        "Capabilities",
+        "  Query             ready (default)",
     ]
+    tree_count = len(payload.get("trees") or [])
+    if tree_count:
+        lines.append(f"  Metric trees      {tree_count} available (advanced)")
+    else:
+        lines.append("  Metric trees      not configured (advanced, optional)")
+    lines.extend(["", "Available metric trees"])
     trees_payload = {"trees": payload.get("trees", [])}
     if payload.get("trees"):
         for tree in trees_payload["trees"]:
@@ -154,7 +173,7 @@ def _print_status(as_json: bool) -> None:
 @cli.command()
 @click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
 def status(as_json: bool) -> None:
-    """Show the connected project, API environment, user, and available trees."""
+    """Show the connected project, API environment, and available capabilities."""
     _print_status(as_json)
 
 
@@ -583,7 +602,7 @@ def _format_runs_table(records: list[Any]) -> str:
     "--command",
     "command_filter",
     default=None,
-    type=click.Choice(["trees investigate", "trees deep-dive", "query"]),
+    type=click.Choice(KNOWN_COMMANDS),
     help="Filter by command kind.",
 )
 @click.option(
@@ -644,7 +663,7 @@ def runs_list(
     "--command",
     "command_filter",
     default=None,
-    type=click.Choice(["trees investigate", "trees deep-dive", "query"]),
+    type=click.Choice(KNOWN_COMMANDS),
     help="When used with --last, filter by command kind.",
 )
 @click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")

--- a/src/qluent_cli/suggestions.py
+++ b/src/qluent_cli/suggestions.py
@@ -6,6 +6,7 @@ import json
 from typing import Any
 
 import click
+import httpx
 
 from qluent_cli.client import QluentClient
 from qluent_cli.config import load_config
@@ -46,10 +47,64 @@ def _root_node(tree: dict[str, Any]) -> dict[str, Any] | None:
     return (tree.get("nodes") or [None])[0]
 
 
-def build_suggestions(trees_data: dict[str, Any]) -> list[dict[str, Any]]:
-    """Build deterministic project-specific example questions from tree metadata."""
-    trees = trees_data.get("trees") or []
+def _catalog_dimensions(catalog: dict[str, Any]) -> list[str]:
+    derived = [str(item) for item in catalog.get("derived_dimensions") or [] if item]
+    columns: list[str] = []
+    for base in (catalog.get("bases") or {}).values():
+        raw_columns = base.get("columns") if isinstance(base, dict) else []
+        if isinstance(raw_columns, dict):
+            raw_columns = raw_columns.keys()
+        for column in raw_columns or []:
+            name = str(column)
+            if name and name not in columns:
+                columns.append(name)
+    return derived + [name for name in columns if name not in derived]
+
+
+def build_query_suggestions(catalog_data: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Build query-first examples from the project's closed-world catalog."""
+    if not catalog_data or catalog_data.get("success") is False:
+        return []
+    catalog = catalog_data.get("catalog") or {}
+    metrics = [str(name) for name in (catalog.get("metrics") or {}) if name]
+    bases = [str(name) for name in (catalog.get("bases") or {}) if name]
+    dimensions = _catalog_dimensions(catalog)
+    subjects = metrics or bases
     suggestions: list[dict[str, Any]] = []
+
+    for subject in subjects[:3]:
+        dimension = next(
+            (name for name in dimensions if name != subject),
+            None,
+        )
+        if dimension:
+            question = f"Show {subject} by {dimension} for the last complete month."
+        else:
+            question = f"What was {subject} for the last complete month?"
+        suggestions.append(
+            {
+                "tree_id": None,
+                "tree_label": "Catalog queries",
+                "analysis_type": "query",
+                "example_question": question,
+                "recommended_command": f'qluent query "{question}" --json-output',
+                "preferred_engine": "composed_plan",
+                "rationale": (
+                    "Starts from catalog vocabulary; agents should use a deterministic "
+                    "composed plan when coverage is complete and fall back to the NL query."
+                ),
+            }
+        )
+    return suggestions
+
+
+def build_suggestions(
+    trees_data: dict[str, Any],
+    catalog_data: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Build query-first examples, followed by advanced metric-tree analyses."""
+    trees = trees_data.get("trees") or []
+    suggestions = build_query_suggestions(catalog_data)
 
     for index, tree in enumerate(trees):
         tree_id = str(tree.get("id") or "")
@@ -177,11 +232,16 @@ def format_suggestions(suggestions: list[dict[str, Any]]) -> str:
 @click.command()
 @click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")
 def suggestions(as_json: bool) -> None:
-    """Show project-specific example questions for available metric trees."""
+    """Show query-first examples and advanced tree analyses for the project."""
     config = load_config()
     client = QluentClient(config)
+    try:
+        catalog_data = client.get_query_catalog()
+    except httpx.HTTPStatusError:
+        catalog_data = None
     data = {
-        "suggestions": build_suggestions(client.list_trees()),
+        "default_workflow": "query",
+        "suggestions": build_suggestions(client.list_trees(), catalog_data),
     }
 
     if as_json:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -42,7 +42,7 @@ def test_setup_saves_config_and_writes_agents_md(monkeypatch, isolated_config, t
     }
     agents_md = tmp_path / "AGENTS.md"
     assert agents_md.exists()
-    assert "# Qluent Metric Trees" in agents_md.read_text()
+    assert "# Qluent" in agents_md.read_text()
     assert not (tmp_path / "CLAUDE.md").exists()
 
 
@@ -96,7 +96,7 @@ def test_claude_init_writes_file(monkeypatch, tmp_path):
 
     assert result.exit_code == 0
     assert (tmp_path / "CLAUDE.md").exists()
-    assert "# Qluent Metric Trees" in (tmp_path / "CLAUDE.md").read_text()
+    assert "# Qluent" in (tmp_path / "CLAUDE.md").read_text()
 
 
 def test_claude_init_requires_force_to_overwrite(monkeypatch, tmp_path):
@@ -117,7 +117,7 @@ def test_agents_init_default_writes_agents_md(monkeypatch, tmp_path):
     assert result.exit_code == 0
     agents_md = tmp_path / "AGENTS.md"
     assert agents_md.exists()
-    assert "# Qluent Metric Trees" in agents_md.read_text()
+    assert "# Qluent" in agents_md.read_text()
     assert not (tmp_path / "CLAUDE.md").exists()
 
 
@@ -129,7 +129,7 @@ def test_agents_init_as_claude_writes_claude_md(monkeypatch, tmp_path):
     assert result.exit_code == 0
     claude_md = tmp_path / "CLAUDE.md"
     assert claude_md.exists()
-    assert "# Qluent Metric Trees" in claude_md.read_text()
+    assert "# Qluent" in claude_md.read_text()
     assert not (tmp_path / "AGENTS.md").exists()
 
 
@@ -161,7 +161,7 @@ def test_agents_init_requires_force_to_overwrite(monkeypatch, tmp_path):
 
     forced = CliRunner().invoke(cli, ["agents", "init", "--force"])
     assert forced.exit_code == 0
-    assert "# Qluent Metric Trees" in (tmp_path / "AGENTS.md").read_text()
+    assert "# Qluent" in (tmp_path / "AGENTS.md").read_text()
 
 
 def test_agents_init_as_both_rejects_custom_path(monkeypatch, tmp_path):
@@ -200,7 +200,7 @@ def test_setup_accepts_deprecated_claude_path_alias(
     assert result.exit_code == 0
     custom_path = tmp_path / "CUSTOM_CLAUDE.md"
     assert custom_path.exists()
-    assert "# Qluent Metric Trees" in custom_path.read_text()
+    assert "# Qluent" in custom_path.read_text()
     assert not (tmp_path / "AGENTS.md").exists()
 
 
@@ -240,7 +240,9 @@ def test_status_outputs_connected_project_and_trees(monkeypatch):
     assert "User: user@example.com" in result.output
     assert "revenue" in result.output
     assert "Net Revenue, Orders" in result.output
-    assert 'qluent trees investigate revenue --period "last month" --json-output' in result.output
+    assert "Query             ready (default)" in result.output
+    assert "Metric trees      1 available (advanced)" in result.output
+    assert "qluent suggestions --json-output" in result.output
 
 
 def test_whoami_json_outputs_agent_friendly_status(monkeypatch):
@@ -268,6 +270,20 @@ def test_whoami_json_outputs_agent_friendly_status(monkeypatch):
         "client_safe": True,
     }
     assert payload["trees"] == []
+    assert payload["capabilities"] == {
+        "query": {
+            "available": True,
+            "status": "ready",
+            "default": True,
+        },
+        "metric_trees": {
+            "available": False,
+            "status": "not_configured",
+            "count": 0,
+            "advanced": True,
+        },
+    }
+    assert payload["suggested_first_command"] == "qluent suggestions --json-output"
 
 
 def test_status_explains_login_when_not_configured(monkeypatch):

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -34,6 +34,16 @@ TREE_DATA = {
     ]
 }
 
+CATALOG_DATA = {
+    "success": True,
+    "catalog": {
+        "bases": {"orders": {"columns": ["brand", "country"]}},
+        "metrics": {"gfv": ["orders"]},
+        "relationships": {},
+        "derived_dimensions": ["order_month"],
+    },
+}
+
 
 def test_build_suggestions_derives_examples_from_tree_metadata():
     suggestions = build_suggestions(TREE_DATA)
@@ -55,6 +65,24 @@ def test_build_suggestions_derives_examples_from_tree_metadata():
     )
 
 
+def test_build_suggestions_puts_catalog_queries_first():
+    suggestions = build_suggestions(TREE_DATA, CATALOG_DATA)
+
+    assert suggestions[0]["analysis_type"] == "query"
+    assert suggestions[0]["tree_label"] == "Catalog queries"
+    assert suggestions[0]["preferred_engine"] == "composed_plan"
+    assert "gfv" in suggestions[0]["example_question"]
+    assert any(item["analysis_type"] == "rca" for item in suggestions)
+
+
+def test_build_suggestions_supports_catalog_only_projects():
+    suggestions = build_suggestions({"trees": []}, CATALOG_DATA)
+
+    assert suggestions
+    assert {item["analysis_type"] for item in suggestions} == {"query"}
+    assert all(item["tree_id"] is None for item in suggestions)
+
+
 def test_suggestions_json_output_contains_agent_fields(monkeypatch):
     monkeypatch.setattr(
         "qluent_cli.suggestions.load_config",
@@ -66,6 +94,10 @@ def test_suggestions_json_output_contains_agent_fields(monkeypatch):
         ),
     )
     monkeypatch.setattr("qluent_cli.suggestions.QluentClient.list_trees", lambda self: TREE_DATA)
+    monkeypatch.setattr(
+        "qluent_cli.suggestions.QluentClient.get_query_catalog",
+        lambda self: CATALOG_DATA,
+    )
 
     result = CliRunner().invoke(cli, ["suggestions", "--json-output"])
 
@@ -79,7 +111,9 @@ def test_suggestions_json_output_contains_agent_fields(monkeypatch):
         "recommended_command",
         "rationale",
     } <= set(first)
-    assert first["tree_id"] == "revenue"
+    assert payload["default_workflow"] == "query"
+    assert first["tree_id"] is None
+    assert first["analysis_type"] == "query"
 
 
 def test_suggestions_human_output_groups_by_tree(monkeypatch):
@@ -93,9 +127,14 @@ def test_suggestions_human_output_groups_by_tree(monkeypatch):
         ),
     )
     monkeypatch.setattr("qluent_cli.suggestions.QluentClient.list_trees", lambda self: TREE_DATA)
+    monkeypatch.setattr(
+        "qluent_cli.suggestions.QluentClient.get_query_catalog",
+        lambda self: CATALOG_DATA,
+    )
 
     result = CliRunner().invoke(cli, ["suggestions"])
 
     assert result.exit_code == 0
+    assert "Catalog queries\n- Show gfv" in result.output
     assert "Revenue\n- Why did Net Revenue change last complete month?" in result.output
     assert "Growth\n- Why did Active Users change last complete month?" in result.output


### PR DESCRIPTION
## Summary

- expose query as the ready/default capability in `qluent status`
- present metric trees as an advanced, optional capability
- derive query-first project suggestions from catalog metrics, bases, and dimensions
- support useful suggestions for catalog-only projects with zero trees
- update generated agent guidance and CLI documentation for query-first routing

## Why

Catalog-only customers can already query their warehouse, but the previous status and suggestion flow treated an empty metric-tree list like incomplete setup. This stack makes the available query workflow the successful default and reserves trees for governed RCA, trend, mix, and lever analysis.

## User impact

A connected project with no trees now receives catalog-backed starting questions instead of an unusable `<tree_id>` investigation recommendation.

## Stack

Stacked on #96 (`feat/compose-plan-commands`).

## Checks

- `uv run pytest` — 272 passed
- `git diff --check`
