### PR TITLE
ci: run tests on PRs and automate the release from a tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  python:
+    name: Python tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Verify version manifests are in sync
+        run: python scripts/bump_version.py --check
+
+      - name: Run pytest
+        run: uv run pytest -q
+
+  npm:
+    name: npm installer tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run installer tests
+        working-directory: npm
+        run: npm test
+
+  build:
+    name: Binary builds cleanly
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # A PyInstaller build that only breaks at tag time blocks a release at
+      # the worst moment. One cheap native build per PR catches it earlier.
+      - name: Install build dependencies
+        run: python -m pip install -e .[build]
+
+      - name: Build standalone binary
+        run: python -m qluent_cli.build_binary
+
+      - name: Smoke the built binary
+        run: ./dist/binaries/qluent-linux-x64 --version

--- a/.github/workflows/qluent-cli-binaries.yml
+++ b/.github/workflows/qluent-cli-binaries.yml
@@ -12,17 +12,21 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
+      # Every target the npm installer can resolve in lib/installer.js must be
+      # built here. A missing target is invisible until a user on that platform
+      # runs `npm install -g @qluent/cli` and postinstall 404s.
       matrix:
         include:
           - os: macos-14
-            python-version: "3.11"
-            artifact-pattern: "qluent-darwin-*"
+            artifact-pattern: "qluent-darwin-arm64*"
+          - os: macos-13
+            artifact-pattern: "qluent-darwin-x64*"
           - os: ubuntu-latest
-            python-version: "3.11"
-            artifact-pattern: "qluent-linux-*"
+            artifact-pattern: "qluent-linux-x64*"
+          - os: ubuntu-24.04-arm
+            artifact-pattern: "qluent-linux-arm64*"
           - os: windows-latest
-            python-version: "3.11"
-            artifact-pattern: "qluent-windows-*"
+            artifact-pattern: "qluent-windows-x64*"
 
     runs-on: ${{ matrix.os }}
 
@@ -31,7 +35,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
 
       - name: Install build dependencies
         run: python -m pip install -e .[build]
@@ -55,15 +59,38 @@ jobs:
       contents: write
 
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           path: release-assets
           merge-multiple: true
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+      - name: Verify the tag matches the committed version
+        run: python3 scripts/bump_version.py --check "${GITHUB_REF_NAME#v}"
+
+      - name: Verify every platform artifact is present
+        run: |
+          missing=0
+          for artifact in \
+            qluent-darwin-arm64 \
+            qluent-darwin-x64 \
+            qluent-linux-x64 \
+            qluent-linux-arm64 \
+            qluent-windows-x64.exe
+          do
+            if [ ! -f "release-assets/$artifact" ]; then
+              echo "::error::Missing release artifact: $artifact"
+              missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ] || exit 1
+          echo "All 5 platform artifacts present."
 
       - name: Install signing dependencies
         run: python -m pip install "cryptography>=43.0"
