### PR TITLE
Surface the executed QueryPlan in the NL query contract

### DIFF
--- a/src/qluent_cli/agent_instructions.md
+++ b/src/qluent_cli/agent_instructions.md
@@ -152,6 +152,11 @@ Rules:
 - Reuse `thread_id` for follow-up questions that build on the same result.
 - Verify the returned `sql` matches the user's intent before presenting numbers, and
   present the numbers as coming from an ad-hoc query, never as deterministic tree evidence.
+- When the response carries a `plan`, that is the QueryPlan the backend compiled for the
+  question. Review it instead of re-authoring one: it is a QueryPlan document, so a
+  corrected version goes straight back through `qluent plan --file <path> --json-output`
+  and re-runs deterministically. A `plan` of `null` just means this project does not
+  compile queries through a plan — fall back to reviewing the `sql`.
 - Never use `qluent query` to re-derive numbers a tree command already returned.
 
 ## Manual root cause analysis workflow

--- a/src/qluent_cli/mcp_server.py
+++ b/src/qluent_cli/mcp_server.py
@@ -258,7 +258,10 @@ def _tool_definitions() -> list[dict[str, Any]]:
                 "may take minutes. Use for row-level or arbitrary questions not covered by "
                 "metric trees; prefer the deterministic tree tools when one fits. Pass "
                 "thread_id from a previous result to follow up or answer a clarification "
