### PR TITLE
Release 0.1.20

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qluent/cli",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Install the Qluent CLI",
   "license": "UNLICENSED",
   "repository": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qluent-cli"
-version = "0.1.19"
+version = "0.1.20"
 description = "CLI for Qluent metric tree analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/qluent_cli/__init__.py
+++ b/src/qluent_cli/__init__.py
@@ -1,3 +1,3 @@
 """Qluent CLI — metric tree analysis from the command line."""
 
-__version__ = "0.1.19"
+__version__ = "0.1.20"

--- a/uv.lock
+++ b/uv.lock
@@ -672,7 +672,7 @@ wheels = [
 
 [[package]]
 name = "qluent-cli"
-version = "0.1.19"
+version = "0.1.20"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Version bump only, produced by `make bump VERSION=0.1.20`.

## Why 0.1.20 and not 0.1.19

The 0.1.19 release built and published all fifteen signed assets to GitHub, then failed at `npm publish` with a provenance 422 (missing `repository` in `package.json`, fixed in #111). Those release artifacts are public, so the version is not reusable. The orphaned `v0.1.19` release and tag will be deleted once 0.1.20 lands, leaving no GitHub release without a matching npm version.

## What ships

- `fbed297` — treat `QUERY_CATALOG_INVALID` as a hard error rather than a repairable plan
- `eae4fd3` — warn when another `qluent` shadows the installed binary on PATH
- `0f88c29` — build Intel macOS on `macos-15-intel` (the retired `macos-13` label stalled indefinitely)
- `a02ead1` — declare `repository` so npm provenance verification succeeds

## First complete run of the new pipeline

- **All five platforms.** `qluent-darwin-x64` and `qluent-linux-arm64` have never shipped in any prior release, so `npm install -g @qluent/cli` has been failing at postinstall on Intel Macs and ARM Linux. Verified building on `main` via a build-only `workflow_dispatch` before tagging.
- **npm publish over OIDC trusted publishing** — no token in the repo — gated on the GitHub release succeeding first.