### PR TITLE
Release 0.1.18

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qluent/cli",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Install the Qluent CLI",
   "license": "UNLICENSED",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qluent-cli"
-version = "0.1.17"
+version = "0.1.18"
 description = "CLI for Qluent metric tree analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/qluent_cli/__init__.py
+++ b/src/qluent_cli/__init__.py
@@ -1,3 +1,3 @@
 """Qluent CLI — metric tree analysis from the command line."""
 
-__version__ = "0.1.17"
+__version__ = "0.1.18"

--- a/uv.lock
+++ b/uv.lock
@@ -672,7 +672,7 @@ wheels = [
 
 [[package]]
 name = "qluent-cli"
-version = "0.1.17"
+version = "0.1.18"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- bump the Python CLI metadata to `0.1.18`
- bump the npm wrapper package to `0.1.18`
- refresh the local package version recorded in `uv.lock`

## Included changes

- add `qluent catalog` and `qluent plan`, plus compose MCP tools (#96)
- make query-first routing the default workflow (#97)

## Release follow-up

After merge:

1. Create and push tag `v0.1.18` on the merge commit.
2. Confirm the binary workflow publishes signed macOS, Linux, and Windows assets.
3. Publish `@qluent/cli@0.1.18` after all release assets are available.

Release automation for future versions is tracked in #99.

## Validation

- `uv run pytest` — 272 passed
- `npm test` — 58 passed
- `git diff --check`