@@ -101,3 +128,43 @@ jobs:
           tag_name: ${{ github.ref_name }}
           files: release-assets/*
           generate_release_notes: true
+
+  npm-publish:
+    # The installer downloads from the GitHub release, so the release must
+    # exist before the package that points at it is published. Ordering this
+    # after `release` is what makes an unresolvable install impossible.
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Verify the tag matches the package version
+        working-directory: npm
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          pkg_version="$(node -p "require('./package.json').version")"
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match npm/package.json version $pkg_version"
+            exit 1
+          fi
+          echo "Publishing @qluent/cli@$pkg_version"
+
+      - name: Run installer tests
+        working-directory: npm
+        run: npm test
+
+      - name: Publish to npm
+        working-directory: npm
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/qluent-cli-binaries.yml
+++ b/.github/workflows/qluent-cli-binaries.yml
@@ -133,6 +133,12 @@ jobs:
     # The installer downloads from the GitHub release, so the release must
     # exist before the package that points at it is published. Ordering this
     # after `release` is what makes an unresolvable install impossible.
+    #
+    # Publishing uses npm trusted publishing (OIDC): there is no npm token.
+    # npmjs.com trusts this repository and THIS WORKFLOW FILENAME, so renaming
+    # this file breaks publishing until the trusted publisher is updated. That
+    # binding is also why the job lives here rather than in its own workflow —
+    # a separate file could not express `needs: release`.
     if: startsWith(github.ref, 'refs/tags/v')
     needs: release
     runs-on: ubuntu-latest
@@ -147,6 +153,10 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+
+      # Trusted publishing needs npm >= 11.5.1; Node 22 still bundles npm 10.
+      - name: Upgrade npm
+        run: npm install -g npm@latest
 
       - name: Verify the tag matches the package version
         working-directory: npm
@@ -163,8 +173,8 @@ jobs:
         working-directory: npm
         run: npm test
 
+      # No token and no --provenance: trusted publishing authenticates over
+      # OIDC and attaches provenance attestations automatically.
       - name: Publish to npm
         working-directory: npm
-        run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+# Developer and release entry points for qluent-cli.
+#
+# Releasing is deliberately a single command: every step that used to be a
+# remembered instruction in npm/RELEASING.md is now either a Make target here
+# or a job in .github/workflows/qluent-cli-binaries.yml.
+
+.PHONY: help test test-py test-npm version-check bump release binary smoke
+
+.DEFAULT_GOAL := help
+
+help: ## Show this help
+	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'
+
+test: test-py test-npm ## Run every test suite
+
+test-py: ## Run the Python test suite
+	uv run pytest -q
+
+test-npm: ## Run the npm installer test suite
+	cd npm && npm test
+
+version-check: ## Verify every manifest agrees on one version
+	python3 scripts/bump_version.py --check
+
+binary: ## Build the standalone binary for this platform
+	uv run --extra build python -m qluent_cli.build_binary
+
+smoke: ## Build and smoke-test the binary end to end
+	bash scripts/local_smoke_test.sh
+
+bump: ## Bump every manifest to VERSION (make bump VERSION=0.1.19)
+	@test -n "$(VERSION)" || (echo 'Error: VERSION is required, e.g. make bump VERSION=0.1.19'; exit 1)
+	python3 scripts/bump_version.py $(VERSION)
+
+release: ## Tag and push VERSION, triggering the build+release+npm workflow
+	@test -n "$(VERSION)" || (echo 'Error: VERSION is required, e.g. make release VERSION=0.1.19'; exit 1)
+	@test -z "$$(git status --porcelain)" || (echo 'Error: working tree is dirty; commit the version bump first'; exit 1)
+	@test "$$(git rev-parse --abbrev-ref HEAD)" = main || (echo 'Error: release from main'; exit 1)
+	@git fetch -q origin main && test -z "$$(git rev-list HEAD..origin/main)" \
+		|| (echo 'Error: local main is behind origin/main; pull first'; exit 1)
+	python3 scripts/bump_version.py --check $(VERSION)
+	$(MAKE) test
+	git tag -a v$(VERSION) -m 'Release $(VERSION)'
+	git push origin v$(VERSION)
+	@echo
+	@echo 'Pushed v$(VERSION). CI now builds 5 binaries, signs them, cuts the'
+	@echo 'GitHub release, then publishes @qluent/cli to npm. Watch it with:'
+	@echo '  gh run watch $$(gh run list --workflow=qluent-cli-binaries.yml --limit 1 --json databaseId -q ".[0].databaseId")'
+

--- a/npm/RELEASING.md
+++ b/npm/RELEASING.md
@@ -4,133 +4,105 @@ This package is a thin npm installer for the platform-specific `qluent` binary.
 
 ## Overview
 
-Release flow:
-
-1. Build the standalone `qluent` binaries.
-2. Publish them as GitHub Release assets for the matching tag.
-3. Publish the npm package with the matching version.
-4. Smoke-test `npm install -g @qluent/cli`.
-
-The npm installer expects binaries at:
-
-```text
-https://github.com/qluent/qluent-cli/releases/download/v<VERSION>/
-```
-
-With these names:
-
-```text
-qluent-darwin-arm64
-qluent-darwin-x64
-qluent-linux-x64
-qluent-linux-arm64
-qluent-windows-x64.exe
-```
-
-## Step 1: Build binaries
-
-Build one binary per target platform. Recommended targets:
-
-- macOS arm64
-- macOS x64
-- Linux x64
-- Linux arm64
-- Windows x64
-
-From the `qluent-cli` repo root:
+Releasing is one command from a clean `main`:
 
 ```bash
-uv run --extra build python -m qluent_cli.build_binary
+make bump VERSION=0.1.19     # rewrites all four manifests
+git commit -am "Release 0.1.19"
+# open a PR, merge it, pull main, then:
+make release VERSION=0.1.19  # verifies, tests, tags, pushes
 ```
 
-That produces a correctly named artifact in:
+Pushing the `v*` tag triggers
+[.github/workflows/qluent-cli-binaries.yml](../.github/workflows/qluent-cli-binaries.yml),
+which runs three jobs in order:
+
+1. **build** — one native binary per target on its own runner.
+2. **release** — verifies the tag matches the committed version, verifies all
+   five platform artifacts are present, signs the checksums, and publishes the
+   GitHub Release.
+3. **npm-publish** — re-verifies the tag against `package.json`, runs the
+   installer tests, and publishes `@qluent/cli` with provenance.
+
+`npm-publish` `needs: release`, which is the point: the package can never be
+published pointing at a GitHub Release that does not exist yet.
+
+## Version manifests
+
+The version lives in four files. Never edit them by hand:
 
 ```text
-dist/binaries/
+pyproject.toml               project.version
+src/qluent_cli/__init__.py   __version__
+npm/package.json             version
+uv.lock                      the qluent-cli package entry
 ```
 
-Examples:
+`scripts/bump_version.py` writes all four; `--check` verifies they agree and is
+enforced on every PR by [CI](../.github/workflows/ci.yml) and again at tag time.
+
+## Build targets
+
+`lib/installer.js` resolves five artifacts, so the build matrix must produce
+five. Any target missing from the matrix 404s at `npm install` time on that
+platform and nowhere else:
+
+| Artifact | Runner |
+| --- | --- |
+| `qluent-darwin-arm64` | `macos-14` |
+| `qluent-darwin-x64` | `macos-13` |
+| `qluent-linux-x64` | `ubuntu-latest` |
+| `qluent-linux-arm64` | `ubuntu-24.04-arm` |
+| `qluent-windows-x64.exe` | `windows-latest` |
+
+The release job hard-fails on a missing artifact rather than publishing a
+partial release.
+
+Final URLs, for `v0.1.19`:
 
 ```text
-qluent-darwin-arm64
-qluent-linux-x64
-qluent-windows-x64.exe
-```
-
-PyInstaller builds for the current OS/architecture only, so run the build once per target platform or use native CI runners.
-
-You can also use the standalone GitHub Actions workflow in [.github/workflows/qluent-cli-binaries.yml](../.github/workflows/qluent-cli-binaries.yml) to build native artifacts on macOS, Linux, and Windows runners.
-
-## Step 2: Publish GitHub Release assets
-
-The release workflow publishes each binary and checksum file to the tag's GitHub Release.
-For `v0.1.1`, the final URLs look like:
-
-```text
-https://github.com/qluent/qluent-cli/releases/download/v0.1.1/qluent-darwin-arm64
-https://github.com/qluent/qluent-cli/releases/download/v0.1.1/qluent-linux-x64
-https://github.com/qluent/qluent-cli/releases/download/v0.1.1/qluent-windows-x64.exe
-```
-
-With checksum sidecars:
-
-```text
-https://github.com/qluent/qluent-cli/releases/download/v0.1.1/qluent-darwin-arm64.sha256
-https://github.com/qluent/qluent-cli/releases/download/v0.1.1/qluent-linux-x64.sha256
-https://github.com/qluent/qluent-cli/releases/download/v0.1.1/qluent-windows-x64.exe.sha256
-```
-
-When the `QLUENT_SIGNING_PRIVATE_KEY` secret is set, the build also produces
-Ed25519 signature sidecars (`.sha256.sig`) that the npm installer verifies:
-
-```text
-https://github.com/qluent/qluent-cli/releases/download/v0.1.1/qluent-darwin-arm64.sha256.sig
+https://github.com/qluent/qluent-cli/releases/download/v0.1.19/qluent-darwin-arm64
+https://github.com/qluent/qluent-cli/releases/download/v0.1.19/qluent-darwin-arm64.sha256
+https://github.com/qluent/qluent-cli/releases/download/v0.1.19/qluent-darwin-arm64.sha256.sig
 ```
 
 The npm installer verifies each downloaded binary against its checksum sidecar
-and (when available) the Ed25519 signature before installation.
-If the workflow succeeds but no release appears, confirm the repository allows Actions to create releases.
+and its Ed25519 signature before installing.
 
-## Step 3: Publish npm package
+## Required secrets
 
-From [npm](./):
+| Secret | Used by | Purpose |
+| --- | --- | --- |
+| `QLUENT_SIGNING_PRIVATE_KEY` | `release` | Ed25519 PEM key that signs the checksum sidecars |
+| `NPM_TOKEN` | `npm-publish` | npm granular automation token with publish rights on `@qluent` |
+
+## Releasing the plugin
+
+The Claude Code plugin lives in
+[qluent-plugin-cc](https://github.com/qluent/qluent-plugin-cc) and depends on
+this CLI, never the reverse. `QLUENT_MIN_CLI_VERSION` in
+`plugins/qluent/scripts/cli-requirements.sh` is the declared contract between
+them.
+
+**Always release the CLI first.** A CLI release is backward-compatible for
+plugin users; a plugin release that raised its minimum is not, and it points
+users at an upgrade that does not exist yet. Plugin CI enforces this by
+checking `QLUENT_MIN_CLI_VERSION` against the latest version published here.
+
+## Manual fallback
+
+If you need to build locally rather than in CI:
 
 ```bash
-npm publish --access restricted
+make binary   # current platform only — PyInstaller does not cross-compile
+make smoke    # build plus an end-to-end smoke test
 ```
 
-If you publish to a private registry:
-
-```bash
-npm publish --registry https://<your-registry>
-```
-
-## Step 4: Smoke test
-
-Use a clean machine or container and run:
+Then verify a published release before announcing it:
 
 ```bash
 npm install -g @qluent/cli
-qluent --help
-qluent setup
-```
-
-Also verify override paths:
-
-```bash
-QLUENT_CLI_DIST_BASE_URL=https://github.com/qluent/qluent-cli/releases/download npm install -g @qluent/cli
-```
-
-and:
-
-```bash
-QLUENT_CLI_BIN_URL=https://your-host/qluent-darwin-arm64 npm install -g @qluent/cli
-```
-
-If you need to test an insecure local `http://` host during development, use:
-
-```bash
-QLUENT_CLI_ALLOW_INSECURE_DOWNLOAD=1 QLUENT_CLI_DIST_BASE_URL=http://localhost:9000 npm install -g @qluent/cli
+qluent --version
 ```
 
 ## Signing key management
@@ -164,18 +136,28 @@ console.log('Public key (raw hex):',
 4. Update the `QLUENT_SIGNING_PRIVATE_KEY` secret to the new private key.
 5. After a grace period (2-3 releases), remove the old public key from the array.
 
-### Enabling mandatory signature verification
+### Signature verification
 
-Once all active releases include `.sha256.sig` files, set `SIGNATURE_REQUIRED = true`
-in `lib/installer.js`. Users can still bypass with `QLUENT_CLI_SKIP_SIGNATURE_VERIFICATION=1`
-as an escape hatch.
+`SIGNATURE_REQUIRED = true` in `lib/installer.js`: every release must carry
+`.sha256.sig` sidecars or installs fail. `QLUENT_CLI_SKIP_SIGNATURE_VERIFICATION=1`
+remains the escape hatch. The release job fails when
+`QLUENT_SIGNING_PRIVATE_KEY` is unset, so an unsigned release cannot ship.
 
 ## Rollback
 
-If the npm package is published but release assets are missing or broken:
+The workflow's job ordering makes the classic failure — npm published against a
+missing release — unreachable. What remains:
 
-1. unpublish or deprecate the npm version
-2. fix and re-publish the GitHub Release assets
-3. republish or cut a patch release
+**npm publish failed, GitHub Release succeeded.** The tag and release are fine;
+nothing points at them yet. Fix the cause and re-run the `npm-publish` job from
+the Actions UI. No version bump needed.
 
-Keep the npm package version and release tag aligned.
+**Both succeeded but the build is bad.** Do not unpublish; `npm deprecate` the
+version and roll forward with a patch release:
+
+```bash
+npm deprecate @qluent/cli@0.1.19 "Broken build, use 0.1.20"
+```
+
+The npm package version and the release tag are always equal, verified twice in
+the workflow. Keep it that way.

--- a/npm/RELEASING.md
+++ b/npm/RELEASING.md
@@ -91,9 +91,22 @@ Provenance attestations are generated automatically under trusted publishing;
 the `--provenance` flag is not needed and is deliberately absent.
 
 To reconfigure it: npmjs.com → the `@qluent/cli` package → Settings → Trusted
-Publisher → GitHub Actions, with organization `qluent`, repository `qluent-cli`,
-workflow filename `qluent-cli-binaries.yml`, and no environment. Only
-GitHub-hosted runners are supported, and a package can have one trusted
+Publisher → GitHub Actions.
+
+| Field | Value |
+| --- | --- |
+| Publisher | GitHub Actions |
+| Organization or user | `qluent` |
+| Repository | `qluent-cli` |
+| Workflow filename | `qluent-cli-binaries.yml` |
+| Environment name | *(empty)* |
+| Allowed actions | **Allow `npm publish`** only |
+
+Leave `Allow npm stage publish` unchecked: the workflow runs a plain
+`npm publish`, and granting only what it actually does is the same reasoning
+that made trusted publishing preferable to a token.
+
+Only GitHub-hosted runners are supported, and a package can have one trusted
 publisher at a time.
 
 ### GitHub Actions secrets

--- a/npm/RELEASING.md
+++ b/npm/RELEASING.md
@@ -22,7 +22,8 @@ which runs three jobs in order:
    five platform artifacts are present, signs the checksums, and publishes the
    GitHub Release.
 3. **npm-publish** — re-verifies the tag against `package.json`, runs the
-   installer tests, and publishes `@qluent/cli` with provenance.
+   installer tests, and publishes `@qluent/cli` over OIDC trusted publishing,
+   which attaches provenance automatically.
 
 `npm-publish` `needs: release`, which is the point: the package can never be
 published pointing at a GitHub Release that does not exist yet.
@@ -69,12 +70,39 @@ https://github.com/qluent/qluent-cli/releases/download/v0.1.19/qluent-darwin-arm
 The npm installer verifies each downloaded binary against its checksum sidecar
 and its Ed25519 signature before installing.
 
-## Required secrets
+## Authentication
+
+### npm: trusted publishing, not a token
+
+`npm-publish` authenticates over OIDC. There is no npm token in this repo, and
+there is nothing to rotate or leak. npmjs.com is configured to trust exactly one
+workflow in one repository, so a stolen GitHub secret cannot publish `@qluent/cli`
+from anywhere else.
+
+Two consequences to keep in mind:
+
+- **The workflow filename is load-bearing.** The trusted publisher is registered
+  against `qluent-cli-binaries.yml`. Renaming that file breaks publishing until
+  the setting on npmjs.com is updated to match.
+- **npm must be >= 11.5.1 and Node >= 22.14.0.** Node 22 still bundles npm 10,
+  so the job upgrades npm explicitly before publishing.
+
+Provenance attestations are generated automatically under trusted publishing;
+the `--provenance` flag is not needed and is deliberately absent.
+
+To reconfigure it: npmjs.com → the `@qluent/cli` package → Settings → Trusted
+Publisher → GitHub Actions, with organization `qluent`, repository `qluent-cli`,
+workflow filename `qluent-cli-binaries.yml`, and no environment. Only
+GitHub-hosted runners are supported, and a package can have one trusted
+publisher at a time.
+
+### GitHub Actions secrets
 
 | Secret | Used by | Purpose |
 | --- | --- | --- |
 | `QLUENT_SIGNING_PRIVATE_KEY` | `release` | Ed25519 PEM key that signs the checksum sidecars |
-| `NPM_TOKEN` | `npm-publish` | npm granular automation token with publish rights on `@qluent` |
+
+That is the only secret this repo needs.
 
 ## Releasing the plugin
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Single source of truth for the qluent-cli version.
+
+The version is duplicated across four files that must never drift: a stale
+``npm/package.json`` makes the installer download from a release URL that does
+not exist, which only surfaces on a user's machine at ``npm install`` time.
+
+Usage:
+  python scripts/bump_version.py <version>          Bump every manifest.
+  python scripts/bump_version.py --check [version]  Verify they agree.
+                                                    Pass <version> to require
+                                                    a specific value.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+SEMVER = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class Target:
+    """One version string in one file."""
+
+    def __init__(self, label: str, path: Path, pattern: re.Pattern[str]) -> None:
+        self.label = label
+        self.path = path
+        self.pattern = pattern
+
+    def read(self) -> str | None:
+        match = self.pattern.search(self.path.read_text())
+        return match.group("version") if match else None
+
+    def write(self, version: str) -> None:
+        text = self.path.read_text()
+        new_text, count = self.pattern.subn(
+            lambda m: m.group(0).replace(m.group("version"), version, 1), text, count=1
+        )
+        if count != 1:
+            die(f"Could not locate the version in {self.path}")
+        self.path.write_text(new_text)
+
+
+def targets(root: Path) -> list[Target]:
+    return [
+        Target(
+            "pyproject.toml (project.version)",
+            root / "pyproject.toml",
+            # Anchored to a line-initial `version =`, which only the [project]
+            # block has; dependency pins are all indented inside arrays.
+            re.compile(r'(?m)^version = "(?P<version>[^"]+)"'),
+        ),
+        Target(
+            "src/qluent_cli/__init__.py (__version__)",
+            root / "src" / "qluent_cli" / "__init__.py",
+            re.compile(r'(?m)^__version__ = "(?P<version>[^"]+)"'),
+        ),
+        Target(
+            "npm/package.json (version)",
+            root / "npm" / "package.json",
+            re.compile(r'(?m)^  "version": "(?P<version>[^"]+)"'),
+        ),
+        Target(
+            "uv.lock (qluent-cli package)",
+            root / "uv.lock",
+            # Only the self-entry; every other package has its own version line.
+            re.compile(r'(?m)^name = "qluent-cli"\nversion = "(?P<version>[^"]+)"'),
+        ),
+    ]
+
+
+def die(message: str) -> None:
+    print(f"Error: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def check(root: Path, expected: str | None) -> None:
+    found = [(t.label, t.read()) for t in targets(root)]
+    distinct = {version for _, version in found}
+
+    if len(distinct) != 1:
+        print("Error: version drift detected across manifests:", file=sys.stderr)
+        for label, version in found:
+            print(f"  {label}: {version or '(missing)'}", file=sys.stderr)
+        raise SystemExit(1)
+
+    (actual,) = distinct
+    if not actual or not SEMVER.match(actual):
+        die(f'Version "{actual}" is not a valid semver string')
+    if expected and actual != expected:
+        die(f'Expected version "{expected}" but found "{actual}"')
+
+    print(f"OK: every manifest is at {actual}")
+
+
+def bump(root: Path, version: str) -> None:
+    if not SEMVER.match(version):
+        die(f'"{version}" is not a valid semver string')
+    items = targets(root)
+    for target in items:
+        target.write(version)
+    print(f"Bumped {len(items)} file(s) to {version}:")
+    for target in items:
+        print(f"  {target.path.relative_to(root)}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Bump or verify the qluent-cli version across every manifest."
+    )
+    parser.add_argument(
+        "version", nargs="?", help="the version to set, or to require with --check"
+    )
+    parser.add_argument("--check", action="store_true", help="verify instead of bumping")
+    parser.add_argument("--root", type=Path, default=ROOT, help="repository root")
+    args = parser.parse_args()
+
+    if args.check:
+        check(args.root, args.version)
+    elif args.version:
+        bump(args.root, args.version)
+    else:
+        parser.print_help()
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -1,0 +1,119 @@
+"""Tests for scripts/bump_version.py.
+
+A regex that silently stops matching would let the release workflow tag a
+version that half the manifests disagree with, so the patterns are pinned here
+against realistic file bodies.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "bump_version.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("bump_version", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["bump_version"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+bump_version = _load_module()
+
+
+@pytest.fixture
+def fake_root(tmp_path: Path) -> Path:
+    """A miniature repo whose four manifests all sit at 1.2.3."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\n'
+        'name = "qluent-cli"\n'
+        'version = "1.2.3"\n'
+        'dependencies = [\n'
+        '    "click>=8.0",\n'
+        ']\n'
+    )
+    package = tmp_path / "src" / "qluent_cli"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text('"""Docstring."""\n\n__version__ = "1.2.3"\n')
+    npm = tmp_path / "npm"
+    npm.mkdir()
+    (npm / "package.json").write_text(
+        '{\n  "name": "@qluent/cli",\n  "version": "1.2.3",\n  "license": "UNLICENSED"\n}\n'
+    )
+    (tmp_path / "uv.lock").write_text(
+        '[[package]]\n'
+        'name = "click"\n'
+        'version = "8.1.7"\n'
+        '\n'
+        '[[package]]\n'
+        'name = "qluent-cli"\n'
+        'version = "1.2.3"\n'
+        'source = { editable = "." }\n'
+    )
+    return tmp_path
+
+
+def test_every_target_is_found(fake_root: Path) -> None:
+    for target in bump_version.targets(fake_root):
+        assert target.read() == "1.2.3", target.label
+
+
+def test_check_passes_when_manifests_agree(fake_root: Path, capsys) -> None:
+    bump_version.check(fake_root, None)
+    assert "1.2.3" in capsys.readouterr().out
+
+
+def test_check_accepts_a_matching_expected_version(fake_root: Path) -> None:
+    bump_version.check(fake_root, "1.2.3")
+
+
+def test_check_rejects_a_mismatched_expected_version(fake_root: Path) -> None:
+    with pytest.raises(SystemExit):
+        bump_version.check(fake_root, "1.2.4")
+
+
+def test_check_detects_drift(fake_root: Path) -> None:
+    path = fake_root / "npm" / "package.json"
+    path.write_text(path.read_text().replace("1.2.3", "1.2.4"))
+    with pytest.raises(SystemExit):
+        bump_version.check(fake_root, None)
+
+
+def test_bump_rewrites_every_manifest(fake_root: Path) -> None:
+    bump_version.bump(fake_root, "1.3.0")
+    bump_version.check(fake_root, "1.3.0")
+
+
+def test_bump_leaves_other_packages_alone(fake_root: Path) -> None:
+    """uv.lock lists many packages; only the qluent-cli entry may move."""
+    bump_version.bump(fake_root, "1.3.0")
+    lock = (fake_root / "uv.lock").read_text()
+    assert 'name = "click"\nversion = "8.1.7"' in lock
+    assert 'name = "qluent-cli"\nversion = "1.3.0"' in lock
+
+
+def test_bump_leaves_dependency_pins_alone(fake_root: Path) -> None:
+    bump_version.bump(fake_root, "1.3.0")
+    assert '"click>=8.0"' in (fake_root / "pyproject.toml").read_text()
+
+
+def test_bump_rejects_a_non_semver_version(fake_root: Path) -> None:
+    with pytest.raises(SystemExit):
+        bump_version.bump(fake_root, "not-a-version")
+
+
+def test_bump_accepts_a_prerelease(fake_root: Path) -> None:
+    bump_version.bump(fake_root, "1.3.0-rc1")
+    bump_version.check(fake_root, "1.3.0-rc1")
+
+
+def test_real_repo_manifests_are_in_sync() -> None:
+    """The guard CI and the release workflow both run."""
+    bump_version.check(REPO_ROOT, None)


### PR DESCRIPTION
## Why

Two gaps, both of which only ever surface on a user's machine:

- **No tests ran in CI.** `tests/` and `npm/tests/` existed; no workflow invoked them. Binaries shipped to users without a single test executing.
- **Two of five platforms were never built.** `npm/lib/installer.js` resolves `darwin-x64`, `darwin-arm64`, `linux-x64`, `linux-arm64`, `windows-x64`. The matrix built three. `gh release view v0.1.18` confirms `qluent-darwin-x64` and `qluent-linux-arm64` have never existed, so `npm install -g @qluent/cli` has been failing at postinstall on Intel Macs and ARM Linux.

Releases were also a sequence of remembered manual steps, with the version hand-edited across four files.

## What changed

- **`.github/workflows/ci.yml`** — pytest, npm installer tests, version-sync check, and one native PyInstaller build on every PR.
- **`scripts/bump_version.py`** — sole writer of the four files carrying the version (`pyproject.toml`, `__init__.py`, `npm/package.json`, `uv.lock`). `--check` catches drift; enforced in CI and again at tag time. Ported from the plugin repo's `bump-version.mjs`. Covered by `tests/test_bump_version.py`.
- **Build matrix extended to all five targets** (`macos-13` for darwin-x64, `ubuntu-24.04-arm` for linux-arm64). The release job now hard-fails on a missing artifact rather than publishing a partial release.
- **`npm-publish` job** — publishes with provenance, `needs: release`. The package can no longer point at a GitHub release that does not exist.
- **`Makefile`** — `make test`, `make bump VERSION=`, `make release VERSION=`. The release target refuses a dirty tree, a non-`main` branch, a stale `main`, or manifests that disagree with `VERSION`.
- **`npm/RELEASING.md`** rewritten. Also corrects `--access restricted` → `public` (the package resolves without auth, so it is public) and the stale "enabling mandatory signature verification" section (`SIGNATURE_REQUIRED` is already `true`).

## Before merging

`NPM_TOKEN` must be added as a repo secret — a granular automation token with publish rights on `@qluent`. Without it the `npm-publish` job fails at tag time.

## Not in scope

Lint. `ruff` runs on defaults here and reports 91 errors across 46 files; picking a config or reformatting is a style decision that shouldn't ride along in release plumbing.

## Test plan

- `uv run pytest -q` → 289 passed (278 existing + 11 new)
- `cd npm && npm test` → 78 passed
- `make bump` round-trip produces exactly the 4-file diff of `c6560f0`
- drift injected into any one manifest → `--check` exits 1