### PR TITLE
fix(npm): warn when another qluent shadows the installed binary on PATH

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -53,3 +53,25 @@ For local development only, you can allow insecure `http://` download URLs with:
 ```bash
 QLUENT_CLI_ALLOW_INSECURE_DOWNLOAD=1 npm install -g @qluent/cli
 ```
+
+## Troubleshooting: `qluent --version` shows an older version
+
+`npm install -g @qluent/cli` can succeed while a different `qluent` earlier on
+`PATH` (a `uv tool` install, a distro package) keeps winning. The installer
+warns when it detects this and prints both paths and versions. To confirm:
+
+```bash
+which -a qluent
+```
+
+Two common causes:
+
+- **Shell command hashing.** bash/zsh cache the resolved path, so a shell that
+  ran `qluent` before the install keeps using the old one. Run `hash -r`
+  (bash) or `rehash` (zsh), or start a new shell.
+- **Node version managers.** With fnm/nvm/volta, npm's global bin lives under
+  the *active node version* and is injected per shell, so the CLI disappears
+  from `PATH` after a node upgrade or in shells started without that
+  environment.
+
+Set `QLUENT_SKIP_PATH_CHECK=1` to skip the check during install.

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,7 +1,20 @@
 const pkg = require("./package.json");
 const { installBinary } = require("./lib/installer");
+const { warnIfShadowed } = require("./lib/shadow-check");
 
-installBinary({ version: pkg.version }).catch((error) => {
-  console.error(`Failed to install Qluent CLI: ${error.message}`);
-  process.exit(1);
-});
+installBinary({ version: pkg.version })
+  .then((installedPath) => {
+    if (!installedPath || process.env.QLUENT_SKIP_PATH_CHECK === "1") {
+      return;
+    }
+    try {
+      warnIfShadowed({ installedPath, installedVersion: pkg.version });
+    } catch (error) {
+      // Diagnostics only — never fail an otherwise successful install.
+      console.error(`Could not verify qluent on PATH: ${error.message}`);
+    }
+  })
+  .catch((error) => {
+    console.error(`Failed to install Qluent CLI: ${error.message}`);
+    process.exit(1);
+  });

