### PR TITLE
ci: move every action to its Node 24 major

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10
         with:
           enable-cache: true
 
@@ -32,9 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
 
@@ -47,9 +47,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10
+        # Pinned exactly: setup-uv stopped publishing floating major tags
+        # after v7, so `@v10` does not resolve.
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
 

--- a/.github/workflows/qluent-cli-binaries.yml
+++ b/.github/workflows/qluent-cli-binaries.yml
@@ -36,9 +36,9 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
@@ -49,7 +49,7 @@ jobs:
         run: python -m qluent_cli.build_binary
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: qluent-${{ runner.os }}-${{ runner.arch }}
           path: dist/binaries/${{ matrix.artifact-pattern }}
@@ -64,14 +64,14 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: release-assets
           merge-multiple: true
@@ -128,7 +128,7 @@ jobs:
           PY
 
       - name: Publish GitHub release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           files: release-assets/*
@@ -152,9 +152,9 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org

--- a/npm/RELEASING.md
+++ b/npm/RELEASING.md
@@ -59,6 +59,11 @@ platform and nowhere else:
 The release job hard-fails on a missing artifact rather than publishing a
 partial release.
 
+Action versions are load-bearing too. Most actions publish a floating major
+tag (`@v7`), but not all do — `astral-sh/setup-uv` stopped after `v7`, so it is
+pinned to an exact version. A tag that does not resolve fails the job outright,
+which is at least loud.
+
 Runner labels are load-bearing and they expire. A label that no longer exists
 does not fail the build — it queues until GitHub gives up, which is how the
 retired `macos-13` image silently stalled the first 0.1.19 attempt. The build


### PR DESCRIPTION
Clears the `Node.js 20 is deprecated ... being forced to run on Node.js 24` annotation on every job. A warning today, a hard failure once the runners stop forcing it.

## Versions

I pulled the current majors from the API rather than assuming `v5` — the actions have moved considerably further than that:

| Action | From | To |
| --- | --- | --- |
| `actions/checkout` | v4 | **v7** |
| `actions/setup-python` | v5 | **v7** |
| `actions/setup-node` | v4 | **v7** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/download-artifact` | v4 | **v8** |
| `astral-sh/setup-uv` | v5 | **v10** |
| `softprops/action-gh-release` | v2 | **v3** |

## Compatibility checked, not assumed

Verified every input this repo actually passes still exists on the new majors: `merge-multiple` (download-artifact v8), `enable-cache` (setup-uv v10), `registry-url` (setup-node v7), `if-no-files-found` / `retention-days` (upload-artifact v7).

The intervening majors are Node 24 runtime bumps and ESM migrations. `upload-artifact@v7` adds an `archive` input that defaults to the existing behaviour.

**One deliberate behaviour change rides along:** `download-artifact@v8` errors on a hash mismatch by default rather than warning. That is the right default for a pipeline that signs whatever it downloads.

## Test coverage caveat

CI on this PR exercises `checkout`, `setup-python`, `setup-node` and `setup-uv`. `upload-artifact` is exercised by a build-only `workflow_dispatch`, which I will run on `main` after merge.

`download-artifact` and `action-gh-release` only run on a tag ref, so they are first exercised by the next real release. That failure is contained by design — the `release` job failing means nothing is signed, published, or sent to npm.