### PR TITLE
fix: treat QUERY_CATALOG_INVALID as a hard error, not a repairable plan

### DIFF
--- a/src/qluent_cli/agent_instructions.md
+++ b/src/qluent_cli/agent_instructions.md
@@ -126,6 +126,9 @@ bases/metrics/dimensions cover the question:
 - `status = plan_invalid` is a repair instruction, not a failure: fix the plan
   from the error message and re-run. Only fall back to `qluent query` when the
   catalog genuinely lacks the vocabulary (a column/metric that does not exist).
+- `QUERY_CATALOG_INVALID` is *not* repairable: the project's catalog itself
+  fails to load, so no plan will ever compile. Stop re-authoring plans — report
+  the error (the catalog is fixed under the Model tab) and use `qluent query`.
 - Before combining numbers across several plan results, check `grain` and
   `metrics[*].summable`: only summable metrics (plain sums, row counts) may be
   added across result sets — recompute averages, ratios and distinct counts.

--- a/src/qluent_cli/mcp_server.py
+++ b/src/qluent_cli/mcp_server.py
@@ -303,8 +303,10 @@ def _tool_definitions() -> list[dict[str, Any]]:
                 "correct-by-construction: the same plan always produces the "
                 "same SQL, and anything outside the catalog is rejected with "
                 "status 'plan_invalid' and a repairable error message — fix "
-                "the plan and retry. Prefer this over qluent_query when the "
-                "catalog vocabulary covers the question. When combining "
+                "the plan and retry. A status of 'error' is not repairable "
+                "(QUERY_CATALOG_INVALID means the project's catalog does not "
+                "load, so no plan will compile). Prefer this over qluent_query "
+                "when the catalog vocabulary covers the question. When combining "
                 "several results, aggregate early (group_by) and only add "
                 "metrics whose metadata marks them summable."
             ),

--- a/src/qluent_cli/plan.py
+++ b/src/qluent_cli/plan.py
@@ -35,6 +35,27 @@ def _heartbeat(_stage: str, elapsed: float) -> None:
     echo_status(f"[qluent] awaiting response... ({int(elapsed)}s)")
 
 
+# Hard errors an agent cannot repair by rewriting the plan. The hint names the
+# real remedy so callers stop re-authoring plans that can never compile.
+_REMEDIATION_HINTS = {
+    "QUERY_CATALOG_INVALID": (
+        "The project's query catalog could not be loaded, so no plan will "
+        "compile. Fix the catalog under the Model tab, then re-run."
+    ),
+}
+
+
+def _hard_error(
+    contract: dict, default_code: str, default_message: str
+) -> click.ClickException:
+    code = contract.get("error_code") or default_code
+    message = f"{code}: {contract.get('error') or default_message}"
+    hint = _REMEDIATION_HINTS.get(code)
+    if hint:
+        message = f"{message}\n{hint}"
+    return click.ClickException(message)
+
+
 def _persist_run_safely(**kwargs):
     try:
         return sessions.record_run(**kwargs)
@@ -123,9 +144,8 @@ def catalog(as_json: bool) -> None:
 
     contract = build_catalog_contract(raw, config)
     if contract.get("status") != STATUS_OK:
