### PR TITLE
Release 0.1.19

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qluent/cli",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Install the Qluent CLI",
   "license": "UNLICENSED",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qluent-cli"
-version = "0.1.18"
+version = "0.1.19"
 description = "CLI for Qluent metric tree analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/qluent_cli/__init__.py
+++ b/src/qluent_cli/__init__.py
@@ -1,3 +1,3 @@
 """Qluent CLI — metric tree analysis from the command line."""
 
-__version__ = "0.1.18"
+__version__ = "0.1.19"

--- a/uv.lock
+++ b/uv.lock
@@ -672,7 +672,7 @@ wheels = [
 
 [[package]]
 name = "qluent-cli"
-version = "0.1.18"
+version = "0.1.19"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Version bump only, produced by `make bump VERSION=0.1.19`.

## What ships in 0.1.19

- `fbed297` — treat `QUERY_CATALOG_INVALID` as a hard error rather than a repairable plan. Previously an agent would burn repair loops rewriting a plan against a catalog that cannot load, when no plan will ever compile.
- `eae4fd3` — warn when another `qluent` shadows the installed binary on PATH.

## First release on the new pipeline

This is also the first release built by the reworked workflow, so two things change beyond the commits above:

- **All five platforms are built.** `qluent-darwin-x64` and `qluent-linux-arm64` have never existed in any prior release, so `npm install -g @qluent/cli` has been failing at postinstall on Intel Macs and ARM Linux. 0.1.19 is the first release that installs everywhere the installer claims to support.
- **npm publishing is automatic**, over OIDC trusted publishing — no token — and gated on the GitHub release succeeding first.

## Test plan

Version-sync is enforced by CI on this PR and re-verified against the tag at release time.