### PR TITLE
Expose plan runs in command filters

### DIFF
--- a/src/qluent_cli/main.py
+++ b/src/qluent_cli/main.py
@@ -17,6 +17,7 @@ from qluent_cli.formatters import format_tree_list
 from qluent_cli.plan import catalog, plan
 from qluent_cli.query import query
 from qluent_cli.rca import rca
+from qluent_cli.sessions import KNOWN_COMMANDS
 from qluent_cli.suggestions import suggestions
 from qluent_cli.trees import trees
 from qluent_cli.output import echo_status
@@ -583,7 +584,7 @@ def _format_runs_table(records: list[Any]) -> str:
     "--command",
     "command_filter",
     default=None,
-    type=click.Choice(["trees investigate", "trees deep-dive", "query"]),
+    type=click.Choice(KNOWN_COMMANDS),
     help="Filter by command kind.",
 )
 @click.option(
@@ -644,7 +645,7 @@ def runs_list(
     "--command",
     "command_filter",
     default=None,
-    type=click.Choice(["trees investigate", "trees deep-dive", "query"]),
+    type=click.Choice(KNOWN_COMMANDS),
     help="When used with --last, filter by command kind.",
 )
 @click.option("--json-output", "as_json", is_flag=True, help="Output raw JSON")

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -228,6 +228,19 @@ def test_runs_list_filters_by_tree(isolated_config):
     assert payload[0]["tree_id"] == "revenue"
 
 
+def test_runs_list_accepts_plan_command_filter(isolated_config):
+    _record(command=sessions.PLAN_COMMAND, tree_id=None)
+
+    result = CliRunner().invoke(
+        cli, ["runs", "list", "--command", "plan", "--json-output"]
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert len(payload) == 1
+    assert payload[0]["command"] == sessions.PLAN_COMMAND
+
+
 def test_runs_show_by_id(isolated_config):
     record = _record(payload={"tree_id": "revenue", "delta": 5})
     result = CliRunner().invoke(cli, ["runs", "show", record.run_id, "--json-output"])
@@ -249,6 +262,24 @@ def test_runs_show_last(isolated_config):
     body = json.loads(result.output)
     assert body["run_id"] == newer.run_id
     assert body["result"]["tag"] == "newer"
+
+
+def test_runs_show_last_accepts_plan_command_filter(isolated_config):
+    plan_record = _record(
+        command=sessions.PLAN_COMMAND,
+        tree_id=None,
+        payload={"tag": "plan"},
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["runs", "show", "--last", "--command", "plan", "--json-output"],
+    )
+
+    assert result.exit_code == 0, result.output
+    body = json.loads(result.output)
+    assert body["run_id"] == plan_record.run_id
+    assert body["command"] == sessions.PLAN_COMMAND
 
 
 def test_runs_show_requires_run_id_or_last(isolated_config):


### PR DESCRIPTION
## What changed

- derive the `runs list --command` and `runs show --last --command` Click choices from `KNOWN_COMMANDS`
- expose persisted `plan` runs through both command filters
- add regression coverage for list and show-last filtering

## Why

`qluent plan` persists successful runs with the `plan` command value, but the persisted-run CLI retained a hard-coded command list that rejected `plan` before querying storage.

## Impact

Users can retrieve plan runs with `qluent runs list --command plan` and `qluent runs show --last --command plan`. Future command additions only need to update `KNOWN_COMMANDS`.

## Validation

- `uv run pytest -q` — 272 passed

This is a stacked PR targeting `feat/compose-plan-commands` because the fix depends on the plan command introduced by PR #96.