### PR TITLE
docs: record the release flow and correct the stale command list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This is the source repo for the `qluent` CLI tool. For the Claude Code plugin
 
 ```
 src/qluent_cli/
-├── main.py                # CLI entry point (Click groups: trees, rca, config, setup, login, claude, instructions, elasticity)
+├── main.py                # CLI entry point (see `qluent --help` for the full command list)
 ├── trees.py               # `qluent trees` command group (list, match, get, validate, evaluate, trend, compare, investigate)
 ├── rca.py                 # `qluent rca` command group (analyze)
 ├── elasticity.py          # `qluent elasticity` command
@@ -40,26 +40,51 @@ src/qluent_cli/
 
 npm/                 # NPM package (@qluent/cli) — Node.js shim that spawns the Python binary
 tests/               # pytest test suite
-scripts/             # Smoke tests and release helpers
+scripts/             # bump_version.py (version manifests) and local_smoke_test.sh
+Makefile             # Developer and release entry points
 ```
 
 ## Running tests
 
 ```bash
+make test                                              # pytest + npm installer tests
 uv run pytest
 uv run pytest tests/test_trees.py -k "test_evaluate"   # single test
 ```
 
+CI runs pytest, the npm installer tests, and a native binary build on every PR.
+
 ## Building binaries
 
 ```bash
-uv run python -m qluent_cli.build_binary
+make binary   # or: uv run python -m qluent_cli.build_binary
 # Output: dist/binaries/qluent-<platform>-<arch>
 ```
 
+PyInstaller builds for the current platform only. CI builds all five targets the
+npm installer can resolve.
+
+## Releasing
+
+The version lives in four files. Never edit them by hand — `scripts/bump_version.py`
+is the only writer, and CI fails on drift.
+
+```bash
+make bump VERSION=0.1.21     # pyproject, __init__.py, npm/package.json, uv.lock
+git commit -am "Release 0.1.21"
+# PR, merge, pull main, then:
+make release VERSION=0.1.21  # verifies, tests, tags, pushes
+```
+
+The tag triggers build → sign → GitHub release → npm publish (OIDC trusted
+publishing, no token). See [npm/RELEASING.md](npm/RELEASING.md) for the full
+flow, the cross-repo ordering rule with the plugin, and rollback.
+
 ## CLI architecture
 
-- **Click** groups: `cli` → `trees`, `rca`, `config`, `setup`, `login`, `claude`, `instructions`
+- **Click** commands: `trees`, `query`, `catalog`, `plan`, `rca`, `elasticity`,
+  `suggestions`, `runs`, `agents`, `claude`, `mcp`, `config`, `setup`, `login`,
+  `status`/`whoami`, `instructions`
 - **httpx** client with API key auth (`X-API-Key` header)
 - Config stored at `~/.qluent/config.json` (api_key, api_url, project_uuid, user_email, client_safe)
 - `--json-output` flag on all tree/rca commands for structured output

--- a/npm/RELEASING.md
+++ b/npm/RELEASING.md
@@ -7,10 +7,10 @@ This package is a thin npm installer for the platform-specific `qluent` binary.
 Releasing is one command from a clean `main`:
 
 ```bash
-make bump VERSION=0.1.19     # rewrites all four manifests
-git commit -am "Release 0.1.19"
+make bump VERSION=0.1.21     # rewrites all four manifests
+git commit -am "Release 0.1.21"
 # open a PR, merge it, pull main, then:
-make release VERSION=0.1.19  # verifies, tests, tags, pushes
+make release VERSION=0.1.21  # verifies, tests, tags, pushes
 ```
 
 Pushing the `v*` tag triggers
@@ -71,12 +71,12 @@ job carries a 30-minute timeout so that shows up as a failure. GitHub drops
 x86_64 macOS entirely when the macOS 15 image retires in Fall 2027; after that,
 `qluent-darwin-x64` needs cross-compilation under Rosetta on an arm64 runner.
 
-Final URLs, for `v0.1.19`:
+Final URLs, for `v0.1.21`:
 
 ```text
-https://github.com/qluent/qluent-cli/releases/download/v0.1.19/qluent-darwin-arm64
-https://github.com/qluent/qluent-cli/releases/download/v0.1.19/qluent-darwin-arm64.sha256
-https://github.com/qluent/qluent-cli/releases/download/v0.1.19/qluent-darwin-arm64.sha256.sig
+https://github.com/qluent/qluent-cli/releases/download/v0.1.21/qluent-darwin-arm64
+https://github.com/qluent/qluent-cli/releases/download/v0.1.21/qluent-darwin-arm64.sha256
+https://github.com/qluent/qluent-cli/releases/download/v0.1.21/qluent-darwin-arm64.sha256.sig
 ```
 
 The npm installer verifies each downloaded binary against its checksum sidecar
@@ -215,7 +215,7 @@ the Actions UI. No version bump needed.
 version and roll forward with a patch release:
 
 ```bash
-npm deprecate @qluent/cli@0.1.19 "Broken build, use 0.1.20"
+npm deprecate @qluent/cli@0.1.21 "Broken build, use 0.1.22"
 ```
 
 The npm package version and the release tag are always equal, verified twice in


### PR DESCRIPTION
Found while auditing repo state after 0.1.20. Docs only — no behaviour change.

## 1. CLAUDE.md did not describe the release process

The Makefile, `scripts/bump_version.py` and the tag-triggered pipeline all exist now and none were mentioned. Added a `## Releasing` section, plus `make test` / `make binary` in the existing sections and a note that CI builds all five targets.

## 2. CLAUDE.md's command list was stale

It read `trees, rca, config, setup, login, claude, instructions, elasticity` — missing `query`, `catalog`, `plan`, `runs`, `agents`, `mcp` and `status`/`whoami`. That omits the entire compose/query path, which is the default workflow. Replaced with the current list taken from `qluent --help`, and pointed the file-tree annotation at `--help` so it cannot drift again.

## 3. RELEASING.md's examples pointed at a deleted release

The doc used `0.1.19` throughout, including literal download URLs. 0.1.19 was cut and then deleted after the provenance failure, so those URLs 404. Examples moved to `0.1.21`. The one factual reference to the failed 0.1.19 attempt is intentionally kept.

## Still outstanding after this

- **`src/qluent_cli/` file tree in CLAUDE.md is missing 13 modules** — `plan.py`, `query.py`, `plan_contracts.py`, `query_contracts.py`, `runs.py`, `run_manager.py`, `window_resolver.py`, `rendering.py`, `command_runner.py`, `contracts.py`, `investigation_contracts.py`, `client_configs.py`, `__main__.py`. Not fixed here because writing an accurate one-line description per module is real work, not a mechanical edit, and it predates this branch of work.