### PR TITLE
fix(ci): build Intel macOS on macos-15-intel, not the retired macos-13

### DIFF
--- a/.github/workflows/qluent-cli-binaries.yml
+++ b/.github/workflows/qluent-cli-binaries.yml
@@ -19,7 +19,11 @@ jobs:
         include:
           - os: macos-14
             artifact-pattern: "qluent-darwin-arm64*"
-          - os: macos-13
+          # Intel macOS. `macos-13` was retired in December 2025; this label
+          # is the supported x86_64 image and is available until August 2027,
+          # after which GitHub drops x86_64 macOS entirely and darwin-x64 will
+          # need cross-compilation under Rosetta on an arm64 runner.
+          - os: macos-15-intel
             artifact-pattern: "qluent-darwin-x64*"
           - os: ubuntu-latest
             artifact-pattern: "qluent-linux-x64*"
@@ -29,6 +33,7 @@ jobs:
             artifact-pattern: "qluent-windows-x64*"
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4

--- a/npm/RELEASING.md
+++ b/npm/RELEASING.md
@@ -51,13 +51,20 @@ platform and nowhere else:
 | Artifact | Runner |
 | --- | --- |
 | `qluent-darwin-arm64` | `macos-14` |
-| `qluent-darwin-x64` | `macos-13` |
+| `qluent-darwin-x64` | `macos-15-intel` |
 | `qluent-linux-x64` | `ubuntu-latest` |
 | `qluent-linux-arm64` | `ubuntu-24.04-arm` |
 | `qluent-windows-x64.exe` | `windows-latest` |
 
 The release job hard-fails on a missing artifact rather than publishing a
 partial release.
+
+Runner labels are load-bearing and they expire. A label that no longer exists
+does not fail the build — it queues until GitHub gives up, which is how the
+retired `macos-13` image silently stalled the first 0.1.19 attempt. The build
+job carries a 30-minute timeout so that shows up as a failure. GitHub drops
+x86_64 macOS entirely when the macOS 15 image retires in Fall 2027; after that,
+`qluent-darwin-x64` needs cross-compilation under Rosetta on an arm64 runner.
 
 Final URLs, for `v0.1.19`:
 


### PR DESCRIPTION
Caught on the first real 0.1.19 release attempt.

## What happened

Four of five builds went green in about two minutes. `macos-13` sat queued indefinitely. The [macOS 13 image was retired in December 2025](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/) — I picked a label that no longer exists.

The failure mode is the nasty part: an unknown runner label does not error. The job queues until GitHub gives up 24 hours later, so the release just stalls with no red anywhere.

Nothing shipped — no GitHub release was created and npm is still on 0.1.18 — so the run was cancelled and `v0.1.19` will be re-tagged onto this fix.

## Changes

- `macos-13` → **`macos-15-intel`**, the supported x86_64 macOS label, [available until August 2027](https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/).
- 30-minute `timeout-minutes` on the build job, so a stalled runner shows up as a failure rather than a hang.
- `RELEASING.md` records both the label change and the expiry.

## Worth knowing

GitHub drops x86_64 macOS entirely when the macOS 15 image retires in **Fall 2027**. At that point `qluent-darwin-x64` needs cross-compilation under Rosetta on an arm64 runner, or the target gets dropped. Not urgent, but it is a dated dependency now written down rather than rediscovered.