-                "(status = clarification_needed)."
+                "(status = clarification_needed). When the result carries a 'plan', that "
+                "is the QueryPlan the backend compiled for the question — review it and "
+                "send a corrected version to qluent_compose_query to re-run it "
+                "deterministically."
             ),
             "inputSchema": {
                 "type": "object",

--- a/src/qluent_cli/query_contracts.py
+++ b/src/qluent_cli/query_contracts.py
@@ -48,6 +48,7 @@ class QueryContract(TypedDict, total=False):
     google_sheets_url: str | None
     thread_id: str | None
     message_id: str | None
+    plan: dict[str, Any] | None
     clarification: QueryClarification | None
     error_code: str | None
     error: str | None
@@ -70,6 +71,21 @@ def _normalize_clarification(
             "options": list(nested.get("options") or nested.get("questions") or []),
         }
     return None
+
+
+def _normalize_plan(raw: dict[str, Any]) -> dict[str, Any] | None:
+    """The QueryPlan the backend compiled and executed for this question.
+
+    Present only on ``plan_compile`` projects, and only on success. It is
+    carried through verbatim — the same document ``qluent plan`` accepts — so
+    an agent can review the plan behind an answer and re-run a corrected
+    version deterministically. Anything that is not a JSON object is dropped
+    rather than passed on as an unusable ``plan``.
+    """
+    plan = raw.get("plan")
+    if plan is None:
+        plan = raw.get("query_plan")
+    return plan if isinstance(plan, dict) else None
 
 
 def _derive_status(raw: dict[str, Any], clarification: QueryClarification | None) -> str:
@@ -137,6 +153,7 @@ def build_query_contract(
         "google_sheets_url": raw.get("google_sheets_url"),
         "thread_id": raw.get("thread_id"),
         "message_id": raw.get("message_id"),
+        "plan": _normalize_plan(raw),
         "clarification": clarification,
         "error_code": raw.get("error_code"),
         "error": raw.get("error"),

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -123,6 +123,7 @@ class FakeClient:
             "question": question,
             "explanation": "Answer.",
             "sql": "SELECT 1",
+            "plan": {"source": "orders", "group_by": ["a"]},
             "data": [{"a": 1}],
             "columns": ["a"],
             "row_count": 1,
@@ -396,6 +397,9 @@ def test_dispatch_query_returns_contract_and_forwards_thread_id():
     assert result["answer"] == "Answer."
     assert result["sql"] == "SELECT 1"
     assert result["thread_id"] == "th_1"
+    # The executed plan rides the contract through to the tool result, so the
+    # agent can re-run a corrected version via qluent_compose_query.
+    assert result["plan"] == {"source": "orders", "group_by": ["a"]}
 
 
 def test_dispatch_suggestions_filters_by_tree_id():

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -21,8 +21,26 @@ def _config(**overrides: Any) -> QluentConfig:
     return QluentConfig(**defaults)
 
 
+# The QueryPlan the backend compiled for the question, as it rides the NL query
+# response on a plan_compile project. Shaped like the documents `qluent plan`
+# accepts (see tests/test_plan.py).
+EXECUTED_PLAN = {
+    "nodes": [
+        {"op": "source", "id": "src", "base": "orders"},
+        {
+            "op": "group_by",
+            "id": "g",
+            "input": "src",
+            "dims": ["customer"],
+            "metrics": ["revenue"],
+        },
+    ],
+    "output": "g",
+}
+
 RESULT_EVENT = {
     "success": True,
+    "plan": EXECUTED_PLAN,
     "thread_id": "th_1",
     "message_id": "msg_1",
     "question": "top customers?",
@@ -118,6 +136,45 @@ def test_query_json_output_emits_contract(monkeypatch, isolated_config):
     assert payload["deterministic"] is False
     assert payload["sql"] == "SELECT 1"
     assert payload["answer"] == "Acme leads on revenue."
+    assert payload["plan"] == EXECUTED_PLAN
+
+
+def test_query_plan_round_trips_into_the_plan_command(monkeypatch, isolated_config):
+    """The emitted plan is a document `qluent plan --file` takes unchanged."""
+    FakeStreamingClient.events = [("result", dict(RESULT_EVENT))]
+    _wire(monkeypatch, FakeStreamingClient)
+
+    runner = CliRunner()
+    emitted = json.loads(
+        runner.invoke(cli, ["query", "top customers?", "--json-output"]).stdout
+    )["plan"]
+
+    executed: list[dict[str, Any]] = []
+
+    class FakePlanClient:
+        def __init__(self, config: QluentConfig) -> None:
+            self.config = config
+
+        def execute_plan(self, plan, *, progress_callback=None):
+            executed.append(plan)
+            return {
+                "success": True,
+                "sql": "SELECT 1",
+                "rows": [{"customer": "Acme", "revenue": 120340}],
+                "row_count": 1,
+                "metadata": {"columns": ["customer", "revenue"]},
+            }
+
+    monkeypatch.setattr("qluent_cli.plan.load_config", lambda: _config())
+    monkeypatch.setattr("qluent_cli.plan.QluentClient", FakePlanClient)
+
+    with runner.isolated_filesystem():
+        with open("plan.json", "w") as handle:
+            json.dump(emitted, handle)
+        result = runner.invoke(cli, ["plan", "--file", "plan.json", "--json-output"])
+
+    assert result.exit_code == 0, result.output
+    assert executed == [EXECUTED_PLAN]
 
 
 def test_query_clarification_renders_options_and_exits_zero(

--- a/tests/test_query_contracts.py
+++ b/tests/test_query_contracts.py
@@ -46,6 +46,60 @@ def test_sync_success_normalizes_explanation_to_answer():
     assert contract["provenance"]["source"] == "nl_query"
 
 
+def test_sync_success_carries_executed_plan_verbatim():
+    plan = {
+        "source": "orders",
+        "filter_by": [{"column": "region", "op": "in", "values": ["EU"]}],
+        "group_by": ["brand"],
+        "metrics": ["revenue"],
+    }
+    raw = {
+        "success": True,
+        "question": "revenue by brand in the EU?",
+        "sql": "SELECT 1",
+        "plan": plan,
+        "data": [],
+        "columns": [],
+        "row_count": 0,
+    }
+
+    contract = build_query_contract(raw, CONFIG)
+
+    # Verbatim: the contract's plan is the document `qluent plan --file` takes.
+    assert contract["plan"] == plan
+
+
+def test_plan_absent_or_malformed_is_none():
+    base = {"success": True, "question": "q", "data": [], "row_count": 0}
+
+    assert build_query_contract(base, CONFIG)["plan"] is None
+    assert build_query_contract({**base, "plan": None}, CONFIG)["plan"] is None
+    assert build_query_contract({**base, "plan": "SELECT 1"}, CONFIG)["plan"] is None
+
+
+def test_plan_falls_back_to_query_plan_key():
+    raw = {"success": True, "question": "q", "query_plan": {"source": "orders"}}
+
+    assert build_query_contract(raw, CONFIG)["plan"] == {"source": "orders"}
+
+
+def test_stream_result_event_carries_plan():
+    raw = {
+        "success": True,
+        "thread_id": "th_5",
+        "question": "q",
+        "explanation": "Answer.",
+        "plan": {"source": "orders", "group_by": ["brand"]},
+        "data": [],
+        "columns": [],
+        "row_count": 0,
+    }
+
+    contract = build_query_contract(raw, CONFIG, event="result", sql="SELECT 2")
+
+    assert contract["plan"] == {"source": "orders", "group_by": ["brand"]}
+
+
 def test_sync_truncation_derived_from_row_count():
     raw = {
         "success": True,


### PR DESCRIPTION
Closes #119 (part of #118).

## What

`build_query_contract` builds an explicit dict, so a new backend field is dropped unless it is added by hand. This adds `plan` to `QueryContract` and to the builder's return.

- **`query_contracts.py`** — `plan` is normalized off the raw payload by `_normalize_plan`. Both wire shapes go through the same builder, so the sync `POST /query/` body and the SSE `result` event are both covered. The plan is passed through **verbatim** — it is the same document `qluent plan --file` accepts. Anything that is not a JSON object is dropped rather than emitted as an unusable `plan`, mirroring how the module already normalizes `clarification` and `explanation`/`answer`.
- **`mcp_server.py`** — verified: `_query` returns the contract unchanged, so the `qluent_query` tool result carries `plan` through automatically. Added a test that pins that. The tool description now tells the agent what to do with it (review, then re-run a corrected version through `qluent_compose_query`).
- **`formatters/`** — no change, as the issue specifies. The plan is for the agent, not for terminal display.
- **`agent_instructions.md`** — one rule under `qluent query`: review the returned `plan` instead of re-authoring one, and send corrections back through `qluent plan`. A `plan` of `null` means the project does not compile queries through a plan — review the `sql` instead.

## Why it matters

This is what makes the agent a reviewer instead of an author: it gets the plan that produced the rows and can re-run a corrected version through `qluent plan`, which already exists and is already deterministic. Unblocks the plugin rewrite (qluent/qluent-plugin-cc#99).

## Tests

`uv run pytest` — 294 passed. New coverage:

- `plan` carried verbatim on the sync body and on the SSE `result` event.
- absent / `null` / non-object `plan` all normalize to `None`.
- the `qluent_query` MCP tool result carries `plan`.
- **round trip** (the issue's "done when"): `qluent query --json-output` emits a `plan`, which is written to a file and fed to `qluent plan --file` — the plan document reaches the client unchanged.

## Note on the backend field

The backend side (qluent/qluent-ui#656) is not merged, so the exact key could not be verified against a live response. The builder reads `plan` and falls back to `query_plan`; if the backend nests it somewhere else (e.g. under `metadata`), `_normalize_plan` is the one place to adjust and the tests pin the behavior. Nothing else in the CLI depends on the field being present — a project that does not return one emits `plan: null`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYKuCpUn9rxpXt5ZnHZNMs)_