--- a/npm/lib/shadow-check.js
+++ b/npm/lib/shadow-check.js
@@ -1,0 +1,264 @@
+// Post-install sanity check: does `qluent` on the user's PATH actually resolve
+// to the binary we just installed?
+//
+// `npm install -g @qluent/cli` can report success while an older `qluent`
+// (a uv tool install, a distro package) keeps winning on PATH, so the user
+// believes they upgraded and stays on the old CLI. Two things make it common:
+// shells cache resolved paths (`hash -r` / `rehash` clears that), and node
+// version managers put npm's global bin under the *active node version*, so
+// the install effectively disappears when that environment is not present.
+//
+// This only ever warns — never fail an install over it.
+
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const PACKAGE_DIR = path.join(__dirname, "..");
+
+// Directory names that mean npm's global bin is scoped to a node version.
+const VERSION_MANAGER_MARKERS = ["fnm", "nvm", "volta", "nodenv", "asdf", "nvs"];
+
+function pathEntries({ env = process.env, platform = process.platform } = {}) {
+  const raw = env.PATH || env.Path || env.path || "";
+  const delimiter = platform === "win32" ? ";" : ":";
+  return raw
+    .split(delimiter)
+    .map((entry) => entry.trim().replace(/^"(.*)"$/, "$1"))
+    .filter(Boolean);
+}
+
+/** Filenames a shell would try for `name` in a PATH directory. */
+function executableNames(name, { env = process.env, platform = process.platform } = {}) {
+  if (platform !== "win32") {
+    return [name];
+  }
+  const extensions = (env.PATHEXT || ".COM;.EXE;.BAT;.CMD")
+    .split(";")
+    .map((ext) => ext.trim())
+    .filter(Boolean);
+  return extensions.map((ext) => `${name}${ext.toLowerCase()}`).concat(name);
+}
+
+function isExecutableFile(candidate, { platform = process.platform } = {}) {
+  try {
+    if (!fs.statSync(candidate).isFile()) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+  if (platform === "win32") {
+    return true;
+  }
+  try {
+    fs.accessSync(candidate, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function realPath(target) {
+  try {
+    return fs.realpathSync(target);
+  } catch {
+    return path.resolve(target);
+  }
+}
+
+function sameDirectory(a, b) {
+  if (!a || !b) {
+    return false;
+  }
+  return realPath(a) === realPath(b);
+}
+
+/**
+ * Where npm links global bins. During `postinstall` the link may not exist
+ * yet, so we compare PATH *positions* rather than looking for the file.
+ */
+function npmBinDirs({
+  env = process.env,
+  platform = process.platform,
+  binDir,
+} = {}) {
+  const dirs = [];
+  const prefix = env.npm_config_prefix;
+  if (prefix) {
+    dirs.push(platform === "win32" ? prefix : path.join(prefix, "bin"));
+  }
+  if (process.execPath) {
+    dirs.push(path.dirname(process.execPath));
+  }
+  if (binDir) {
+    dirs.push(binDir);
+  }
+  return dirs;
+}
+
+/**
+ * Walk PATH in order and stop at the first entry that either is one of our own
+ * bin directories or holds an executable named `name`.
+ *
+ * Returns `{ kind: "ours" | "foreign" | "none", directory, resolved }`. A PATH
+ * entry of ours that comes first wins even when it is still empty: npm creates
+ * the link after this script runs, and it will then shadow anything later.
+ */
+function resolveFirstOnPath(
+  name,
+  { env = process.env, platform = process.platform, ownDirs = [] } = {}
+) {
+  const candidateNames = executableNames(name, { env, platform });
+
+  for (const directory of pathEntries({ env, platform })) {
+    if (ownDirs.some((own) => sameDirectory(own, directory))) {
+      return { kind: "ours", directory, resolved: null };
+    }
+    for (const candidateName of candidateNames) {
+      const candidate = path.join(directory, candidateName);
+      if (isExecutableFile(candidate, { platform })) {
+        return { kind: "foreign", directory, resolved: candidate };
+      }
+    }
+  }
+
+  return { kind: "none", directory: null, resolved: null };
+}
+
+/** True when the resolved entry is this package's shim after all. */
+function belongsToThisPackage(resolved, { packageDir = PACKAGE_DIR } = {}) {
+  if (!resolved) {
+    return false;
+  }
+  const real = realPath(resolved);
+  const root = realPath(packageDir);
+  if (real === root || real.startsWith(root + path.sep)) {
+    return true;
+  }
+  // npm's Windows wrappers (.cmd/.ps1) are generated files, not symlinks, so
+  // path comparison misses them — look for the package they point at.
+  try {
+    if (fs.statSync(real).size > 8 * 1024) {
+      return false;
+    }
+    return fs.readFileSync(real, "utf8").includes("@qluent/cli");
+  } catch {
+    return false;
+  }
+}
+
+/** Ask an executable for its version. Returns null if it cannot be run. */
+function readVersion(executable, { spawn = spawnSync } = {}) {
+  try {
+    const result = spawn(executable, ["--version"], {
+      encoding: "utf8",
+      timeout: 10_000,
+      windowsHide: true,
+    });
+    if (!result || result.error || result.status !== 0) {
+      return null;
+    }
+    const output = `${result.stdout || ""} ${result.stderr || ""}`;
+    const match = output.match(/\d+\.\d+\.\d+\S*/);
+    return match ? match[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Name the node version manager whose directory layout contains `target`. */
+function detectVersionManager(target) {
+  if (!target) {
+    return null;
+  }
+  const segments = target.split(/[\\/]/).map((segment) => segment.toLowerCase());
+  for (const marker of VERSION_MANAGER_MARKERS) {
+    if (segments.some((segment) => segment === marker || segment === `.${marker}`)) {
+      return marker;
+    }
+  }
+  if (segments.includes("node-versions")) {
+    return "a node version manager";
+  }
+  return null;
+}
+
+function formatShadowWarning({
+  shadowingPath,
+  shadowingVersion,
+  installedPath,
+  installedVersion,
+  versionManager,
+}) {
+  const describe = (version) => (version ? ` (version ${version})` : "");
+  const lines = [
+    "WARNING: `qluent` on your PATH is not the CLI that was just installed.",
+    `  PATH resolves to: ${shadowingPath}${describe(shadowingVersion)}`,
+    `  just installed:   ${installedPath}${describe(installedVersion)}`,
+    "",
+    "Until that is fixed, `qluent` keeps running the other install. Either",
+    "remove/upgrade it, or put npm's global bin directory earlier on PATH.",
+    "If you already ran `qluent` in this shell, clear its cached lookup with",
+    "`hash -r` (bash) or `rehash` (zsh).",
+  ];
+  if (versionManager) {
+    lines.push(
+      "",
+      `Note: npm's global bin lives under ${versionManager}, so it is scoped to`,
+      "the active node version — the CLI disappears from PATH after a node",
+      "upgrade or in shells started without that environment."
+    );
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Warn when another `qluent` wins on PATH. Returns the warning text (also
+ * logged), or null when the install is the one that will be used.
+ */
+function warnIfShadowed({
+  installedPath,
+  installedVersion,
+  env = process.env,
+  platform = process.platform,
+  binDir = path.join(PACKAGE_DIR, "bin"),
+  packageDir = PACKAGE_DIR,
+  logger = console,
+  spawn = spawnSync,
+} = {}) {
+  const ownDirs = npmBinDirs({ env, platform, binDir });
+  const found = resolveFirstOnPath("qluent", { env, platform, ownDirs });
+
+  if (found.kind !== "foreign") {
+    return null;
+  }
+  if (belongsToThisPackage(found.resolved, { packageDir })) {
+    return null;
+  }
+
+  const warning = formatShadowWarning({
+    shadowingPath: found.resolved,
+    shadowingVersion: readVersion(found.resolved, { spawn }),
+    installedPath,
+    installedVersion,
+    versionManager: detectVersionManager(ownDirs[0] || binDir),
+  });
+  logger.warn ? logger.warn(warning) : logger.log(warning);
+  return warning;
+}
+
+module.exports = {
+  PACKAGE_DIR,
+  VERSION_MANAGER_MARKERS,
+  belongsToThisPackage,
+  detectVersionManager,
+  executableNames,
+  formatShadowWarning,
+  isExecutableFile,
+  npmBinDirs,
+  pathEntries,
+  readVersion,
+  resolveFirstOnPath,
+  warnIfShadowed,
+};

--- a/npm/package.json
+++ b/npm/package.json
@@ -13,6 +13,7 @@
   "files": [
     "bin/qluent.js",
     "lib/installer.js",
+    "lib/shadow-check.js",
     "install.js",
     "README.md"
   ],

--- a/npm/tests/shadow-check.test.js
+++ b/npm/tests/shadow-check.test.js
@@ -1,0 +1,352 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  belongsToThisPackage,
+  detectVersionManager,
+  executableNames,
+  formatShadowWarning,
+  isExecutableFile,
+  npmBinDirs,
+  pathEntries,
+  readVersion,
+  resolveFirstOnPath,
+  warnIfShadowed,
+} = require("../lib/shadow-check");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "qluent-shadow-test-"));
+}
+
+/** Create an executable stub named `qluent` inside `directory`. */
+function makeFakeBinary(directory, name = "qluent") {
+  fs.mkdirSync(directory, { recursive: true });
+  const target = path.join(directory, name);
+  fs.writeFileSync(target, "#!/bin/sh\necho fake\n", { mode: 0o755 });
+  return target;
+}
+
+function collectingLogger() {
+  const messages = [];
+  return {
+    messages,
+    warn: (message) => messages.push(message),
+    log: (message) => messages.push(message),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PATH parsing
+// ---------------------------------------------------------------------------
+
+test("pathEntries splits on the platform delimiter and drops empties", () => {
+  assert.deepEqual(
+    pathEntries({ env: { PATH: "/a::/b:/c" }, platform: "linux" }),
+    ["/a", "/b", "/c"]
+  );
+  assert.deepEqual(
+    pathEntries({ env: { PATH: 'C:\\a;"C:\\b";' }, platform: "win32" }),
+    ["C:\\a", "C:\\b"]
+  );
+});
+
+test("pathEntries returns nothing when PATH is unset", () => {
+  assert.deepEqual(pathEntries({ env: {}, platform: "linux" }), []);
+});
+
+test("executableNames applies PATHEXT on Windows only", () => {
+  assert.deepEqual(executableNames("qluent", { env: {}, platform: "linux" }), [
+    "qluent",
+  ]);
+  assert.deepEqual(
+    executableNames("qluent", { env: { PATHEXT: ".EXE;.CMD" }, platform: "win32" }),
+    ["qluent.exe", "qluent.cmd", "qluent"]
+  );
+});
+
+test("isExecutableFile rejects directories and non-executable files", () => {
+  const dir = makeTempDir();
+  const plain = path.join(dir, "plain");
+  fs.writeFileSync(plain, "hi", { mode: 0o644 });
+
+  assert.equal(isExecutableFile(dir, { platform: "linux" }), false);
+  assert.equal(isExecutableFile(plain, { platform: "linux" }), false);
+  assert.equal(
+    isExecutableFile(path.join(dir, "missing"), { platform: "linux" }),
+    false
+  );
+  assert.equal(isExecutableFile(makeFakeBinary(dir), { platform: "linux" }), true);
+});
+
+// ---------------------------------------------------------------------------
+// Resolution order
+// ---------------------------------------------------------------------------
+
+test("resolveFirstOnPath reports a foreign qluent that comes first", () => {
+  const root = makeTempDir();
+  const other = path.join(root, "local-bin");
+  const npmBin = path.join(root, "npm-bin");
+  fs.mkdirSync(npmBin, { recursive: true });
+  const shadowing = makeFakeBinary(other);
+
+  const found = resolveFirstOnPath("qluent", {
+    env: { PATH: [other, npmBin].join(path.delimiter) },
+    platform: "linux",
+    ownDirs: [npmBin],
+  });
+
+  assert.equal(found.kind, "foreign");
+  assert.equal(found.resolved, shadowing);
+});
+
+test("resolveFirstOnPath is satisfied by our own bin dir coming first", () => {
+  // npm links the shim after postinstall runs, so an empty own directory that
+  // wins on PATH must not be reported as shadowed.
+  const root = makeTempDir();
+  const other = path.join(root, "local-bin");
+  const npmBin = path.join(root, "npm-bin");
+  fs.mkdirSync(npmBin, { recursive: true });
+  makeFakeBinary(other);
+
+  const found = resolveFirstOnPath("qluent", {
+    env: { PATH: [npmBin, other].join(path.delimiter) },
+    platform: "linux",
+    ownDirs: [npmBin],
+  });
+
+  assert.equal(found.kind, "ours");
+  assert.equal(found.resolved, null);
+});
+
+test("resolveFirstOnPath reports none when nothing matches", () => {
+  const root = makeTempDir();
+  const found = resolveFirstOnPath("qluent", {
+    env: { PATH: root },
+    platform: "linux",
+    ownDirs: [],
+  });
+
+  assert.equal(found.kind, "none");
+});
+
+test("npmBinDirs derives the global bin from npm_config_prefix", () => {
+  assert.equal(
+    npmBinDirs({ env: { npm_config_prefix: "/opt/node" }, platform: "linux" })[0],
+    path.join("/opt/node", "bin")
+  );
+  assert.equal(
+    npmBinDirs({ env: { npm_config_prefix: "C:\\node" }, platform: "win32" })[0],
+    "C:\\node"
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Ownership
+// ---------------------------------------------------------------------------
+
+test("belongsToThisPackage accepts paths inside the package", () => {
+  const packageDir = makeTempDir();
+  const binary = makeFakeBinary(path.join(packageDir, "bin"));
+
+  assert.equal(belongsToThisPackage(binary, { packageDir }), true);
+});
+
+test("belongsToThisPackage accepts a generated wrapper naming the package", () => {
+  const packageDir = makeTempDir();
+  const elsewhere = makeTempDir();
+  const wrapper = path.join(elsewhere, "qluent.cmd");
+  fs.writeFileSync(wrapper, '@node "%~dp0\\node_modules\\@qluent/cli\\bin\\qluent.js"');
+
+  assert.equal(belongsToThisPackage(wrapper, { packageDir }), true);
+});
+
+test("belongsToThisPackage rejects an unrelated binary", () => {
+  const packageDir = makeTempDir();
+  const binary = makeFakeBinary(makeTempDir());
+
+  assert.equal(belongsToThisPackage(binary, { packageDir }), false);
+  assert.equal(belongsToThisPackage(null, { packageDir }), false);
+});
+
+// ---------------------------------------------------------------------------
+// Version probing and messaging
+// ---------------------------------------------------------------------------
+
+test("readVersion parses the version out of --version output", () => {
+  const version = readVersion("/somewhere/qluent", {
+    spawn: (executable, args) => {
+      assert.deepEqual(args, ["--version"]);
+      return { status: 0, stdout: "qluent, version 0.1.15\n", stderr: "" };
+    },
+  });
+
+  assert.equal(version, "0.1.15");
+});
+
+test("readVersion returns null when the executable cannot be run", () => {
+  assert.equal(
+    readVersion("/somewhere/qluent", {
+      spawn: () => ({ error: new Error("ENOENT"), status: null }),
+    }),
+    null
+  );
+  assert.equal(
+    readVersion("/somewhere/qluent", {
+      spawn: () => ({ status: 1, stdout: "", stderr: "boom" }),
+    }),
+    null
+  );
+  assert.equal(
+    readVersion("/somewhere/qluent", {
+      spawn: () => {
+        throw new Error("spawn failed");
+      },
+    }),
+    null
+  );
+});
+
+test("detectVersionManager recognises version-scoped install prefixes", () => {
+  assert.equal(
+    detectVersionManager("/home/u/.local/share/fnm/node-versions/v22.23.1/bin"),
+    "fnm"
+  );
+  assert.equal(detectVersionManager("/home/u/.nvm/versions/node/v20.0.0/bin"), "nvm");
+  assert.equal(detectVersionManager("C:\\Users\\u\\AppData\\volta\\bin"), "volta");
+  assert.equal(detectVersionManager("/usr/local/bin"), null);
+  assert.equal(detectVersionManager(null), null);
+});
+
+test("formatShadowWarning names both paths, both versions and hash -r", () => {
+  const warning = formatShadowWarning({
+    shadowingPath: "/home/u/.local/bin/qluent",
+    shadowingVersion: "0.1.15",
+    installedPath: "/npm/node_modules/@qluent/cli/bin/qluent",
+    installedVersion: "0.1.18",
+    versionManager: null,
+  });
+
+  assert.match(warning, /\/home\/u\/\.local\/bin\/qluent/);
+  assert.match(warning, /version 0\.1\.15/);
+  assert.match(warning, /@qluent\/cli\/bin\/qluent/);
+  assert.match(warning, /version 0\.1\.18/);
+  assert.match(warning, /hash -r/);
+  assert.doesNotMatch(warning, /node version/);
+});
+
+test("formatShadowWarning adds the version-manager caveat when relevant", () => {
+  const warning = formatShadowWarning({
+    shadowingPath: "/home/u/.local/bin/qluent",
+    shadowingVersion: null,
+    installedPath: "/fnm/bin/qluent",
+    installedVersion: "0.1.18",
+    versionManager: "fnm",
+  });
+
+  assert.match(warning, /fnm/);
+  assert.match(warning, /active node version/);
+  // An unknown version is simply omitted rather than printed as "undefined".
+  assert.doesNotMatch(warning, /undefined/);
+});
+
+// ---------------------------------------------------------------------------
+// warnIfShadowed
+// ---------------------------------------------------------------------------
+
+test("warnIfShadowed warns when an older qluent wins on PATH", () => {
+  const root = makeTempDir();
+  const other = path.join(root, "local-bin");
+  const npmBin = path.join(root, "npm-bin");
+  fs.mkdirSync(npmBin, { recursive: true });
+  const shadowing = makeFakeBinary(other);
+  const logger = collectingLogger();
+
+  const warning = warnIfShadowed({
+    installedPath: path.join(npmBin, "qluent"),
+    installedVersion: "0.1.18",
+    env: { PATH: [other, npmBin].join(path.delimiter), npm_config_prefix: root },
+    platform: "linux",
+    binDir: npmBin,
+    packageDir: makeTempDir(),
+    logger,
+    spawn: () => ({ status: 0, stdout: "qluent, version 0.1.15\n", stderr: "" }),
+  });
+
+  assert.ok(warning);
+  assert.equal(logger.messages.length, 1);
+  assert.match(warning, new RegExp(shadowing.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.match(warning, /0\.1\.15/);
+  assert.match(warning, /0\.1\.18/);
+});
+
+test("warnIfShadowed stays quiet when our bin directory wins", () => {
+  const root = makeTempDir();
+  const other = path.join(root, "local-bin");
+  const npmBin = path.join(root, "npm-bin");
+  fs.mkdirSync(npmBin, { recursive: true });
+  makeFakeBinary(other);
+  const logger = collectingLogger();
+
+  const warning = warnIfShadowed({
+    installedPath: path.join(npmBin, "qluent"),
+    installedVersion: "0.1.18",
+    env: { PATH: [npmBin, other].join(path.delimiter) },
+    platform: "linux",
+    binDir: npmBin,
+    packageDir: makeTempDir(),
+    logger,
+    spawn: () => ({ status: 0, stdout: "qluent, version 0.1.15\n", stderr: "" }),
+  });
+
+  assert.equal(warning, null);
+  assert.deepEqual(logger.messages, []);
+});
+
+test("warnIfShadowed stays quiet when the resolved entry is our own shim", () => {
+  const root = makeTempDir();
+  const packageDir = path.join(root, "node_modules", "@qluent", "cli");
+  const shimDir = path.join(packageDir, "bin");
+  makeFakeBinary(shimDir);
+  const globalBin = path.join(root, "global-bin");
+  fs.mkdirSync(globalBin, { recursive: true });
+  fs.symlinkSync(path.join(shimDir, "qluent"), path.join(globalBin, "qluent"));
+  const logger = collectingLogger();
+
+  const warning = warnIfShadowed({
+    installedPath: path.join(shimDir, "qluent"),
+    installedVersion: "0.1.18",
+    env: { PATH: globalBin },
+    platform: "linux",
+    binDir: shimDir,
+    packageDir,
+    logger,
+    spawn: () => ({ status: 0, stdout: "qluent, version 0.1.18\n", stderr: "" }),
+  });
+
+  assert.equal(warning, null);
+});
+
+test("warnIfShadowed stays quiet when no qluent is on PATH", () => {
+  const logger = collectingLogger();
+
+  const warning = warnIfShadowed({
+    installedPath: "/npm/bin/qluent",
+    installedVersion: "0.1.18",
+    env: { PATH: makeTempDir() },
+    platform: "linux",
+    binDir: makeTempDir(),
+    packageDir: makeTempDir(),
+    logger,
+    spawn: () => ({ status: 0, stdout: "", stderr: "" }),
+  });
+
+  assert.equal(warning, null);
+  assert.deepEqual(logger.messages, []);
+});


### PR DESCRIPTION
Closes #103

## Problem

`npm install -g @qluent/cli` can report success while a different, older `qluent` keeps winning on `PATH` (a `uv tool` install, a distro package). Nothing detected it, so the user reasonably believed they had upgraded — and below 0.1.18 that means `qluent plan` and `qluent catalog` do not exist, with the plugin silently falling back to the multi-minute NL workflow.

## Changes

- **`npm/lib/shadow-check.js`** (new): resolves `qluent` the way a shell would — PATH order, `PATHEXT` on Windows, executable-bit check — and reports whether the winner is ours.
  - PATH *position* is compared against npm's global bin directory (`npm_config_prefix`, `dirname(process.execPath)`, the package's own `bin/`) rather than looking for the link on disk: npm creates the bin link after `postinstall` runs, so an own directory that comes first must not be reported as shadowed.
  - Our own entry is recognised by realpath (symlink into the package) and, for npm's generated Windows `.cmd`/`.ps1` wrappers, by the `@qluent/cli` reference inside them.
  - The shadowing binary is probed with `--version` (10s timeout, failures ignored) so the warning can show both versions.
  - The message names both paths, both versions, `hash -r`/`rehash` for the shell command-hashing case, and adds the node-version-manager caveat when the install prefix sits under fnm/nvm/volta/nodenv/asdf/nvs.
- **`npm/install.js`**: runs the check after a successful install, inside a `try/catch` — it only ever warns, never fails the install. `QLUENT_SKIP_PATH_CHECK=1` skips it.
- **`npm/package.json`**: ship the new module in `files`.
- **`npm/README.md`**: troubleshooting section for "`qluent --version` shows an older version".

Example output:

```
WARNING: `qluent` on your PATH is not the CLI that was just installed.
  PATH resolves to: /home/ludvig/.local/bin/qluent (version 0.1.15)
  just installed:   /…/@qluent/cli/bin/qluent (version 0.1.18)

Until that is fixed, `qluent` keeps running the other install. Either
remove/upgrade it, or put npm's global bin directory earlier on PATH.
If you already ran `qluent` in this shell, clear its cached lookup with
`hash -r` (bash) or `rehash` (zsh).

Note: npm's global bin lives under fnm, so it is scoped to
the active node version — the CLI disappears from PATH after a node
upgrade or in shells started without that environment.
```

## Tests

`npm test` in `npm/` — 78 pass (20 new in `tests/shadow-check.test.js`): PATH parsing on both platforms, PATHEXT, executable detection, resolution order (foreign first / own dir first / nothing found), ownership via symlink and Windows wrapper, version parsing and its failure modes, version-manager detection, message content, and the four `warnIfShadowed` outcomes. Also exercised end-to-end against a real stub binary on a synthetic PATH. `uv run pytest` unaffected (274 passed).

## Not included

The issue's "Related" note — whether npm is the right channel for a 28MB PyInstaller binary — is left as a separate decision.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPDJqBTQHxKeL1Mh1bqhd7)_