### PR TITLE
ci: handle prerelease tags without publishing them to npm

### DIFF
--- a/.github/workflows/qluent-cli-binaries.yml
+++ b/.github/workflows/qluent-cli-binaries.yml
@@ -133,6 +133,9 @@ jobs:
           tag_name: ${{ github.ref_name }}
           files: release-assets/*
           generate_release_notes: true
+          # A tag carrying a prerelease suffix (v0.1.21-rc1) is marked as such,
+          # so it never shows as the repository's latest release.
+          prerelease: ${{ contains(github.ref_name, '-') }}
 
   npm-publish:
     # The installer downloads from the GitHub release, so the release must
@@ -144,7 +147,12 @@ jobs:
     # this file breaks publishing until the trusted publisher is updated. That
     # binding is also why the job lives here rather than in its own workflow —
     # a separate file could not express `needs: release`.
-    if: startsWith(github.ref, 'refs/tags/v')
+    #
+    # Prerelease tags stop here. `npm publish` would tag the prerelease as
+    # `latest` and serve it to every plain `npm install`, and a published npm
+    # version cannot be taken back. A prerelease tag therefore exercises the
+    # build and release path and leaves the registry alone.
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     needs: release
     runs-on: ubuntu-latest
     permissions:

--- a/npm/RELEASING.md
+++ b/npm/RELEASING.md
@@ -28,6 +28,22 @@ which runs three jobs in order:
 `npm-publish` `needs: release`, which is the point: the package can never be
 published pointing at a GitHub Release that does not exist yet.
 
+## Prereleases
+
+A tag with a prerelease suffix — `v0.1.21-rc1` — runs **build** and **release**
+and then stops. It is marked as a prerelease on GitHub so it never displays as
+the latest release, and `npm-publish` is skipped: `npm publish` would tag it
+`latest` and serve it to every plain `npm install`, and a published npm version
+cannot be taken back.
+
+That makes a prerelease tag the way to exercise the release path end to end
+without touching the registry — worth doing after changing anything in the
+`release` job, whose actions are otherwise first executed during a real release.
+
+The tag does not have to be on `main`. Branch, `make bump VERSION=0.1.21-rc1`,
+commit, tag that commit and push only the tag; `main` keeps its version. Delete
+the tag, the prerelease and the branch afterwards.
+
 ## Version manifests
 
 The version lives in four files. Never edit them by hand:


### PR DESCRIPTION
Prerequisite for rehearsing the release path safely.

## The problem

A tag like `v0.1.21-rc1` was treated exactly like a real release: `npm-publish` would run and publish it under the **`latest`** dist-tag, serving a release candidate to every plain `npm install -g @qluent/cli`. And a published npm version cannot be taken back.

So there was no safe way to exercise the release path — which matters, because the `release` job's actions (`download-artifact`, `action-gh-release`) only ever execute on a tag ref. After the recent bump to `@v8`/`@v3` they have never run at all, and would first execute during a real release.

## Changes

- `npm-publish` skips tags containing `-`: `startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')`
- `action-gh-release` gets `prerelease: ${{ contains(github.ref_name, '-') }}`, so an rc never displays as the repository's latest release.
- `RELEASING.md` documents the prerelease flow, including that the tag need not be on `main` — branch, bump, tag that commit, push only the tag, and `main` keeps its version.

## Next

Once this lands I'll cut a throwaway `v0.1.21-rc1` off a scratch branch to verify `download-artifact@v8` and `action-gh-release@v3` actually work, then delete the tag, the prerelease and the branch. `main` stays at 0.1.20 and npm is untouched.