### PR TITLE
fix(npm): declare repository so provenance verification can succeed

### DIFF
--- a/npm/RELEASING.md
+++ b/npm/RELEASING.md
@@ -97,6 +97,12 @@ Two consequences to keep in mind:
 Provenance attestations are generated automatically under trusted publishing;
 the `--provenance` flag is not needed and is deliberately absent.
 
+Provenance also imposes a requirement on the manifest: `repository.url` in
+`npm/package.json` must match the repository the OIDC token was issued for, or
+the registry rejects the upload with a 422 after the binaries have already been
+built, signed and released. `npm/tests/package-manifest.test.js` pins that
+field so the failure surfaces on a PR rather than mid-release.
+
 To reconfigure it: npmjs.com → the `@qluent/cli` package → Settings → Trusted
 Publisher → GitHub Actions.
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.19",
   "description": "Install the Qluent CLI",
   "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/qluent/qluent-cli.git",
+    "directory": "npm"
+  },
   "bin": {
     "qluent": "bin/qluent.js"
   },

--- a/npm/tests/package-manifest.test.js
+++ b/npm/tests/package-manifest.test.js
@@ -1,0 +1,40 @@
+const assert = require("node:assert");
+const test = require("node:test");
+const path = require("node:path");
+
+const pkg = require("../package.json");
+
+// npm's provenance verification compares package.json's repository.url against
+// the repository the OIDC token was issued for, and rejects the publish with a
+// 422 when they disagree. An absent field reads as "" and fails the same way —
+// after the binaries are built, signed and released, so the cost of finding out
+// at publish time is a whole wasted release run.
+const EXPECTED_REPOSITORY_URL = "git+https://github.com/qluent/qluent-cli.git";
+
+test("package.json declares a repository for provenance verification", () => {
+  assert.ok(pkg.repository, "package.json must declare a repository");
+  assert.strictEqual(pkg.repository.type, "git");
+  assert.strictEqual(pkg.repository.url, EXPECTED_REPOSITORY_URL);
+});
+
+test("repository.directory points at this package inside the monorepo", () => {
+  assert.strictEqual(pkg.repository.directory, "npm");
+});
+
+test("every published file is present on disk", () => {
+  const fs = require("node:fs");
+  const root = path.join(__dirname, "..");
+  for (const relative of pkg.files) {
+    assert.ok(
+      fs.existsSync(path.join(root, relative)),
+      `package.json "files" lists ${relative}, which does not exist`
+    );
+  }
+});
+
+test("the postinstall entry point is published", () => {
+  // install.js runs on every consumer install; shipping a package without it
+  // would silently install no binary at all.
+  assert.ok(pkg.files.includes("install.js"));
+  assert.strictEqual(pkg.scripts.postinstall, "node install.js");
+});


### PR DESCRIPTION
## What happened on 0.1.19

Everything succeeded except the last step. All five binaries built (including `darwin-x64` and `linux-arm64` for the first time), all fifteen release assets were signed and published, and then:

```
npm error code E422
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@qluent%2fcli
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match "https://github.com/qluent/qluent-cli" from provenance
```

**Trusted publishing itself worked.** The log shows `Signed provenance statement with source and build information from GitHub Actions` and the statement reached the [Sigstore transparency log](https://search.sigstore.dev/?logIndex=2660789987). The registry rejected the upload because `npm/package.json` never declared a `repository`, so provenance had nothing to verify its claim against.

The field was optional for years — it only became load-bearing when we turned on provenance, which is why nothing had ever missed it.

## Changes

- `npm/package.json` declares `repository` (`git+https://github.com/qluent/qluent-cli.git`, `directory: "npm"`).
- `npm/tests/package-manifest.test.js` pins that field, and additionally asserts every path in `files` exists on disk and that the `postinstall` entry point ships. Each of those otherwise fails at publish time — after five binaries have been built, signed and released.
- `RELEASING.md` records the provenance/manifest coupling.

Verified the guard catches the real bug: removing `repository` makes `npm test` exit 1; restoring it passes. Suite is 82 tests, up from 78.

## Note on the failure mode

This is the second dated/implicit external requirement to bite this pipeline in one day, after the retired `macos-13` runner. Both were invisible until a real release ran. Both now have a check that runs on every PR.