### PR TITLE
fix: build binaries from the lockfile and bound mcp below 2.x (#116)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,17 +51,34 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v7
+      - name: Install uv
+        # Pinned exactly: setup-uv stopped publishing floating major tags
+        # after v7, so `@v10` does not resolve.
+        uses: astral-sh/setup-uv@v10.0.1
         with:
-          python-version: "3.11"
+          enable-cache: true
 
       # A PyInstaller build that only breaks at tag time blocks a release at
       # the worst moment. One cheap native build per PR catches it earlier.
+      #
+      # Built from the lockfile rather than a fresh resolve, so the binary is
+      # compiled against the same dependency set the tests ran against. The
+      # explicit --python matches what setup-python pinned before uv took over.
       - name: Install build dependencies
-        run: python -m pip install -e .[build]
+        run: uv sync --frozen --no-dev --extra build --python 3.11
 
       - name: Build standalone binary
-        run: python -m qluent_cli.build_binary
+        run: uv run --frozen --no-dev --extra build python -m qluent_cli.build_binary
 
       - name: Smoke the built binary
         run: ./dist/binaries/qluent-linux-x64 --version
+
+      # `--version` never imports the mcp SDK -- main.py defers that import
+      # into the `mcp serve` body -- so only a real handshake reaches the code
+      # that shipped broken in 0.1.20. It has to run against the packaged
+      # binary: the unit tests exercise the module, not the artifact.
+      - name: Smoke the MCP stdio handshake
+        run: |
+          printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci","version":"0"}}}' \
+            | timeout 30 ./dist/binaries/qluent-linux-x64 mcp serve > handshake.json || true
+          grep -q '"serverInfo"' handshake.json

--- a/.github/workflows/qluent-cli-binaries.yml
+++ b/.github/workflows/qluent-cli-binaries.yml
@@ -38,15 +38,23 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v7
+      - name: Install uv
+        # Pinned exactly: setup-uv stopped publishing floating major tags
+        # after v7, so `@v10` does not resolve.
+        uses: astral-sh/setup-uv@v10.0.1
         with:
-          python-version: "3.11"
+          enable-cache: true
 
+      # --frozen builds the shipped artifact from uv.lock, the same dependency
+      # set CI tested. A plain `pip install -e .[build]` re-resolves every
+      # unbounded pin at build time, so the binary users receive is compiled
+      # against versions no test has run: that is how 0.1.20 shipped with an
+      # `mcp` 2.x that has no `Server.list_tools`, breaking `mcp serve` (#116).
       - name: Install build dependencies
-        run: python -m pip install -e .[build]
+        run: uv sync --frozen --no-dev --extra build --python 3.11
 
       - name: Build standalone binary
-        run: python -m qluent_cli.build_binary
+        run: uv run --frozen --no-dev --extra build python -m qluent_cli.build_binary
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v7

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qluent/cli",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Install the Qluent CLI",
   "license": "UNLICENSED",
   "repository": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "qluent-cli"
-version = "0.1.20"
+version = "0.1.21"
 description = "CLI for Qluent metric tree analysis"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "click>=8.0",
     "httpx>=0.25",
-    "mcp>=1.0",
+    "mcp>=1.27,<2",
 ]
 
 [project.optional-dependencies]

--- a/src/qluent_cli/__init__.py
+++ b/src/qluent_cli/__init__.py
@@ -1,3 +1,3 @@
 """Qluent CLI — metric tree analysis from the command line."""
 
-__version__ = "0.1.20"
+__version__ = "0.1.21"

--- a/uv.lock
+++ b/uv.lock
@@ -672,7 +672,7 @@ wheels = [
 
 [[package]]
 name = "qluent-cli"
-version = "0.1.20"
+version = "0.1.21"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -696,7 +696,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.0" },
     { name = "cryptography", marker = "extra == 'build'", specifier = ">=43.0" },
     { name = "httpx", specifier = ">=0.25" },
-    { name = "mcp", specifier = ">=1.0" },
+    { name = "mcp", specifier = ">=1.27,<2" },
     { name = "pyinstaller", marker = "extra == 'build'", specifier = ">=6.0" },
 ]
 provides-extras = ["build"]


### PR DESCRIPTION
Fixes #116.

`qluent mcp serve` crashed on startup in the released 0.1.20 binary, so the MCP transport was unavailable to every user who installed via npm — while the same code ran fine from source.

## Cause

Tests and releases resolved different dependency sets:

- `pyproject.toml` declared `mcp>=1.0` — unbounded.
- `uv.lock` pinned `mcp==1.27.0`, and CI ran pytest against the lock, so `test_build_server_registers_all_tools` passed.
- Both build jobs ran `pip install -e .[build]`, which ignores the lock and re-resolves at build time. The 0.1.20 build picked up mcp 2.x, which removed the `Server.list_tools` **and** `Server.call_tool` decorators that `build_server` registers with (`mcp_server.py:565`, `:569`).

The artifact users received was built from a dependency set no test had ever run against.

## Changes

| | Fixes |
|---|---|
| `mcp>=1.27,<2` in `pyproject.toml` | this instance |
| `uv sync --frozen` in both build jobs | the next occurrence |
| MCP handshake smoke test in `ci.yml` | binary-only failures generally |

**Bound the dependency.** `build_server` is written against the 1.x API; a 2.x upgrade is separate, deliberate work.

**Build from the lock.** Both build jobs now install uv and run `uv sync --frozen --no-dev --extra build`. This is the change that matters — `click>=8.0` and `httpx>=0.25` carry identical unbounded exposure, and building from the lock covers all three at once.

Two details worth noting for review: neither build job had uv (it was only in ci.yml's *test* job), so this adds `astral-sh/setup-uv` to both and switches the build step to `uv run`. And since there is no `.python-version`, `--python 3.11` preserves the interpreter `setup-python` was pinning.

**Smoke the handshake.** The existing `--version` check could never catch this — `main.py:556` defers the mcp import into the `mcp serve` body, so `--version` never loads the SDK. Note this test can no longer catch dependency drift once builds come from the lock; its ongoing value is the class the lock *doesn't* cover — PyInstaller packaging failures such as missed hidden imports.

Added to `ci.yml` (Linux) only, not the 5-platform matrix in the binaries workflow: `timeout` isn't portable to the macOS and Windows runners, and this failure mode is dependency-wide rather than platform-specific.

## Verification

Reproduced the original bug against this repo's source with `mcp==2.1.1`:

```
AttributeError: 'Server' object has no attribute 'list_tools'
```

Then ran the exact new CI commands locally, in both directions:

- Binary built via `uv sync --frozen` → `--version` and the handshake both pass, `serverInfo` returned.
- Same handshake against mcp 2.1.1 → exit 1, zero bytes on stdout, original `AttributeError` on stderr. **The guard catches the bug it was written for.**

`uv run pytest -q` → 289 passed. `bump_version.py --check 0.1.21` → manifests in sync.

## Release

Includes the 0.1.21 bump as its own commit, per the flow in CLAUDE.md. After merge: pull main, then `make release VERSION=0.1.21`.

Worth confirming afterwards that the plugin actually routes to the MCP tools once they are genuinely available — per the issue, that path has never executed in the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MrYZFmbi5RFrAfq8yfYsXE