-        code = contract.get("error_code") or "CATALOG_UNAVAILABLE"
-        raise click.ClickException(
-            f"{code}: {contract.get('error') or 'could not load the query catalog'}"
+        raise _hard_error(
+            contract, "CATALOG_UNAVAILABLE", "could not load the query catalog"
         )
     render(
         Result(json_payload=contract, human=lambda: _format_catalog(contract)),
@@ -219,7 +239,4 @@ def plan(plan_json: str | None, plan_file: str | None, as_json: bool) -> None:
 
         render(Result(json_payload=contract, human=_human_invalid), as_json=as_json)
     else:
-        code = contract.get("error_code") or "PLAN_FAILED"
-        raise click.ClickException(
-            f"{code}: {contract.get('error') or 'plan execution failed'}"
-        )
+        raise _hard_error(contract, "PLAN_FAILED", "plan execution failed")

--- a/src/qluent_cli/plan_contracts.py
+++ b/src/qluent_cli/plan_contracts.py
@@ -25,9 +25,10 @@ STATUS_OK = "ok"
 STATUS_PLAN_INVALID = "plan_invalid"
 STATUS_ERROR = "error"
 
-_REPAIRABLE_ERROR_CODES = frozenset(
-    {"PLAN_INVALID", "PLAN_SCOPE_VIOLATION", "QUERY_CATALOG_INVALID"}
-)
+# Only codes the caller can actually act on by editing the plan. A broken
+# catalog (QUERY_CATALOG_INVALID) is deliberately absent: no plan compiles
+# against a catalog that fails to load, so repairing the plan is wasted work.
+_REPAIRABLE_ERROR_CODES = frozenset({"PLAN_INVALID", "PLAN_SCOPE_VIOLATION"})
 
 
 class PlanContract(TypedDict, total=False):

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -216,6 +216,51 @@ def test_plan_hard_error_raises(monkeypatch):
     assert "DATA_SOURCE_ERROR" in result.output
 
 
+def test_plan_catalog_invalid_is_a_hard_error_with_remediation(monkeypatch):
+    FakePlanClient.plan_response = {
+        "success": False,
+        "error_code": "QUERY_CATALOG_INVALID",
+        "error": "The project has no loadable query_catalog",
+    }
+    _wire(monkeypatch)
+
+    result = CliRunner().invoke(cli, ["plan", json.dumps(PLAN)])
+
+    assert result.exit_code != 0
+    assert "QUERY_CATALOG_INVALID" in result.output
+    assert "Model tab" in result.output
+    # Never presented as something a corrected plan could fix.
+    assert "Fix the plan" not in result.output
+
+
+def test_plan_catalog_invalid_json_contract_is_status_error(monkeypatch):
+    FakePlanClient.plan_response = {
+        "success": False,
+        "error_code": "QUERY_CATALOG_INVALID",
+        "error": "The project has no loadable query_catalog",
+    }
+    _wire(monkeypatch)
+
+    result = CliRunner().invoke(cli, ["plan", json.dumps(PLAN), "--json-output"])
+
+    assert result.exit_code != 0
+    assert "plan_invalid" not in result.output
+
+
+def test_catalog_invalid_error_carries_remediation(monkeypatch):
+    FakePlanClient.catalog_response = {
+        "success": False,
+        "error_code": "QUERY_CATALOG_INVALID",
+        "error": "The project has no loadable query_catalog",
+    }
+    _wire(monkeypatch)
+
+    result = CliRunner().invoke(cli, ["catalog"])
+
+    assert result.exit_code != 0
+    assert "Model tab" in result.output
+
+
 def test_plan_requires_exactly_one_input(monkeypatch, tmp_path):
     _wire(monkeypatch)
 

--- a/tests/test_plan_contracts.py
+++ b/tests/test_plan_contracts.py
@@ -57,12 +57,27 @@ def test_plan_contract_marks_deterministic_provenance():
 
 
 def test_plan_contract_repairable_codes_map_to_plan_invalid():
-    for code in ("PLAN_INVALID", "PLAN_SCOPE_VIOLATION", "QUERY_CATALOG_INVALID"):
+    for code in ("PLAN_INVALID", "PLAN_SCOPE_VIOLATION"):
         contract = build_plan_contract(
             {"success": False, "error_code": code, "error": "fix me"}, CONFIG
         )
         assert contract["status"] == STATUS_PLAN_INVALID
         assert contract["error"] == "fix me"
+
+
+def test_plan_contract_catalog_invalid_is_not_repairable():
+    # A catalog that fails to load cannot be repaired by editing the plan, so
+    # it must not be dressed up as a repair instruction.
+    contract = build_plan_contract(
+        {
+            "success": False,
+            "error_code": "QUERY_CATALOG_INVALID",
+            "error": "The project has no loadable query_catalog",
+        },
+        CONFIG,
+    )
+    assert contract["status"] == STATUS_ERROR
+    assert contract["error_code"] == "QUERY_CATALOG_INVALID"
 
 
 def test_plan_contract_other_failures_are_errors():


### PR DESCRIPTION
Closes #102

## Problem

`QUERY_CATALOG_INVALID` sat in `_REPAIRABLE_ERROR_CODES`, so `_derive_status` returned `plan_invalid` for it. Consuming agents read `plan_invalid` as a repair instruction and re-author the plan — but a catalog that fails to load cannot be corrected by editing the plan, so every round is wasted (the plugin protocol caps at 3, ~6 tool calls) and the eventual fallback message blames missing vocabulary rather than the broken catalog.

## Changes

- `plan_contracts.py`: drop `QUERY_CATALOG_INVALID` from `_REPAIRABLE_ERROR_CODES`, so it surfaces as `status: "error"` with its own `error_code`, and `plan()` raises through the existing hard-error path (non-zero exit).
- `plan.py`: factor the two hard-error paths (`qluent plan`, `qluent catalog`) into `_hard_error()` and attach a remediation hint for `QUERY_CATALOG_INVALID` — "the catalog could not be loaded, so no plan will compile; fix it under the Model tab" — matching the wording the plugin's `scripts/session-start.sh` already prints.
- `agent_instructions.md` and the `qluent_compose_query` MCP tool description now state that `QUERY_CATALOG_INVALID` is not repairable and that the fallback is `qluent query`.

## Tests

`uv run pytest` — 278 passed. New coverage:

- `QUERY_CATALOG_INVALID` maps to `STATUS_ERROR` in the contract.
- `qluent plan` exits non-zero, prints the code and the remediation hint, and never says "Fix the plan".
- `--json-output` for that case does not contain `plan_invalid`.
- `qluent catalog` carries the same hint.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPDJqBTQHxKeL1Mh1bqhd7)_